### PR TITLE
fix: update tests following interest calculation functionality

### DIFF
--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -88,7 +88,7 @@ export class Household {
         affordability: marketPurchase.affordability,
         landPriceOrRent: this.property.landPrice,
       }),
-      marketPurchase: this.tenure.marketPurchase
+      marketPurchase: marketPurchase
     });
 
     const fairholdLandRent = new FairholdLandRent({
@@ -105,7 +105,7 @@ export class Household {
         landPriceOrRent: averageRentYearly,
       }), // fairhold object
 
-      marketPurchase: this.tenure.marketPurchase
+      marketPurchase: marketPurchase
     });
 
     return {

--- a/app/models/tenure/FairholdLandPurchase.test.ts
+++ b/app/models/tenure/FairholdLandPurchase.test.ts
@@ -1,10 +1,16 @@
 import { Fairhold } from "../Fairhold";
 import { DEFAULT_FORECAST_PARAMETERS, ForecastParameters } from "../ForecastParameters";
 import { FairholdLandPurchase } from "./FairholdLandPurchase";
+import { MarketPurchase } from "./MarketPurchase"
 
 let tenureFairholdLandPurchase: FairholdLandPurchase;
 
 beforeEach(() => {
+  // partial MarketPurchase object with only necessary properties for test (instead of mocking a whole MarketPurchase object)
+  const partialMarketPurchase: Pick<MarketPurchase, 'interestPaid'> = {
+    interestPaid: 200000, 
+  };
+
   const forecastParameters: ForecastParameters = {
     ...DEFAULT_FORECAST_PARAMETERS,
   };
@@ -20,7 +26,8 @@ beforeEach(() => {
       affordability: 0.2,
       landPriceOrRent: 31531.579,
     }),
-  forecastParameters: forecastParameters,
+    forecastParameters: forecastParameters,
+    marketPurchase: partialMarketPurchase as MarketPurchase
   });
 });
 

--- a/app/models/tenure/FairholdLandRent.test.ts
+++ b/app/models/tenure/FairholdLandRent.test.ts
@@ -1,10 +1,16 @@
 import { Fairhold } from "../Fairhold";
 import { DEFAULT_FORECAST_PARAMETERS, ForecastParameters } from "../ForecastParameters";
 import { FairholdLandRent } from "./FairholdLandRent";
+import { MarketPurchase } from "./MarketPurchase"
 
 let tenureFairholdLandRent: FairholdLandRent;
 
 beforeEach(() => {
+    // partial MarketPurchase object with only necessary properties for test (instead of mocking a whole MarketPurchase object)
+    const partialMarketPurchase: Pick<MarketPurchase, 'interestPaid'> = {
+      interestPaid: 200000, 
+    };
+
   const forecastParameters: ForecastParameters = {
     ...DEFAULT_FORECAST_PARAMETERS,
   };
@@ -22,7 +28,8 @@ beforeEach(() => {
       landPriceOrRent: 20000,
     }),
     forecastParameters: forecastParameters,
-  });
+    marketPurchase: partialMarketPurchase as MarketPurchase
+  })
 });
 
 it("can be instantiated", () => {


### PR DESCRIPTION
This PR updates the tests that were failing after I changed a few classes to enable interest rate spend & save calculations. Made a new one so as to keep PRs small. 

Uses my previous branch as a base!

I noticed that despite the good coverage we're seeing with Jest, a lot of the calculations aren't actually being tested, if I've understood everything correctly. That's probably something we want to rectify (especially since certain mortgage numbers are looking funky) so I have opened another card (see #122). 