### PR TITLE
fix: Updated `formatData` function in `TenureComparisonWrapper` to access correct properties from `household` object

### DIFF
--- a/app/components/graphs/TenureComparisonWrapper.tsx
+++ b/app/components/graphs/TenureComparisonWrapper.tsx
@@ -31,32 +31,27 @@ const TenureComparisonWrapper: React.FC<TenureComparisonWrapperProps> = ({
         category: "Monthly Costs Land",
         marketPurchase:
           household.tenure.marketPurchase?.landMortgage?.monthlyPayment || 0,
-        marketRent: household.tenure.marketRent?.averageRentLandMonthly
-          ? household.tenure.marketRent.averageRentLandMonthly
-          : 0,
-        socialRent: household.tenure.socialRent?.socialRentMonthlyLand || 0,
+        marketRent: 
+          household.tenure.marketRent?.averageRentLandMonthly || 0,
+        socialRent: 
+          household.tenure.socialRent?.socialRentMonthlyLand || 0,
         fairholdLandPurchase:
-          household.tenure.fairholdLandPurchase?.discountedLandMortgage
-            ?.monthlyPayment || 0,
-        fairholdLandRent: household.tenure.fairholdLandRent
-          ?.discountedLandRentMonthly
-          ? household.tenure.fairholdLandRent.discountedLandRentMonthly
-          : 0,
+          household.tenure.fairholdLandPurchase?.discountedLandMortgage?.monthlyPayment || 0,
+        fairholdLandRent:
+          household.tenure.fairholdLandRent?.discountedLandRentMonthly || 0,
       },
       {
         category: "Monthly Costs House",
         marketPurchase:
           household.tenure.marketPurchase?.houseMortgage?.monthlyPayment || 0,
-        marketRent: household.tenure.marketRent?.averageRentHouseMonthly
-          ? household.tenure.marketRent.averageRentHouseMonthly
-          : 0,
-        socialRent: household.tenure.socialRent?.socialRentMonthlyHouse || 0,
+        marketRent: 
+          household.tenure.marketRent?.averageRentHouseMonthly || 0,
+        socialRent: 
+          household.tenure.socialRent?.socialRentMonthlyHouse || 0,
         fairholdLandPurchase:
-          household.tenure.fairholdLandPurchase?.depreciatedHouseMortgage
-            ?.monthlyPayment || 0,
+          household.tenure.fairholdLandPurchase?.depreciatedHouseMortgage?.monthlyPayment || 0,
         fairholdLandRent:
-          household.tenure.fairholdLandPurchase?.depreciatedHouseMortgage
-            ?.monthlyPayment || 0,
+          household.tenure.fairholdLandPurchase?.depreciatedHouseMortgage?.monthlyPayment || 0,
       },
     ];
   };


### PR DESCRIPTION
Some data restructuring meant that the `TenureComparisonWrapper` was no longer accessing the right properties from `household` and certain tenure bars were missing from the graph. This is now fixed! 