### PR TITLE
chore: Add model names to Prisma file

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,7 +69,7 @@ model Rent {
   @@map("rent")
 }
 
-model SOCRentAdjustments {
+model SocialRentAdjustments {
   year       String? @db.VarChar(10)
   inflation  Float?
   additional Float?


### PR DESCRIPTION
## What?
- Adds `@@map` notation for table names and `@map` notation for column names to Prisma schema

## Why?
- This will enrich the Prisma client with TS-like syntax without touching the db structure
- Doing this will facilitate us using Prisma as an ORM as opposed to relying on `$queryRaw()`
  - This will be more typesafe (we won't be able to query tables and columns that don't exist, and db changes will be picked up by the client)
  - No need to redefine types
  - Should be a better developer experience!
  
### Example
```ts
// Before
type BuildPrice = {
  id: number;
  housetype: string;
  pricemid: number;
};

const buildPriceRes = await prisma.$queryRaw<BuildPrice[]>`
  SELECT * FROM "public"."buildprices" 
  WHERE "housetype" = ${data.houseType}
`;
const buildPrice = buildPriceRes[0]["pricemid"];


// After
const buildPrice = await prisma.buildPrices.findFirst({
  where: {
    houseType: { equals: data.houseType as string },
  },
  select: { priceMid: true },
});
```

## Next steps...
- Work through `routes.ts` and replace calls to `$queryRaw()` with calls to Prisma models