### PR TITLE
feat: new maintenance selector

### DIFF
--- a/app/api/route.test.ts
+++ b/app/api/route.test.ts
@@ -33,6 +33,7 @@ describe("POST API Route", () => {
       houseAge: 3,
       houseBedrooms: 2,
       houseType: "D",
+      maintenanceSpend: "0.02",
     });
 
     const householdData = {
@@ -82,6 +83,7 @@ describe("POST API Route", () => {
       houseAge: 3,
       houseBedrooms: 2,
       houseType: "D",
+      maintenanceSpend: "0.02",
     });
 
     const errorMessage = "Service error";

--- a/app/api/route.test.ts
+++ b/app/api/route.test.ts
@@ -33,7 +33,7 @@ describe("POST API Route", () => {
       houseAge: 3,
       houseBedrooms: 2,
       houseType: "D",
-      maintenanceSpend: "0.02",
+      maintenancePercentage: "0.02",
     });
 
     const householdData = {
@@ -83,7 +83,7 @@ describe("POST API Route", () => {
       houseAge: 3,
       houseBedrooms: 2,
       houseType: "D",
-      maintenanceSpend: "0.02",
+      maintenancePercentage: "0.02",
     });
 
     const errorMessage = "Service error";

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -21,18 +21,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-const maintenance = {
-  "Low (1.5%)": "0.015",
-  "Medium (2.0%)": "0.02",
-  "High (3.75%)": "0.0375",
-}; // variables associated with maintenance spend levels
-
 const CalculatorInput = () => {
   const methods = useForm<formType>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       houseType: "D", // Default value for house type
-      maintenanceSpend: "0.02",
+      maintenancePercentage: "0.015",
     },
   });
 
