### PR TITLE
fix: Updated `soc_rent_adjustments` data types in schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,8 +59,8 @@ model rent {
 
 model soc_rent_adjustments {
   year       String? @db.VarChar(10)
-  inflation  String? @db.VarChar(10)
-  additional String? @db.VarChar(10)
+  inflation  Float?
+  additional Float?
   total      Float?
   id         Int     @id @default(autoincrement())
 }


### PR DESCRIPTION
Following Gabry noticing `soc_rent_adjustments` weren't pulling through correctly, I updated the table ID and data types for the `total` column. This is now updated in the schema. 

NB: the percentages are now stored as floats at _face value_ (eg 4.00 = 4%).