### PR TITLE
feat: Setup automatic test when PR is open on main

### DIFF
--- a/.github/workflows/test-on-pull-request.yml
+++ b/.github/workflows/test-on-pull-request.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - gg/set-workflow # for testing
 
 jobs:
   test:


### PR DESCRIPTION
# What does this PR do?
It allows to automatically run `rpm run test ` when a PR is made to merge into main.
It does so by creating a `test-on-pull-request.yml` file inside the folder `.github/worflows`.
Explanation of the Workflow:

`on: pull_request`: This specifies that the workflow should run on a pull request event.
`jobs`: Defines the jobs that will run as part of this workflow.
`runs-on: ubuntu-latest`: The environment where the job will run, here it's an Ubuntu machine.
`steps`: The specific steps the job will execute:
`Checkout repository`: This step checks out your repository so the workflow can access the code.
`Set up Node.js`: This step installs the specified version of Node.js.
`Install dependencies`: This step `runs npm install` to install the necessary dependencies.
Run tests: Finally, this step runs your test script using `npm run test`.

Before merging we should now see the test being passed: 
![Screenshot 2024-08-08 at 17 36 13](https://github.com/user-attachments/assets/1b2339bb-2d0f-40cb-82bb-38d7bab8bc3d)


