### PR TITLE
feat: calculate `totalInterest` in Mortgage class

### DIFF
--- a/app/models/Mortgage.ts
+++ b/app/models/Mortgage.ts
@@ -35,6 +35,7 @@ export class Mortgage {
   monthlyPayment: number;
   totalMortgageCost: number;
   yearlyPaymentBreakdown: MortgageBreakdown;
+  totalInterest: number;
 
   constructor(params: MortgageParams) {
     this.propertyValue = params.propertyValue;
@@ -51,6 +52,7 @@ export class Mortgage {
     this.totalMortgageCost = totalMortgageCost;
 
     this.yearlyPaymentBreakdown = this.calculateYearlyPaymentBreakdown();
+    this.totalInterest = this.calculateTotalInterest();
   }
 
   private calculateMortgagePrinciple() {
@@ -109,5 +111,10 @@ export class Mortgage {
     }
 
     return yearlyPaymentBreakdown;
+  }
+  private calculateTotalInterest() {
+    const totalInterest = parseFloat((this.principal * this.interestRate * this.termYears).toFixed(2))
+    console.log("Total interest: ", totalInterest)
+    return totalInterest
   }
 }


### PR DESCRIPTION
# What does this PR do? 
- Calculates the total paid towards interest over the term of a mortgage (add this as a property to the `Mortgage` class)
<img width="239" alt="{176E1494-1EAE-424F-90FD-E8172F412190}" src="https://github.com/user-attachments/assets/5818145c-899f-4e5f-ae1c-c203619b9863">


_NB_: There's another instance of `principal` that will also need fixing once #117 is merged. 

Closes #118