@@ -162,6 +156,39 @@ const CalculatorInput = () => {
                   </FormControl>
                   <FormDescription>
                     Select an option for the house type.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={methods.control}
+              name="maintenancePercentage" // Name in the Calculation schema for the new radio field
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Maintenance spend percentage</FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      value={field.value}
+                      onValueChange={(value) => field.onChange(value)} // Bind selection to field
+                    >
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="0.015" id="option-one" />
+                        <Label htmlFor="option-one">Low (1.5%)</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="0.02" id="option-two" />
+                        <Label htmlFor="option-two">Medium (2%)</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="0.0375" id="option-three" />
+                        <Label htmlFor="option-three">High (3.75%)</Label>
+                      </div>
+                    </RadioGroup>
+                  </FormControl>
+                  <FormDescription>
+                    Select a level for maintenance spend, as a percentage of house cost. 
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -21,6 +21,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+const maintenance = {
+  "Low (1.5%)": "0.015",
+  "Medium (2.0%)": "0.02%",
+  "High (3.75%)": "0.0375",
+}; // variables associated with maintenance spend levels
+
 const CalculatorInput = () => {
   const methods = useForm<formType>({
     resolver: zodResolver(formSchema),

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -23,7 +23,7 @@ import { Label } from "@/components/ui/label";
 
 const maintenance = {
   "Low (1.5%)": "0.015",
-  "Medium (2.0%)": "0.02%",
+  "Medium (2.0%)": "0.02",
   "High (3.75%)": "0.0375",
 }; // variables associated with maintenance spend levels
 
@@ -31,7 +31,8 @@ const CalculatorInput = () => {
   const methods = useForm<formType>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      houseType: "D",
+      houseType: "D", // Default value for house type
+      maintenanceSpend: "0.02",
     },
   });
 

--- a/app/components/ui/RadioButton.tsx
+++ b/app/components/ui/RadioButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { UseFormRegister, Path } from "react-hook-form";
 import { Calculation } from "@/app/schemas/calculationSchema";
 
-interface radioButtonProps {
+interface RadioButtonProps {
   id: string;
   value: string;
   label: string;
@@ -11,7 +11,7 @@ interface radioButtonProps {
   error?: string;
 }
 
-const RadioButton: React.FC<radioButtonProps> = ({
+const RadioButton: React.FC<RadioButtonProps> = ({
   id,
   value,
   label,

--- a/app/components/ui/RadioButton.tsx
+++ b/app/components/ui/RadioButton.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { UseFormRegister } from "react-hook-form";
+import { UseFormRegister, Path } from "react-hook-form";
 import { Calculation } from "@/app/schemas/calculationSchema";
 
 interface radioButtonProps {
   id: string;
   value: string;
   label: string;
+  name: Path<Calculation>;
   register: UseFormRegister<Calculation>;
   error?: string;
 }
@@ -14,6 +15,7 @@ const RadioButton: React.FC<radioButtonProps> = ({
   id,
   value,
   label,
+  name,
   register,
   error,
 }) => {
@@ -24,7 +26,7 @@ const RadioButton: React.FC<radioButtonProps> = ({
           className="accent-black"
           type="radio"
           id={id}
-          {...register("houseType")}
+          {...register(name)}
           value={value}
         />
         {label}

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -30,3 +30,6 @@ export const NATIONAL_AVERAGES: nationalAverageType = {
   propertyValue: 49750,
   earningsWeekly: 316.4,
 };
+
+export const MAINTENANCE_LEVELS = ["0.015", "0.02", "0.0375"];
+

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -31,5 +31,4 @@ export const NATIONAL_AVERAGES: nationalAverageType = {
   earningsWeekly: 316.4,
 };
 
-export const MAINTENANCE_LEVELS = ["0.015", "0.02", "0.0375"];
-
+export const MAINTENANCE_LEVELS = ["0.015", "0.02", "0.0375"] as const;

--- a/app/schemas/apiSchema.ts
+++ b/app/schemas/apiSchema.ts
@@ -25,10 +25,10 @@ export const apiSchema = z.object({
       message: `houseType is required and must be one of ${HOUSE_TYPES}`,
     }
   ),
-  maintenanceSpend: MaintenanceEnum.refine(
+  maintenancePercentage: MaintenanceEnum.refine(
     (value) => MaintenanceEnum.options.includes(value),
     {
-      message: `maintenanceSpend is required and must be one of ${MAINTENANCE_LEVELS}`,
+      message: `maintenancePercentage is required and must be one of ${MAINTENANCE_LEVELS}`,
     }
   ),
 });

--- a/app/schemas/apiSchema.ts
+++ b/app/schemas/apiSchema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { parse as parsePostcode } from "postcode";
 import { HOUSE_TYPES } from "../models/Property";
+import { MAINTENANCE_LEVELS } from "../models/constants";
 
 // Type not exported by postcode lib directly
 export type ValidPostcode = Extract<
@@ -9,6 +10,7 @@ export type ValidPostcode = Extract<
 >;
 
 const HouseTypeEnum = z.enum(HOUSE_TYPES);
+const MaintenanceEnum = z.enum(MAINTENANCE_LEVELS);
 
 export const apiSchema = z.object({
   housePostcode: z.custom<ValidPostcode>(),
@@ -21,6 +23,12 @@ export const apiSchema = z.object({
     (value) => HouseTypeEnum.options.includes(value),
     {
       message: `houseType is required and must be one of ${HOUSE_TYPES}`,
+    }
+  ),
+  maintenanceSpend: MaintenanceEnum.refine(
+    (value) => MaintenanceEnum.options.includes(value),
+    {
+      message: `maintenanceSpend is required and must be one of ${MAINTENANCE_LEVELS}`,
     }
   ),
 });

--- a/app/schemas/calculationSchema.ts
+++ b/app/schemas/calculationSchema.ts
@@ -7,6 +7,9 @@ type ValidPostcode = Extract<ReturnType<typeof parsePostcode>, { valid: true }>;
 
 const HouseTypeEnum = z.enum(HOUSE_TYPES);
 
+export const MAINTENANCE_LEVELS = ["0.015", "0.02", "0.0375"] as const;
+const MaintenanceEnum = z.enum(MAINTENANCE_LEVELS);
+
 /**
  * Describes the form the user will interact with in the frontend
  */
@@ -26,6 +29,12 @@ export const calculationSchema = z.object({
     (value) => HouseTypeEnum.options.includes(value),
     {
       message: `houseType is required and must be one of ${HOUSE_TYPES}`,
+    }
+  ),
+  maintenanceSpend: MaintenanceEnum.refine(
+    (value) => MaintenanceEnum.options.includes(value),
+    {
+      message: `maintenanceSpend is required and must be one of ${MAINTENANCE_LEVELS}`,
     }
   ),
 });

--- a/app/schemas/calculationSchema.ts
+++ b/app/schemas/calculationSchema.ts
@@ -31,10 +31,10 @@ export const calculationSchema = z.object({
       message: `houseType is required and must be one of ${HOUSE_TYPES}`,
     }
   ),
-  maintenanceSpend: MaintenanceEnum.refine(
+  maintenancePercentage: MaintenanceEnum.refine(
     (value) => MaintenanceEnum.options.includes(value),
     {
-      message: `maintenanceSpend is required and must be one of ${MAINTENANCE_LEVELS}`,
+      message: `maintenancePercentage is required and must be one of ${MAINTENANCE_LEVELS}`,
     }
   ),
 });

--- a/app/schemas/calculationSchema.ts
+++ b/app/schemas/calculationSchema.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { parse as parsePostcode, fix as fixPostcode } from "postcode";
 import { HOUSE_TYPES } from "../models/Property";
+import { MAINTENANCE_LEVELS } from "../models/constants";
 
 // Type not exported by postcode lib directly
 type ValidPostcode = Extract<ReturnType<typeof parsePostcode>, { valid: true }>;
 
 const HouseTypeEnum = z.enum(HOUSE_TYPES);
 
-export const MAINTENANCE_LEVELS = ["0.015", "0.02", "0.0375"] as const;
 const MaintenanceEnum = z.enum(MAINTENANCE_LEVELS);
 
 /**

--- a/app/schemas/formSchema.ts
+++ b/app/schemas/formSchema.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 import { fix as fixPostcode } from "postcode";
 import { HOUSE_TYPES } from "../models/Property";
+import { MAINTENANCE_LEVELS } from "../models/constants";
 
 const HouseTypeEnum = z.enum(HOUSE_TYPES);
+const MaintenanceEnum = z.enum(MAINTENANCE_LEVELS);
 
 /**
  * Describes the form the user will interact with in the frontend
@@ -23,6 +25,11 @@ export const formSchema = z.object({
       message: `houseType is required and must be one of ${HOUSE_TYPES}`,
     }
   ),
+  maintenancePercentage: MaintenanceEnum.refine(
+    (value) => MaintenanceEnum.options.includes(value),
+    {
+      message: `maintenancePercentage is required and must be one of ${MAINTENANCE_LEVELS}`,
+    }),
 });
 
 export type formType = z.infer<typeof formSchema>;

--- a/app/services/calculationService.test.ts
+++ b/app/services/calculationService.test.ts
@@ -51,6 +51,7 @@ describe("getHouseholdData", () => {
     houseAge: number;
     houseBedrooms: number;
     houseSize: number;
+    maintenanceSpend: "0.015" | "0.02" | "0.0375";
   }
 
   const mockInput: MockInputType = {
@@ -59,6 +60,7 @@ describe("getHouseholdData", () => {
     houseAge: 20,
     houseBedrooms: 3,
     houseSize: 100,
+    maintenanceSpend: "0.02"
   };
 
   beforeEach(() => {

--- a/app/services/calculationService.test.ts
+++ b/app/services/calculationService.test.ts
@@ -51,7 +51,7 @@ describe("getHouseholdData", () => {
     houseAge: number;
     houseBedrooms: number;
     houseSize: number;
-    maintenanceSpend: "0.015" | "0.02" | "0.0375";
+    maintenancePercentage: "0.015" | "0.02" | "0.0375";
   }
 
   const mockInput: MockInputType = {
@@ -60,7 +60,7 @@ describe("getHouseholdData", () => {
     houseAge: 20,
     houseBedrooms: 3,
     houseSize: 100,
-    maintenanceSpend: "0.02"
+    maintenancePercentage: "0.02"
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Adds a radio button selector to the calculator form to select between maintenance spend levels. This PR has been rebased to create the selector with ShadCN. 