### PR TITLE
chore: renamed consumerPriceGrowthPerYear

### DIFF
--- a/app/models/ForecastParameters.ts
+++ b/app/models/ForecastParameters.ts
@@ -2,7 +2,7 @@ export interface ForecastParameters {
   maintenanceCostPercentage: number;
   incomeGrowthPerYear: number;
   rentGrowthPerYear: number;
-  constructionPriceGrowthPerYear: number;
+  consumerPriceGrowthPerYear: number;
   propertyPriceGrowthPerYear: number;
   yearsForecast: number;
   affordabilityThresholdIncomePercentage: number;
@@ -11,7 +11,7 @@ export interface ForecastParameters {
 export const DEFAULT_FORECAST_PARAMETERS: ForecastParameters = {
   maintenanceCostPercentage: 0.0125, // percentage maintenance cost
   incomeGrowthPerYear: 0.04, // 4% income growth per year
-  constructionPriceGrowthPerYear: 0.025, // 2.5%
+  consumerPriceGrowthPerYear: 0.025, // 2.5%
   rentGrowthPerYear: 0.03, // 3%
   propertyPriceGrowthPerYear: 0.05, // 5%
   yearsForecast: 40, // 40 years

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -64,8 +64,8 @@ export class Household {
       landPrice: this.property.landPrice,
       propertyPriceGrowthPerYear:
         this.forecastParameters.propertyPriceGrowthPerYear,
-      constructionPriceGrowthPerYear:
-        this.forecastParameters.constructionPriceGrowthPerYear,
+      consumerPriceGrowthPerYear:
+        this.forecastParameters.consumerPriceGrowthPerYear,
       yearsForecast: this.forecastParameters.yearsForecast,
       maintenanceCostPercentage:
         this.forecastParameters.maintenanceCostPercentage,
@@ -80,8 +80,8 @@ export class Household {
       incomeYearly: this.incomeYearly,
       propertyPriceGrowthPerYear:
         this.forecastParameters.propertyPriceGrowthPerYear,
-      constructionPriceGrowthPerYear:
-        this.forecastParameters.constructionPriceGrowthPerYear,
+      consumerPriceGrowthPerYear:
+        this.forecastParameters.consumerPriceGrowthPerYear,
       yearsForecast: this.forecastParameters.yearsForecast,
       maintenanceCostPercentage:
         this.forecastParameters.maintenanceCostPercentage,
@@ -99,8 +99,8 @@ export class Household {
     const fairholdLandPurchase = new FairholdLandPurchase({
       newBuildPrice: this.property.newBuildPrice,
       depreciatedBuildPrice: this.property.depreciatedBuildPrice,
-      constructionPriceGrowthPerYear:
-        this.forecastParameters.constructionPriceGrowthPerYear,
+      consumerPriceGrowthPerYear:
+        this.forecastParameters.consumerPriceGrowthPerYear,
       yearsForecast: this.forecastParameters.yearsForecast,
       maintenanceCostPercentage:
         this.forecastParameters.maintenanceCostPercentage,
@@ -123,8 +123,8 @@ export class Household {
         this.forecastParameters.affordabilityThresholdIncomePercentage, //  affordability threshold percentage
       propertyPriceGrowthPerYear:
         this.forecastParameters.propertyPriceGrowthPerYear, // property price growth per year
-      constructionPriceGrowthPerYear:
-        this.forecastParameters.constructionPriceGrowthPerYear, // construction price growth per year
+      consumerPriceGrowthPerYear:
+        this.forecastParameters.consumerPriceGrowthPerYear, // construction price growth per year
       yearsForecast: this.forecastParameters.yearsForecast, // years forecast
       maintenanceCostPercentage:
         this.forecastParameters.maintenanceCostPercentage, // maintenance cost percentage
@@ -154,7 +154,7 @@ export class Household {
         fairholdLandRent: this.tenure.fairholdLandRent,
         property: this.property,
         propertyPriceGrowthPerYear: params.forecastParameters.propertyPriceGrowthPerYear,
-        constructionPriceGrowthPerYear: params.forecastParameters.constructionPriceGrowthPerYear,
+        consumerPriceGrowthPerYear: params.forecastParameters.consumerPriceGrowthPerYear,
         rentGrowthPerYear: params.forecastParameters.rentGrowthPerYear,
         yearsForecast: params.forecastParameters.yearsForecast,
         maintenanceCostPercentage: params.forecastParameters.maintenanceCostPercentage,

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -15,7 +15,7 @@ export interface LifetimeParams {
     fairholdLandRent: FairholdLandRent;
     property: Property;
     propertyPriceGrowthPerYear: number;
-    constructionPriceGrowthPerYear: number;
+    consumerPriceGrowthPerYear: number;
     rentGrowthPerYear: number;
     yearsForecast: number;
     maintenanceCostPercentage: number;
@@ -102,7 +102,7 @@ export class Lifetime {
             averageMarketPriceIterative =
                 averageMarketPriceIterative * (1 + params.propertyPriceGrowthPerYear);
             newBuildPriceIterative =
-              newBuildPriceIterative * (1 + params.constructionPriceGrowthPerYear);
+              newBuildPriceIterative * (1 + params.consumerPriceGrowthPerYear);
             landToTotalRatioIterative = 
                 landPriceIterative / averageMarketPriceIterative;
             landPriceIterative = 
@@ -118,9 +118,9 @@ export class Lifetime {
             maintenanceCostIterative =
                 newBuildPriceIterative * params.maintenanceCostPercentage;
             gasBillAdjustedYearlyIterative = 
-                gasBillAdjustedYearlyIterative * (1 + params.constructionPriceGrowthPerYear);
+                gasBillAdjustedYearlyIterative * (1 + params.consumerPriceGrowthPerYear);
             gasBillRetrofitYearlyIterative = 
-                gasBillRetrofitYearlyIterative * (1 + params.constructionPriceGrowthPerYear);
+                gasBillRetrofitYearlyIterative * (1 + params.consumerPriceGrowthPerYear);
 
             if (i < params.marketPurchase.houseMortgage.termYears - 1) {
                 newbuildHouseMortgageYearlyIterative = params.marketPurchase.houseMortgage.yearlyPaymentBreakdown[i].yearlyPayment;

--- a/app/models/tenure/FairholdLandPurchase.ts
+++ b/app/models/tenure/FairholdLandPurchase.ts
@@ -4,7 +4,7 @@ import { Mortgage } from "../Mortgage";
 interface FairholdLandPurchaseParams {
   newBuildPrice: number;
   depreciatedBuildPrice: number;
-  constructionPriceGrowthPerYear: number;
+  consumerPriceGrowthPerYear: number;
   yearsForecast: number;
   maintenanceCostPercentage: number;
   incomeGrowthPerYear: number;

--- a/app/models/tenure/FairholdLandRent.ts
+++ b/app/models/tenure/FairholdLandRent.ts
@@ -11,7 +11,7 @@ interface FairholdLandRentParams {
   incomeYearly: number;
   affordabilityThresholdIncomePercentage: number;
   propertyPriceGrowthPerYear: number;
-  constructionPriceGrowthPerYear: number;
+  consumerPriceGrowthPerYear: number;
   yearsForecast: number;
   maintenanceCostPercentage: number;
   incomeGrowthPerYear: number;

--- a/app/models/tenure/MarketPurchase.test.ts
+++ b/app/models/tenure/MarketPurchase.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
   const forecastParameters = {
     maintenanceCostPercentage: 0.0125, // percentage maintenance cost
     incomeGrowthPerYear: 0.04, // 4% income growth per year
-    constructionPriceGrowthPerYear: 0.025, // 2.5%
+    consumerPriceGrowthPerYear: 0.025, // 2.5%
     rentGrowthPerYear: 0.03, // 3%
     propertyPriceGrowthPerYear: 0.05, // 5%
     yearsForecast: 40, // 40 years
@@ -20,8 +20,8 @@ beforeEach(() => {
     depreciatedBuildPrice: 110717.45,
     landPrice: 31531.579,
     propertyPriceGrowthPerYear: forecastParameters.propertyPriceGrowthPerYear,
-    constructionPriceGrowthPerYear:
-      forecastParameters.constructionPriceGrowthPerYear,
+    consumerPriceGrowthPerYear:
+      forecastParameters.consumerPriceGrowthPerYear,
     yearsForecast: forecastParameters.yearsForecast,
     maintenanceCostPercentage: forecastParameters.maintenanceCostPercentage,
   });

--- a/app/models/tenure/MarketPurchase.ts
+++ b/app/models/tenure/MarketPurchase.ts
@@ -8,7 +8,7 @@ interface ConstructorParams {
   landPrice: number;
   incomeYearly: number;
   propertyPriceGrowthPerYear: number;
-  constructionPriceGrowthPerYear: number;
+  consumerPriceGrowthPerYear: number;
   yearsForecast: number;
   maintenanceCostPercentage: number;
 }

--- a/app/models/tenure/MarketRent.test.ts
+++ b/app/models/tenure/MarketRent.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
   const forecastParameters = {
     maintenanceCostPercentage: 0.0125, // percentage maintenance cost
     incomeGrowthPerYear: 0.04, // 4% income growth per year
-    constructionPriceGrowthPerYear: 0.025, // 2.5%
+    consumerPriceGrowthPerYear: 0.025, // 2.5%
     rentGrowthPerYear: 0.03, // 3%
     propertyPriceGrowthPerYear: 0.05, // 5%
     yearsForecast: 40, // 40 years
@@ -21,8 +21,8 @@ beforeEach(() => {
     depreciatedBuildPrice: 110717.45,
     landPrice: 31531.579,
     propertyPriceGrowthPerYear: forecastParameters.propertyPriceGrowthPerYear,
-    constructionPriceGrowthPerYear:
-      forecastParameters.constructionPriceGrowthPerYear,
+    consumerPriceGrowthPerYear:
+      forecastParameters.consumerPriceGrowthPerYear,
     yearsForecast: forecastParameters.yearsForecast,
     maintenanceCostPercentage: forecastParameters.maintenanceCostPercentage,
     rentGrowthPerYear: forecastParameters.rentGrowthPerYear,

--- a/app/models/tenure/MarketRent.ts
+++ b/app/models/tenure/MarketRent.ts
@@ -8,7 +8,7 @@ interface ConstructorParams {
   landPrice: number;
   incomeYearly: number;
   propertyPriceGrowthPerYear: number;
-  constructionPriceGrowthPerYear: number;
+  consumerPriceGrowthPerYear: number;
   yearsForecast: number;
   maintenanceCostPercentage: number;
   rentGrowthPerYear: number;


### PR DESCRIPTION
Since the CPI-type value previously called `constructionPriceGrowthPerYear` is now being used for inflating gas bills over time too, its name was no longer accurate so this has been updated! 