### PR TITLE
feat: update depreciation 

### DIFF
--- a/app/models/Property.test.ts
+++ b/app/models/Property.test.ts
@@ -1,71 +1,183 @@
 import { Property } from "./Property";
+import { HOUSE_BREAKDOWN_PERCENTAGES, MAINTENANCE_LEVELS } from './constants';
 
-let property: Property;
-
-beforeEach(() => {
-  property = new Property({
-    postcode: "WV8 1HG",
-    houseType: "T",
-    numberOfBedrooms: 2,
-    age: 10,
-    size: 88,
-    maintenancePercentage: 0.02,
-    newBuildPricePerMetre: 2120,
-    averageMarketPrice: 218091.58,
-    itl3: "TLG24",
+describe('Property', () => {
+  beforeEach(() => {
+    property = new Property({
+      postcode: "MK14 7AG",
+      houseType: "T",
+      numberOfBedrooms: 2,
+      age: 10,
+      size: 88,
+      maintenancePercentage: 0.02,
+      newBuildPricePerMetre: 2120,
+      averageMarketPrice: 219135,
+      itl3: "TLJ12",
+    });
   });
-});
 
-it("can be instantiated", () => {
-  expect(property).toBeInstanceOf(Property);
-});
+  let property: Property;
 
-it("correctly calculates the newBuildPrice", () => {
-  expect(property.newBuildPrice).toBeCloseTo(186560);
-});
-
-it("correctly calculates the depreciatedBuildPrice for existing builds (age > 0)", () => {
-  expect(property.depreciatedBuildPrice).toBeCloseTo(172988.92);
-});
-
-it("correctly calculates depreciatedBuildPrice for newbuilds (age = 0)", () => {
-  property = new Property({
-    postcode: "WV8 1HG",
-    houseType: "T",
-    numberOfBedrooms: 2,
-    age: 1,
-    size: 88,
-    maintenancePercentage: 0.02,
-    newBuildPricePerMetre: 2120,
-    averageMarketPrice: 218091.58,
-    itl3: "TLG24",
+  it("can be instantiated", () => {
+    expect(property).toBeInstanceOf(Property);
   });
-  expect(property.depreciatedBuildPrice).toBeCloseTo(186560)
-});
-
-it("correctly calculates the bedWeightedAveragePrice", () => {
-  expect(property.bedWeightedAveragePrice).toBeCloseTo(218091.58);
-});
-
-it("correctly calculates the landPrice", () => {
-  expect(property.landPrice).toBeCloseTo(31531.579);
-});
-
-it("correctly calculates the landToTotalRatio", () => {
-  expect(property.landToTotalRatio).toBeCloseTo(0.14);
-});
-
-it("correctly calculates the values even for number of bedroooms exceeding the max ", () => {
-  property = new Property({
-    postcode: "WV8 1HG",
-    houseType: "T",
-    numberOfBedrooms: 20,
-    age: 9,
-    size: 88,
-    maintenancePercentage: 0.02,
-    newBuildPricePerMetre: 2120,
-    averageMarketPrice: 218091.58,
-    itl3: "TLG24",
+  
+  it("correctly calculates the newBuildPrice", () => {
+    expect(property.newBuildPrice).toBeCloseTo(186560);
   });
-  expect(property).toBeInstanceOf(Property);
+
+  // 
+  it("correctly calculates the bedWeightedAveragePrice", () => {
+    expect(property.bedWeightedAveragePrice).toBeCloseTo(219135);
+  });
+  
+  it("correctly calculates the landPrice", () => {
+    expect(property.landPrice).toBeCloseTo(32575);
+  });
+  
+  it("correctly calculates the landToTotalRatio", () => {
+    expect(property.landToTotalRatio).toBeCloseTo(0.1446);
+  });
+  
+  it("correctly calculates the values even for number of bedroooms exceeding the max ", () => {
+    property = new Property({
+      postcode: "WV8 1HG",
+      houseType: "T",
+      numberOfBedrooms: 20,
+      age: 11,
+      size: 88,
+      maintenancePercentage: 0.02,
+      newBuildPricePerMetre: 2120,
+      averageMarketPrice: 218091.58,
+      itl3: "TLG24",
+    });
+    expect(property).toBeInstanceOf(Property);
+  });
+
+  it("correctly returns newBuildPrice if newbuild", () => {
+    property = new Property({
+      postcode: "WV8 1HG",
+      houseType: "T",
+      numberOfBedrooms: 20,
+      age: 1,
+      size: 88,
+      maintenancePercentage: 0.02,
+      newBuildPricePerMetre: 2120,
+      averageMarketPrice: 218091.58,
+      itl3: "TLG24",
+    });
+
+    expect(property.depreciatedBuildPrice).toBe(property.newBuildPrice);
+  });
+
+  describe('depreciation calculations (existing build)', () => {
+
+    it("correctly calculates newComponentValue for foundations", () => {
+      const result = property.calculateComponentValue(
+        'foundations',
+        property.newBuildPrice,
+        property.age,
+        MAINTENANCE_LEVELS[0]
+      );
+
+      const expectedNewComponentValue = 
+        property.newBuildPrice * 
+        HOUSE_BREAKDOWN_PERCENTAGES.foundations.percentageOfHouse;
+
+      expect(result.newComponentValue).toBe(expectedNewComponentValue);
+      expect(result.maintenanceAddition).toBe(0); // Foundations should have no maintenance
+    });
+
+    it("correctly calculates depreciationFactor for internal linings", () => {
+      const result = property.calculateComponentValue(
+        'internalLinings',
+        property.newBuildPrice,
+        property.age,
+        MAINTENANCE_LEVELS[0]
+      );
+
+      const expectedDepreciationFactor = 
+        1 - (HOUSE_BREAKDOWN_PERCENTAGES.internalLinings.depreciationPercentageYearly * property.age);
+
+      expect(result.depreciationFactor).toBe(expectedDepreciationFactor);
+    });
+
+    it("correctly calculates maintenanceAddition for electrical appliances", () => {
+      const result = property.calculateComponentValue(
+        'electricalAppliances',
+        property.newBuildPrice,
+        property.age,
+        MAINTENANCE_LEVELS[0]
+      );
+
+      const expectedMaintenanceAddition = 
+        MAINTENANCE_LEVELS[0] * 
+        property.newBuildPrice * 
+        property.age * 
+        HOUSE_BREAKDOWN_PERCENTAGES.electricalAppliances.percentOfMaintenanceYearly;
+
+      expect(result.maintenanceAddition).toBe(expectedMaintenanceAddition);
+    });
+
+    it("correctly calculates depreciatedComponentValue for ventilation services", () => {
+      const result = property.calculateComponentValue(
+        'ventilationServices',
+        property.newBuildPrice,
+        property.age,
+        MAINTENANCE_LEVELS[0]
+      );
+
+      const component = HOUSE_BREAKDOWN_PERCENTAGES.ventilationServices;
+      const newComponentValue = property.newBuildPrice * component.percentageOfHouse;
+      const depreciationFactor = 1 - (component.depreciationPercentageYearly * property.age);
+      const maintenanceAddition = 
+        MAINTENANCE_LEVELS[0] * 
+        property.newBuildPrice * 
+        property.age * 
+        component.percentOfMaintenanceYearly;
+
+      const expectedValue = Math.max(
+        (newComponentValue * depreciationFactor) + maintenanceAddition,
+        0
+      );
+
+      expect(result.depreciatedComponentValue).toBe(expectedValue);
+    });
+
+    it("ensures depreciatedComponentValue never goes below 0", () => {
+      const result = property.calculateComponentValue(
+        'ventilationServices',
+        property.newBuildPrice,
+        100, // High age to test possible negative values
+        MAINTENANCE_LEVELS[0]
+      );
+
+      expect(result.depreciatedComponentValue).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should calculate correct depreciation for a 10-year-old house', () => {
+      // Calculate the expected value manually
+      const newBuildPrice = property.newBuildPrice;
+      let expectedDepreciatedPrice = 0;
+
+      // Calculate for each component (mimicking calculateComponentValue())
+      for (const [key, value] of Object.entries(HOUSE_BREAKDOWN_PERCENTAGES)) {
+        const newComponentValue = newBuildPrice * value.percentageOfHouse;
+        const depreciationFactor = 1 - (value.depreciationPercentageYearly * property.age);
+        
+        const maintenanceAddition = (key === 'foundations' || key === 'structureEnvelope') 
+          ? 0 
+          : MAINTENANCE_LEVELS[0] * newBuildPrice * property.age * value.percentOfMaintenanceYearly;
+
+        const depreciatedComponentValue = Math.max(
+          (newComponentValue * depreciationFactor) + maintenanceAddition,
+          0
+        );
+
+        expectedDepreciatedPrice += depreciatedComponentValue;
+      }
+
+      expect(property.depreciatedBuildPrice).toBeCloseTo(Number(expectedDepreciatedPrice.toFixed(2)));
+    });
+  });
 });

--- a/app/models/Property.test.ts
+++ b/app/models/Property.test.ts
@@ -24,8 +24,23 @@ it("correctly calculates the newBuildPrice", () => {
   expect(property.newBuildPrice).toBeCloseTo(186560);
 });
 
-it("correctly calculates the depreciatedBuildPrice", () => {
-  expect(property.depreciatedBuildPrice).toBeCloseTo(110717.45);
+it("correctly calculates the depreciatedBuildPrice for existing builds (age > 0)", () => {
+  expect(property.depreciatedBuildPrice).toBeCloseTo(172988.92);
+});
+
+it("correctly calculates depreciatedBuildPrice for newbuilds (age = 0)", () => {
+  property = new Property({
+    postcode: "WV8 1HG",
+    houseType: "T",
+    numberOfBedrooms: 2,
+    age: 1,
+    size: 88,
+    maintenancePercentage: 0.02,
+    newBuildPricePerMetre: 2120,
+    averageMarketPrice: 218091.58,
+    itl3: "TLG24",
+  });
+  expect(property.depreciatedBuildPrice).toBeCloseTo(186560)
 });
 
 it("correctly calculates the bedWeightedAveragePrice", () => {

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -136,7 +136,8 @@ export class Property {
     let depreciatedComponentValue = 
       (newComponentValue * depreciationFactor) + maintenanceAddition;
 
-    depreciatedComponentValue < 0 ? depreciatedComponentValue = 0 : depreciatedComponentValue
+    // Do not depreciate below 0
+    if (depreciatedComponentValue < 0) depreciatedComponentValue = 0
 
     return {
       newComponentValue,

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -1,6 +1,5 @@
-import * as math from "mathjs";
 import { BED_WEIGHTS_AND_CAPS, MAINTENANCE_LEVELS, HOUSE_BREAKDOWN_PERCENTAGES } from "./constants";
-import { houseBreakdownType, componentBreakdownType } from "./constants";
+import { houseBreakdownType } from "./constants";
 /**
  * Number of decimal places to use when rounding numerical values
  */
@@ -24,6 +23,13 @@ export const HOUSE_TYPES = ["D", "S", "T", "F"] as const;
 export type HouseType = (typeof HOUSE_TYPES)[number];
 
 export type MaintenancePercentage = (typeof MAINTENANCE_LEVELS)[number]
+
+export type ComponentCalculation = {
+  newComponentValue: number;
+  depreciationFactor: number;
+  maintenanceAddition: number;
+  depreciatedComponentValue: number;
+}
 
 export class Property {
   postcode: string;
@@ -90,32 +96,28 @@ export class Property {
     
     let depreciatedBuildPrice = 0;
 
-    for (const [key, value] of Object.entries(HOUSE_BREAKDOWN_PERCENTAGES) as [keyof houseBreakdownType, componentBreakdownType][]) {
-      // New component is calculated as a percentage of newBuildPrice
-      const newComponentValue = this.newBuildPrice * value.percentageOfHouse
-      
-      // Calculate depreciation
-      const depreciationFactor = 1 - (value.depreciationPercentageYearly * this.age);
+  // Calculate for each component using the public method
+  for (const key of Object.keys(HOUSE_BREAKDOWN_PERCENTAGES) as (keyof houseBreakdownType)[]) {
+    const result = this.calculateComponentValue(
+      key, 
+      this.newBuildPrice, 
+      this.age, 
+      MAINTENANCE_LEVELS[0]
+    );
 
-      // Calculate maintenance spend (which counters depreciation)
-      const maintenanceAddition = (key === 'foundations' || key === 'structureEnvelope') ? 0 : 
-        MAINTENANCE_LEVELS[0] * this.newBuildPrice * this.age * value.percentOfMaintenanceYearly;
-
-      // Use both depreciationFactor and maintenanceAddition to calculate final depreciatedComponentValue
-      const depreciatedComponentValue = parseFloat(((newComponentValue * depreciationFactor) + maintenanceAddition).toFixed(PRECISION));
-
-      depreciatedBuildPrice += math.max(depreciatedComponentValue, 0) // Add depreciatedComponentValue to depreciatedBuildPrice, or 0 if value is negative
-    }
+    depreciatedBuildPrice += result.depreciatedComponentValue;
+  }
     depreciatedBuildPrice = parseFloat(depreciatedBuildPrice.toFixed(PRECISION))
-    return depreciatedBuildPrice;
-  };
+
+  return depreciatedBuildPrice;
+}
 
   public calculateComponentValue(
     componentKey: keyof houseBreakdownType,
     newBuildPrice: number,
     age: number,
     maintenanceLevel: number
-  ) {
+  ): ComponentCalculation {
     const component = HOUSE_BREAKDOWN_PERCENTAGES[componentKey];
     
     // Calculate new component value
@@ -131,14 +133,16 @@ export class Property {
         : maintenanceLevel * newBuildPrice * age * component.percentOfMaintenanceYearly;
     
     // Calculate final value
-    const depreciatedComponentValue = 
+    let depreciatedComponentValue = 
       (newComponentValue * depreciationFactor) + maintenanceAddition;
-    
+
+    depreciatedComponentValue < 0 ? depreciatedComponentValue = 0 : depreciatedComponentValue
+
     return {
       newComponentValue,
       depreciationFactor,
       maintenanceAddition,
-      depreciatedComponentValue: Math.max(depreciatedComponentValue, 0)
+      depreciatedComponentValue
     };
   }
 

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -1,5 +1,5 @@
 import { BED_WEIGHTS_AND_CAPS, MAINTENANCE_LEVELS, HOUSE_BREAKDOWN_PERCENTAGES } from "./constants";
-import { houseBreakdownType } from "./constants";
+import { HouseBreakdown } from "./constants";
 /**
  * Number of decimal places to use when rounding numerical values
  */
@@ -97,7 +97,7 @@ export class Property {
     let depreciatedBuildPrice = 0;
 
   // Calculate for each component using the public method
-  for (const key of Object.keys(HOUSE_BREAKDOWN_PERCENTAGES) as (keyof houseBreakdownType)[]) {
+  for (const key of Object.keys(HOUSE_BREAKDOWN_PERCENTAGES) as (keyof HouseBreakdown)[]) {
     const result = this.calculateComponentValue(
       key, 
       this.newBuildPrice, 
@@ -113,7 +113,7 @@ export class Property {
 }
 
   public calculateComponentValue(
-    componentKey: keyof houseBreakdownType,
+    componentKey: keyof HouseBreakdown,
     newBuildPrice: number,
     age: number,
     maintenanceLevel: number

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -1,10 +1,9 @@
 import * as math from "mathjs";
-import { BED_WEIGHTS_AND_CAPS, MAINTENANCE_LEVELS } from "./constants";
+import { BED_WEIGHTS_AND_CAPS, MAINTENANCE_LEVELS, HOUSE_BREAKDOWN_PERCENTAGES } from "./constants";
 /**
  * Number of decimal places to use when rounding numerical values
  */
 const PRECISION = 2;
-const DEPRECIATION_FACTOR = -32938;
 
 type PropertyParams = Pick<
   Property,
@@ -87,12 +86,16 @@ export class Property {
   }
 
   private calculateDepreciatedBuildPrice() {
-    let depreciatedBuildPrice =
-      this.newBuildPrice + DEPRECIATION_FACTOR * math.log(this.age);
-    depreciatedBuildPrice = parseFloat(
-      depreciatedBuildPrice.toFixed(PRECISION)
-    );
+    let depreciatedBuildPrice = 0;
 
+    for (const { percentageOfHouse, depreciationPercentageYearly } of Object.values(HOUSE_BREAKDOWN_PERCENTAGES)) {
+      const newComponentValue = this.newBuildPrice * percentageOfHouse
+      
+      const depreciatedComponentValue = newComponentValue * (1 - (depreciationPercentageYearly * this.age)) // Subtract yearly depreciation amount
+        + (MAINTENANCE_LEVELS[0] * percentageOfHouse * this.age * newComponentValue) // Assuming low spend for depreciatedBuildPrice
+      
+        depreciatedBuildPrice += math.max(depreciatedComponentValue, 0) // Add depreciatedComponentValue to depreciatedBuildPrice, or 0 if value is negative
+    }
     return depreciatedBuildPrice;
   }
 

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -63,7 +63,7 @@ export class Property {
     this.postcode = params.postcode;
     this.houseType = params.houseType;
     this.numberOfBedrooms = params.numberOfBedrooms;
-    this.age = params.age;
+    this.age = params.age - 1; // Subtract 1 because years should be indexed to 0
     this.size = params.size;
     this.maintenancePercentage = params.maintenancePercentage;
     this.newBuildPricePerMetre = params.newBuildPricePerMetre;
@@ -88,13 +88,17 @@ export class Property {
   private calculateDepreciatedBuildPrice() {
     let depreciatedBuildPrice = 0;
 
-    for (const { percentageOfHouse, depreciationPercentageYearly } of Object.values(HOUSE_BREAKDOWN_PERCENTAGES)) {
-      const newComponentValue = this.newBuildPrice * percentageOfHouse
-      
-      const depreciatedComponentValue = newComponentValue * (1 - (depreciationPercentageYearly * this.age)) // Subtract yearly depreciation amount
-        + (MAINTENANCE_LEVELS[0] * percentageOfHouse * this.age * newComponentValue) // Assuming low spend for depreciatedBuildPrice
-      
-        depreciatedBuildPrice += math.max(depreciatedComponentValue, 0) // Add depreciatedComponentValue to depreciatedBuildPrice, or 0 if value is negative
+    if (this.age === 0) {
+      depreciatedBuildPrice = this.newBuildPrice
+    } else { 
+      for (const { percentageOfHouse, depreciationPercentageYearly } of Object.values(HOUSE_BREAKDOWN_PERCENTAGES)) {
+        const newComponentValue = this.newBuildPrice * percentageOfHouse
+        
+        const depreciatedComponentValue = newComponentValue * (1 - (depreciationPercentageYearly * this.age)) // Subtract yearly depreciation amount
+          + (MAINTENANCE_LEVELS[0] * percentageOfHouse * this.age * newComponentValue) // Assuming low spend for depreciatedBuildPrice
+        
+          depreciatedBuildPrice += math.max(depreciatedComponentValue, 0) // Add depreciatedComponentValue to depreciatedBuildPrice, or 0 if value is negative
+      }
     }
     return depreciatedBuildPrice;
   }

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -1,7 +1,7 @@
 export const MONTHS_PER_YEAR = 12;
 export const WEEKS_PER_MONTH = 4.2;
 
-export type bedWeightsAndCapsType = {
+export type BedWeightsAndCaps = {
   numberOfBedrooms: number[];
   weight: number[];
   socialRentCap: number[];
@@ -10,13 +10,13 @@ export type bedWeightsAndCapsType = {
 /**
  * This is used to weight social rent values by property size based on number of bedrooms
  */
-export const BED_WEIGHTS_AND_CAPS: bedWeightsAndCapsType = {
+export const BED_WEIGHTS_AND_CAPS: BedWeightsAndCaps = {
   numberOfBedrooms: [0, 1, 2, 3, 4, 5, 6],
   weight: [0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4],
   socialRentCap: [155.73, 155.73, 164.87, 174.03, 183.18, 192.35, 201.5],
 };
 
-export type nationalAverageType = {
+export type NationalAverage = {
   socialRentWeekly: number;
   propertyValue: number;
   earningsWeekly: number;
@@ -25,7 +25,7 @@ export type nationalAverageType = {
 /**
  * National averages from 1999 and 2000 (from MHCLG), used as inputs for calculating social rent
  */
-export const NATIONAL_AVERAGES: nationalAverageType = {
+export const NATIONAL_AVERAGES: NationalAverage = {
   socialRentWeekly: 54.62,
   propertyValue: 49750,
   earningsWeekly: 316.4,
@@ -38,7 +38,7 @@ export const NATIONAL_AVERAGES: nationalAverageType = {
 export const MAINTENANCE_LEVELS = [0.015, 0.02, 0.0375] as const;
 
 /** Type for storing component values and depreciation*/
-export type componentBreakdownType = {
+export type ComponentBreakdown = {
   /** Component value as percentage of total house value */
   percentageOfHouse: number, 
   /** Percentage of the component's total value that is written-down yearly */
@@ -47,22 +47,22 @@ export type componentBreakdownType = {
   percentOfMaintenanceYearly: number
 }
 
-export type houseBreakdownType = {
-  foundations: componentBreakdownType,
-  structureEnvelope: componentBreakdownType,
-  cladding: componentBreakdownType,
-  roofing: componentBreakdownType,
-  windows: componentBreakdownType,
-  internalLinings: componentBreakdownType,
-  bathroomFixtures: componentBreakdownType,
-  fitout: componentBreakdownType,
-  kitchenUnits: componentBreakdownType,
-  electricalAppliances: componentBreakdownType,
-  electricalServices: componentBreakdownType,
-  ventilationServices: componentBreakdownType,
-  waterAndHeatingServices: componentBreakdownType,
-  floorCoverings: componentBreakdownType,
-  landscaping: componentBreakdownType,
+export type HouseBreakdown = {
+  foundations: ComponentBreakdown,
+  structureEnvelope: ComponentBreakdown,
+  cladding: ComponentBreakdown,
+  roofing: ComponentBreakdown,
+  windows: ComponentBreakdown,
+  internalLinings: ComponentBreakdown,
+  bathroomFixtures: ComponentBreakdown,
+  fitout: ComponentBreakdown,
+  kitchenUnits: ComponentBreakdown,
+  electricalAppliances: ComponentBreakdown,
+  electricalServices: ComponentBreakdown,
+  ventilationServices: ComponentBreakdown,
+  waterAndHeatingServices: ComponentBreakdown,
+  floorCoverings: ComponentBreakdown,
+  landscaping: ComponentBreakdown,
 }
 
 /** 
@@ -70,7 +70,7 @@ export type houseBreakdownType = {
  * foundations 21%, structure 25%, cladding 4%, roofing 4%, windows 4%, internal linings 4%, bathroom 4%, fitout 5%,
  * kitchen units 4%, electrical appliances 4%, electrical services 4%, ventilation services 4%, water and heating services 8%,
  * floor coverings 2%, landscaping 3%*/
-export const HOUSE_BREAKDOWN_PERCENTAGES: houseBreakdownType = {
+export const HOUSE_BREAKDOWN_PERCENTAGES: HouseBreakdown = {
   foundations: {
     percentageOfHouse: .21,
     depreciationPercentageYearly: 0,

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -42,7 +42,9 @@ export type componentBreakdownType = {
   /** Component value as percentage of total house value */
   percentageOfHouse: number, 
   /** Percentage of the component's total value that is written-down yearly */
-  depreciationPercentageYearly: number
+  depreciationPercentageYearly: number,
+  /** Percentage of the yearly maintenance spend allocated to component */
+  percentOfMaintenanceYearly: number
 }
 
 export type houseBreakdownType = {
@@ -65,63 +67,78 @@ export type houseBreakdownType = {
 
 export const HOUSE_BREAKDOWN_PERCENTAGES: houseBreakdownType = {
   foundations: {
-    percentageOfHouse: .2049,
+    percentageOfHouse: .21,
     depreciationPercentageYearly: 0,
+    percentOfMaintenanceYearly: 0
   },
   structureEnvelope: {
-    percentageOfHouse: .2459, 
-    depreciationPercentageYearly: 0
+    percentageOfHouse: .25, 
+    depreciationPercentageYearly: 0,
+    percentOfMaintenanceYearly: 0
   },
   cladding: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .0249
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .0249,
+    percentOfMaintenanceYearly: .074
   },
   roofing: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .0237
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .0237,
+    percentOfMaintenanceYearly: .074
   },
   windows: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .023
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .023,
+    percentOfMaintenanceYearly: .074
   },
   internalLinings: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .032
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .032,
+    percentOfMaintenanceYearly: .074
   },
   bathroomFixtures: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .05
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .05,
+    percentOfMaintenanceYearly: .074
   },
   fitout: {
-    percentageOfHouse: .0492, 
-    depreciationPercentageYearly: .0417
+    percentageOfHouse: .05, 
+    depreciationPercentageYearly: .0417,
+    percentOfMaintenanceYearly: .093
   },
   kitchenUnits: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .0556
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .0556,
+    percentOfMaintenanceYearly: .074
   },
   electricalAppliances: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .0833
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .0833,
+    percentOfMaintenanceYearly: .074
   },
   electricalServices: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .0493
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .0493,
+    percentOfMaintenanceYearly: .074
   },
   ventilationServices: {
-    percentageOfHouse: .041, 
-    depreciationPercentageYearly: .0667
+    percentageOfHouse: .04, 
+    depreciationPercentageYearly: .0667,
+    percentOfMaintenanceYearly: .074
   },
   waterAndHeatingServices: {
-    percentageOfHouse: .082, 
-    depreciationPercentageYearly: .0357
+    percentageOfHouse: .08, 
+    depreciationPercentageYearly: .0357,
+    percentOfMaintenanceYearly: .148
   },
   floorCoverings: {
-    percentageOfHouse: .0205, 
-    depreciationPercentageYearly: .039
+    percentageOfHouse: .02, 
+    depreciationPercentageYearly: .039,
+    percentOfMaintenanceYearly: .037
   },
   landscaping: {
-    percentageOfHouse: .0287, 
-    depreciationPercentageYearly: .0343
+    percentageOfHouse: .03, 
+    depreciationPercentageYearly: .0343,
+    percentOfMaintenanceYearly: .056
   },
 }

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -36,3 +36,92 @@ export const NATIONAL_AVERAGES: nationalAverageType = {
  * figures from our own model
  */
 export const MAINTENANCE_LEVELS = [0.015, 0.02, 0.0375] as const;
+
+/** Type for storing component values and depreciation*/
+export type componentBreakdownType = {
+  /** Component value as percentage of total house value */
+  percentageOfHouse: number, 
+  /** Percentage of the component's total value that is written-down yearly */
+  depreciationPercentageYearly: number
+}
+
+export type houseBreakdownType = {
+  foundations: componentBreakdownType,
+  structureEnvelope: componentBreakdownType,
+  cladding: componentBreakdownType,
+  roofing: componentBreakdownType,
+  windows: componentBreakdownType,
+  internalLinings: componentBreakdownType,
+  bathroomFixtures: componentBreakdownType,
+  fitout: componentBreakdownType,
+  kitchenUnits: componentBreakdownType,
+  electricalAppliances: componentBreakdownType,
+  electricalServices: componentBreakdownType,
+  ventilationServices: componentBreakdownType,
+  waterAndHeatingServices: componentBreakdownType,
+  floorCoverings: componentBreakdownType,
+  landscaping: componentBreakdownType,
+}
+
+export const HOUSE_BREAKDOWN_PERCENTAGES: houseBreakdownType = {
+  foundations: {
+    percentageOfHouse: .2049,
+    depreciationPercentageYearly: 0,
+  },
+  structureEnvelope: {
+    percentageOfHouse: .2459, 
+    depreciationPercentageYearly: 0
+  },
+  cladding: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .0249
+  },
+  roofing: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .0237
+  },
+  windows: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .023
+  },
+  internalLinings: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .032
+  },
+  bathroomFixtures: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .05
+  },
+  fitout: {
+    percentageOfHouse: .0492, 
+    depreciationPercentageYearly: .0417
+  },
+  kitchenUnits: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .0556
+  },
+  electricalAppliances: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .0833
+  },
+  electricalServices: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .0493
+  },
+  ventilationServices: {
+    percentageOfHouse: .041, 
+    depreciationPercentageYearly: .0667
+  },
+  waterAndHeatingServices: {
+    percentageOfHouse: .082, 
+    depreciationPercentageYearly: .0357
+  },
+  floorCoverings: {
+    percentageOfHouse: .0205, 
+    depreciationPercentageYearly: .039
+  },
+  landscaping: {
+    percentageOfHouse: .0287, 
+    depreciationPercentageYearly: .0343
+  },
+}

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -65,6 +65,11 @@ export type houseBreakdownType = {
   landscaping: componentBreakdownType,
 }
 
+/** 
+ * Object (key = component, value = another object with `percentageOfHouse`, `deprecationPercentageYearly` and `percentOfMaintenanceYearly`). Contains a breakdown of a house by component, and the percentage of total value it constitutes:
+ * foundations 21%, structure 25%, cladding 4%, roofing 4%, windows 4%, internal linings 4%, bathroom 4%, fitout 5%,
+ * kitchen units 4%, electrical appliances 4%, electrical services 4%, ventilation services 4%, water and heating services 8%,
+ * floor coverings 2%, landscaping 3%*/
 export const HOUSE_BREAKDOWN_PERCENTAGES: houseBreakdownType = {
   foundations: {
     percentageOfHouse: .21,

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -37,33 +37,30 @@ export const NATIONAL_AVERAGES: NationalAverage = {
  */
 export const MAINTENANCE_LEVELS = [0.015, 0.02, 0.0375] as const;
 
-/** Type for storing component values and depreciation*/
-export type ComponentBreakdown = {
-  /** Component value as percentage of total house value */
-  percentageOfHouse: number, 
-  /** Percentage of the component's total value that is written-down yearly */
-  depreciationPercentageYearly: number,
-  /** Percentage of the yearly maintenance spend allocated to component */
-  percentOfMaintenanceYearly: number
+type Component = 
+  | "foundations" 
+  | "structureEnvelope" 
+  | "cladding"
+  | "roofing"
+  | "windows" 
+  | "internalLinings"
+  | "bathroomFixtures"
+  | "fitout"
+  | "kitchenUnits"
+  | "electricalAppliances"
+  | "electricalServices"
+  | "ventilationServices"
+  | "waterAndHeatingServices"
+  | "floorCoverings"
+  | "landscaping";
+
+interface ComponentBreakdown {
+  percentageOfHouse: number;
+  depreciationPercentageYearly: number;
+  percentOfMaintenanceYearly: number;
 }
 
-export type HouseBreakdown = {
-  foundations: ComponentBreakdown,
-  structureEnvelope: ComponentBreakdown,
-  cladding: ComponentBreakdown,
-  roofing: ComponentBreakdown,
-  windows: ComponentBreakdown,
-  internalLinings: ComponentBreakdown,
-  bathroomFixtures: ComponentBreakdown,
-  fitout: ComponentBreakdown,
-  kitchenUnits: ComponentBreakdown,
-  electricalAppliances: ComponentBreakdown,
-  electricalServices: ComponentBreakdown,
-  ventilationServices: ComponentBreakdown,
-  waterAndHeatingServices: ComponentBreakdown,
-  floorCoverings: ComponentBreakdown,
-  landscaping: ComponentBreakdown,
-}
+export type HouseBreakdown = Record<Component, ComponentBreakdown>;
 
 /** 
  * Object (key = component, value = another object with `percentageOfHouse`, `deprecationPercentageYearly` and `percentOfMaintenanceYearly`). Contains a breakdown of a house by component, and the percentage of total value it constitutes:


### PR DESCRIPTION
# What does this PR do?
`constants.ts`
- Creates new types for calculating depreciation
    - `componentBreakdownType` breaks each component down into the percentage of the house it makes up, how much of its original value it depreciates each year, and what percentage of yearly maintenance spend it accounts for 
    - `houseBreakdownType` is an object with a component breakdown object per-component
- `HOUSE_BREAKDOWN_PERCENTAGES` is exported as a constant for use in `calculateDepreciatedBuildPrice()`

`Property.ts`
- New `calculateComponentValue()` method (separated this out for ease of testing)
- Updates `calculateDepreciatedBuildPrice()`
    - Loops through each object in `HOUSE_BREAKDOWN_PERCENTAGES` and runs `calculateComponentValue()` to calculate depreciated value per-component
    - Sums each value

`Property.test.ts`
- Creates tests for newbuild, depreciated building, component breakdowns

Tests now pass! I ended up opting for a different method where stuff gets calculated again in the test file. Felt a bit more meaningful than just passing the resultant number as the expected value. 

Closes #154