### PR TITLE
feat: calculate resale values in `Lifetime` class

### DIFF
--- a/app/models/Fairhold.ts
+++ b/app/models/Fairhold.ts
@@ -7,10 +7,26 @@ const PLATEAU = 0.15
 
 type ConstructorParams = Pick<Fairhold, "affordability" | "landPriceOrRent">;
 
+/** The Fairhold class is a generic class 
+ * (meaning it will calculate a discount regardless if it is given a purchase price or monthly rent).
+ * It is instantiated twice,
+ * once each for `FairholdLandPurchase` and `FairholdLandRent`
+ */
 export class Fairhold {
+  /** Affordability is calculated as monthly housing cost / GDHI */
   public affordability: number;
+  /** 
+   * Depending on whether calculating `FairholdLandPurchase` or `FairholdLandRent`,
+   * pass the relevant figure (open market residual land value or estimated portion of monthly market rent
+   * that goes towards location)
+   */
   public landPriceOrRent: number;
+  /** The Fairhold discount is a multiplier, so Fairhold prices are `discountLand * open market value`*/
   public discountLand: number;
+  /** 
+   * When the class is instantiated for `FairholdLandPurchase`, this is the discounted up-front land purchase price;
+   * when instantiated for `FairholdLandPurchase`, this is the discounted monthly community ground rent
+  */
   public discountedLandPriceOrRent: number;
 
   constructor(params: ConstructorParams) {
@@ -20,11 +36,19 @@ export class Fairhold {
     this.discountedLandPriceOrRent = this.calculateDiscountedPriceOrRent();
   }
 
+  /** 
+   * Our formula is linear; the more expensive an area is, the lower the generated price multiplier is;
+   * it plateaus at .15 of market rate
+    */
   private calculateFairholdDiscount() {
     const discountLand = math.max(MULTIPLIER * this.affordability + OFFSET, PLATEAU)
     return discountLand;
   }
 
+  /** 
+   * Multiplies market land price or rent by the discountLand multiplier;
+   * in the event that land values are effectively negative, land price will be £1
+   */
   private calculateDiscountedPriceOrRent() {
     if (this.landPriceOrRent < 0) {
       // TODO: Set a nominal value (Check with Ollie)

--- a/app/models/ForecastParameters.ts
+++ b/app/models/ForecastParameters.ts
@@ -8,20 +8,26 @@ export interface ForecastParameters {
   affordabilityThresholdIncomePercentage: number;
 }
 
+/** 
+ * Parameters for forecasting changing costs over time,
+ * all values except years are percentages represented in decimal form
+ */
 export const DEFAULT_FORECAST_PARAMETERS: ForecastParameters = {
-  maintenancePercentage: 0.02, // percentage maintenance cost
-  incomeGrowthPerYear: 0.04, // 4% income growth per year
-  constructionPriceGrowthPerYear: 0.025, // 2.5%
-  rentGrowthPerYear: 0.03, // 3%
-  propertyPriceGrowthPerYear: 0.05, // 5%
-  yearsForecast: 40, // 40 years
-  affordabilityThresholdIncomePercentage: 0.35, // percentage of income to afford rent or purchase
+  maintenancePercentage: 0.02, 
+  incomeGrowthPerYear: 0.04,
+  constructionPriceGrowthPerYear: 0.025, 
+  rentGrowthPerYear: 0.03, 
+  propertyPriceGrowthPerYear: 0.05, 
+  /** The number of years to forecast values over */
+  yearsForecast: 40,
+  /** The threshold of GDHI at which housing is no longer considered affordable  */
+  affordabilityThresholdIncomePercentage: 0.35, 
 } as const;
 
 /**
  * Creates forecast parameters
- * @param maintenancePercentage - Maintenance spend value from form (0.015 | 0.02 | 0.0375)
- * @returns ForecastParameters with updated maintenance cost
+ * @param maintenancePercentage - Maintenance spend value, user input from form
+ * @returns ForecastParameters with updated maintenance spend (overwrites default)
  */
 export function createForecastParameters(maintenancePercentage: number): ForecastParameters {
   

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -9,7 +9,7 @@ import { ForecastParameters } from "./ForecastParameters";
 import { socialRentAdjustmentTypes } from "../data/socialRentAdjustmentsRepo";
 import { Lifetime, LifetimeParams } from "./Lifetime"; 
 
-const HOUSE_MULTIPLIER = 2.4;
+const HEADS_PER_HOUSEHOLD = 2.4;
 
 type ConstructorParams = Pick<
   Household,
@@ -18,9 +18,11 @@ type ConstructorParams = Pick<
   averageRentYearly: number;
   socialRentAverageEarning: number;
   socialRentAdjustments: socialRentAdjustmentTypes;
+  /** The housePriceIndex shown here is used to calculate relative property values and should be from 1999. */
   housePriceIndex: number;
 };
 
+/** The 'parent' class; when instantiated, it instantiates all other relevant classes, including `Property` */
 export class Household {
   public incomePerPersonYearly: number;
   public gasBillYearly: number;
@@ -41,7 +43,7 @@ export class Household {
     this.gasBillYearly = params.gasBillYearly;
     this.property = params.property;
     this.forecastParameters = params.forecastParameters;
-    this.incomeYearly = HOUSE_MULTIPLIER * params.incomePerPersonYearly;
+    this.incomeYearly = HEADS_PER_HOUSEHOLD * params.incomePerPersonYearly;
     this.tenure = this.calculateTenures(params);
     this.lifetime = this.calculateLifetime(params);
   }
@@ -93,17 +95,17 @@ export class Household {
 
     const fairholdLandRent = new FairholdLandRent({
       averageRentYearly: averageRentYearly,
-      averagePrice: this.property.averageMarketPrice, // average price of the property
+      averagePrice: this.property.averageMarketPrice, 
       newBuildPrice: this.property.newBuildPrice,
-      depreciatedBuildPrice: this.property.depreciatedBuildPrice, // depreciated building price
-      landPrice: this.property.landPrice, // land price
-      incomeYearly: this.incomeYearly, // income
+      depreciatedBuildPrice: this.property.depreciatedBuildPrice, 
+      landPrice: this.property.landPrice,
+      incomeYearly: this.incomeYearly,
       forecastParameters: this.forecastParameters,
 
       fairhold: new Fairhold({
         affordability: marketRent.affordability,
         landPriceOrRent: averageRentYearly,
-      }), // fairhold object
+      }), 
 
       marketPurchase: marketPurchase
     });

--- a/app/models/Lifetime.test.ts
+++ b/app/models/Lifetime.test.ts
@@ -1,0 +1,67 @@
+import { Lifetime } from "./Lifetime";
+import { createTestProperty, createTestLifetime } from "./testHelpers";
+
+let lifetime = createTestLifetime();
+
+beforeEach(() => {
+    lifetime = createTestLifetime();
+})
+
+it("can be instantiated", () => {
+    expect(lifetime).toBeInstanceOf(Lifetime);
+})
+
+it("creates an array with the correct number of years", () => {
+    expect(lifetime.lifetimeData).toHaveLength(40)
+})
+
+it("reduces mortgage payments to 0 after the mortgage term is reached", () => {
+    expect(lifetime.lifetimeData[35].newbuildHouseMortgageYearly).toBe(0);
+    expect(lifetime.lifetimeData[34].marketLandMortgageYearly).toBe(0);
+    expect(lifetime.lifetimeData[33].fairholdLandMortgageYearly).toBe(0);
+    expect(lifetime.lifetimeData[32].marketLandMortgageYearly).toBe(0);
+})
+
+describe("resale values", () => {
+    it("correctly calculates for a newbuild house", () => {
+        // Test newbuild (age 0)
+        lifetime = createTestLifetime({
+            property: createTestProperty({ age: 0 })
+        });
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue).toBe(186560);
+    });
+    it("correctly calculates for a 10-year old house", () => {    // Test 10-year-old house
+        lifetime = createTestLifetime({
+            property: createTestProperty({ 
+                age: 10,
+                newBuildPricePerMetre: 2120,
+                size: 88 
+            })
+        }); 
+        // Calculate expected depreciation running `calculateDepreciatedBuildPrice()` method on its own
+        const houseY10 = createTestProperty({ 
+            age: 10,
+            newBuildPricePerMetre: 2120,
+            size: 88 
+        })           
+        const depreciatedHouseY10 = houseY10.calculateDepreciatedBuildPrice()
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue).toBe(depreciatedHouseY10);
+    });
+    it("depreciates the house over time", () => {
+        // Test value changes over time
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue).toBeGreaterThan(
+            lifetime.lifetimeData[10].depreciatedHouseResaleValue);
+    })
+});
+
+
+it("correctly ages the house", () => {
+    lifetime = createTestLifetime({
+        property: createTestProperty({ age: 10 }) 
+    })
+
+    expect(lifetime.lifetimeData[0].houseAge).toBe(10);
+    expect(lifetime.lifetimeData[5].houseAge).toBe(15);
+    expect(lifetime.lifetimeData[20].houseAge).toBe(30);
+    expect(lifetime.lifetimeData[39].houseAge).toBe(49);
+})

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -39,6 +39,7 @@ export interface LifetimeData {
     // gasBillYearly: number;
     depreciatedHouseResaleValue: number;
     fairholdLandPurchaseResaleValue: number;
+    houseAge: number;
     [key: number]: number;
 }
 
@@ -79,6 +80,7 @@ export class Lifetime {
             params.maintenancePercentage * newBuildPriceIterative;
         let depreciatedHouseResaleValueIterative = params.property.depreciatedBuildPrice;
         let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
+        let houseAgeIterative = params.property.age;
 
         for (let i = 0; i < params.yearsForecast - 1; i++) {
             incomeYearlyIterative = 
@@ -103,8 +105,18 @@ export class Lifetime {
                 marketRentYearlyIterative - marketRentLandYearlyIterative;
             maintenanceCostIterative =
                 newBuildPriceIterative * params.maintenancePercentage;
-            depreciatedHouseResaleValueIterative = 0// TODO
-            fairholdLandPurchaseResaleValueIterative = 0// TODO
+            
+            /* A new instance of the `Property` class is needed here in order to
+            re-calculate the depreciated house value as the house gets older*/
+                const iterativeProperty = new Property({ 
+                ...params.property,
+                age: houseAgeIterative 
+            });
+            /* Use the `calculateDepreciatedBuildPrice()` method on the new `Property` class 
+            to calculate an updated depreciated house value */
+            depreciatedHouseResaleValueIterative = iterativeProperty.calculateDepreciatedBuildPrice()            
+            fairholdLandPurchaseResaleValueIterative = (1 + params.constructionPriceGrowthPerYear) // TODO: replace variable name with cpiGrowthPerYear
+            houseAgeIterative += 1
 
             if (i < params.marketPurchase.houseMortgage.termYears - 1) {
                 newbuildHouseMortgageYearlyIterative = params.marketPurchase.houseMortgage.yearlyPaymentBreakdown[i].yearlyPayment;
@@ -138,7 +150,8 @@ export class Lifetime {
                 marketLandRentYearly: marketRentLandYearlyIterative,
                 marketHouseRentYearly: marketRentHouseYearlyIterative,
                 depreciatedHouseResaleValue: depreciatedHouseResaleValueIterative,
-                fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative
+                fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
+                houseAge: houseAgeIterative,
             });
         }
         return lifetime;

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -37,6 +37,8 @@ export interface LifetimeData {
     marketHouseRentYearly: number;
     // we will need the below for newbuilds & retrofits, and oldbuilds
     // gasBillYearly: number;
+    depreciatedHouseResaleValue: number;
+    fairholdLandPurchaseResaleValue: number;
     [key: number]: number;
 }
 
@@ -49,18 +51,6 @@ export class Lifetime {
     
     private calculateLifetime(params: LifetimeParams): LifetimeData[] {
         const lifetime: LifetimeData[] = [];
-
-        // // initialise properties; all properties with default value of 0 will be updated in the loop
-        // this.incomeYearly = params.incomeYearly;
-        // this.affordabilityThresholdIncome = params.incomeYearly * params.affordabilityThresholdIncomePercentage;
-        // this.newbuildHouseMortgageYearly = 0; 
-        // this.depreciatedHouseMortgageYearly = 0;
-        // this.fairholdLandMortgageYearly = 0; 
-        // this.marketLandMortgageYearly = 0; 
-        // this.fairholdLandRentYearly = 0; 
-        // this.maintenanceCost = params.property.newBuildPrice * params.maintenanceCostPercentage;
-        // this.marketLandRentYearly = 0; 
-        // this.marketHouseRentYearly = 0; 
 
         // initialise mortgage values
         let newbuildHouseMortgageYearlyIterative;
@@ -87,6 +77,8 @@ export class Lifetime {
             marketRentYearlyIterative - marketRentLandYearlyIterative;
         let maintenanceCostIterative = 
             params.maintenancePercentage * newBuildPriceIterative;
+        let depreciatedHouseResaleValueIterative = params.property.depreciatedBuildPrice;
+        let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
 
         for (let i = 0; i < params.yearsForecast - 1; i++) {
             incomeYearlyIterative = 
@@ -111,6 +103,8 @@ export class Lifetime {
                 marketRentYearlyIterative - marketRentLandYearlyIterative;
             maintenanceCostIterative =
                 newBuildPriceIterative * params.maintenancePercentage;
+            depreciatedHouseResaleValueIterative = 0// TODO
+            fairholdLandPurchaseResaleValueIterative = 0// TODO
 
             if (i < params.marketPurchase.houseMortgage.termYears - 1) {
                 newbuildHouseMortgageYearlyIterative = params.marketPurchase.houseMortgage.yearlyPaymentBreakdown[i].yearlyPayment;
@@ -143,6 +137,8 @@ export class Lifetime {
                 maintenanceCost: maintenanceCostIterative,
                 marketLandRentYearly: marketRentLandYearlyIterative,
                 marketHouseRentYearly: marketRentHouseYearlyIterative,
+                depreciatedHouseResaleValue: depreciatedHouseResaleValueIterative,
+                fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative
             });
         }
         return lifetime;

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -50,39 +50,86 @@ export class Lifetime {
         this.lifetimeData = this.calculateLifetime(params);
     }
     
+    /**
+     * The `calculateLifetime` method creates an array and populates it with instances of the `LifetimeData` object.
+     * It initialises all variables (except for the mortgage values) using values from `params`, before iterating on them in a `for` loop.
+     * The mortgages are initialised as empty variables and then given values in a `for` loop that ensures that the year is within the `mortgageTerm`
+     * @param params 
+     * @returns 
+     */
     private calculateLifetime(params: LifetimeParams): LifetimeData[] {
         const lifetime: LifetimeData[] = [];
-
-        // initialise mortgage values
-        let newbuildHouseMortgageYearlyIterative;
-        let depreciatedHouseMortgageYearlyIterative;
-        let fairholdLandMortgageYearlyIterative;
-        let marketLandMortgageYearlyIterative;
-
-        // initialise non-mortgage variables; 
+        /** Increases yearly by `ForecastParameters.incomeGrowthPerYear`*/
         let incomeYearlyIterative = params.incomeYearly;
+        /** 35% (or the value of `affordabilityThresholdIncomePercentage`) multiplied by `incomeYearly`*/
         let affordabilityThresholdIncomeIterative =
             incomeYearlyIterative * params.affordabilityThresholdIncomePercentage;
+        /** Increases yearly by `ForecastParameters.propertyPriceGrowthPerYear`*/
         let averageMarketPriceIterative = params.property.averageMarketPrice;
+        /** Increases yearly by `ForecastParameters.constructionPriceGrowthPerYear`*/
         let newBuildPriceIterative = params.property.newBuildPrice;
+        /** Divides `landPrice` by `averageMarketPrice` anew each year as they appreciate */
         let landToTotalRatioIterative = 
             params.property.landPrice / params.property.averageMarketPrice;
+        /** Subtracts `newBuildPriceIterative` from `averageMarketPriceIterative` */
         let landPriceIterative = params.property.landPrice;
+        /** Increases yearly by `ForecastParameters.rentGrowthPerYear`*/
         let marketRentYearlyIterative = 
             params.marketRent.averageRentMonthly * MONTHS_PER_YEAR;
+        /** Increases yearly by `ForecastParameters.rentGrowthPerYear`*/
         let marketRentAffordabilityIterative = 
             marketRentYearlyIterative / incomeYearlyIterative
+        /** Uses the `landToTotalRatioIterative` to calculate the percentage of market rent that goes towards land as the market inflates */
         let marketRentLandYearlyIterative =
             marketRentYearlyIterative * landToTotalRatioIterative;
+        /** Subtracts `marketRentLandYearlyIterative` from inflating `marketRentYearlyIterative` */
         let marketRentHouseYearlyIterative =
             marketRentYearlyIterative - marketRentLandYearlyIterative;
+        /** The percentage (`ForecastParameters.maintenancePercentage`) is kept steady, and is multiplied by the `newBuildPriceIterative` as it inflates  */
         let maintenanceCostIterative = 
             params.maintenancePercentage * newBuildPriceIterative;
+        /** Each loop a new `Property` instance is created, this is updated by running the `calculateDepreciatedBuildPrice()` method on `iterativeProperty` */
         let depreciatedHouseResaleValueIterative = params.property.depreciatedBuildPrice;
+        /** Resale value increases with `ForecastParameters.constructionPriceGrowthPerYear` */
         let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
+        /** Initialises as user input house age and increments by one */
         let houseAgeIterative = params.property.age;
+        
+        // Initialise mortgage variables
+        /** Assuming a constant interest rate, this figures stays the same until the mortgage term (`marketPurchase.houseMortgage.termYears`) is reached */
+        let newbuildHouseMortgageYearlyIterative = params.marketPurchase.houseMortgage.yearlyPaymentBreakdown[0].yearlyPayment;
+        /** Assuming a constant interest rate, this figures stays the same until the mortgage term (`marketPurchase.houseMortgage.termYears`) is reached. `termyears` is the same across tenures, so it doesn't matter that it comes from a `marketPurchase` object here */ 
+        let depreciatedHouseMortgageYearlyIterative = params.fairholdLandPurchase.depreciatedHouseMortgage.yearlyPaymentBreakdown[0].yearlyPayment;
+        /** Assuming a constant interest rate, this figures stays the same until the mortgage term (`marketPurchase.houseMortgage.termYears`) is reached. `termyears` is the same across tenures, so it doesn't matter that it comes from a `marketPurchase` object here */ 
+        let fairholdLandMortgageYearlyIterative = params.fairholdLandPurchase.discountedLandMortgage.yearlyPaymentBreakdown[0].yearlyPayment;
+        /** Assuming a constant interest rate, this figures stays the same until the mortgage term (`marketPurchase.houseMortgage.termYears`) is reached. `termyears` is the same across tenures, so it doesn't matter that it comes from a `marketPurchase` object here */ 
+        let marketLandMortgageYearlyIterative = params.marketPurchase.landMortgage.yearlyPaymentBreakdown[0].yearlyPayment;
+       
+        // New instance of FairholdLandRent class
+        let fairholdLandRentIterative = new Fairhold({
+            affordability: marketRentAffordabilityIterative,
+            landPriceOrRent: marketRentLandYearlyIterative,
+        }).discountedLandPriceOrRent;
 
-        for (let i = 0; i < params.yearsForecast - 1; i++) {
+        // Push the Y0 values before they start being iterated-upon
+        lifetime.push({
+            incomeYearly: incomeYearlyIterative,
+            affordabilityThresholdIncome: affordabilityThresholdIncomeIterative,
+            newbuildHouseMortgageYearly: newbuildHouseMortgageYearlyIterative,
+            depreciatedHouseMortgageYearly: depreciatedHouseMortgageYearlyIterative,
+            fairholdLandMortgageYearly: fairholdLandMortgageYearlyIterative,
+            marketLandMortgageYearly: marketLandMortgageYearlyIterative,
+            fairholdLandRentYearly: fairholdLandRentIterative,
+            maintenanceCost: maintenanceCostIterative,
+            marketLandRentYearly: marketRentLandYearlyIterative,
+            marketHouseRentYearly: marketRentHouseYearlyIterative,
+            depreciatedHouseResaleValue: depreciatedHouseResaleValueIterative,
+            fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
+            houseAge: houseAgeIterative,
+        });
+
+        // The 0th round has already been calculated and pushed above
+        for (let i = 1; i <= params.yearsForecast - 1; i++) {
             incomeYearlyIterative = 
                 incomeYearlyIterative * (1 + params.incomeGrowthPerYear);
             affordabilityThresholdIncomeIterative =
@@ -106,8 +153,10 @@ export class Lifetime {
             maintenanceCostIterative =
                 newBuildPriceIterative * params.maintenancePercentage;
             
-            /* A new instance of the `Property` class is needed here in order to
-            re-calculate the depreciated house value as the house gets older*/
+            /** 
+             * A new instance of the `Property` class is needed each loop in order to
+            re-calculate the depreciated house value as the house gets older
+            */
                 const iterativeProperty = new Property({ 
                 ...params.property,
                 age: houseAgeIterative 
@@ -115,7 +164,7 @@ export class Lifetime {
             /* Use the `calculateDepreciatedBuildPrice()` method on the new `Property` class 
             to calculate an updated depreciated house value */
             depreciatedHouseResaleValueIterative = iterativeProperty.calculateDepreciatedBuildPrice()            
-            fairholdLandPurchaseResaleValueIterative = (1 + params.constructionPriceGrowthPerYear) // TODO: replace variable name with cpiGrowthPerYear
+            fairholdLandPurchaseResaleValueIterative = fairholdLandPurchaseResaleValueIterative * (1 + params.constructionPriceGrowthPerYear) // TODO: replace variable name with cpiGrowthPerYear
             houseAgeIterative += 1
 
             if (i < params.marketPurchase.houseMortgage.termYears - 1) {
@@ -130,14 +179,14 @@ export class Lifetime {
                 marketLandMortgageYearlyIterative = 0;
             }
 
-            /* A new instance of the Fairhold class is needed here in order to
+            /* A new instance of the Fairhold class is needed in each loop in order to
             re-calculate land rent values per-year (with updating local house prices
             and income levels)*/
-            const fairholdLandRentIterative = new Fairhold({
+            fairholdLandRentIterative = new Fairhold({
                 affordability: marketRentAffordabilityIterative,
                 landPriceOrRent: marketRentLandYearlyIterative,
             }).discountedLandPriceOrRent;
-      
+            
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,
                 affordabilityThresholdIncome: affordabilityThresholdIncomeIterative,

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -1,4 +1,3 @@
-// imports (eg constants)
 import { MarketPurchase } from "./tenure/MarketPurchase";
 import { MarketRent } from "./tenure/MarketRent";
 import { FairholdLandPurchase } from "./tenure/FairholdLandPurchase";
@@ -7,7 +6,6 @@ import { Fairhold } from "./Fairhold";
 import { Property } from "./Property";
 import { MONTHS_PER_YEAR } from "./constants";
 
-// interfaces and types
 export interface LifetimeParams {
     marketPurchase: MarketPurchase;
     marketRent: MarketRent;
@@ -42,7 +40,11 @@ export interface LifetimeData {
     houseAge: number;
     [key: number]: number;
 }
-
+/** 
+ * The `Lifetime` class calculates yearly spend on housing over a lifetime (set by `yearsForecast`).
+ * Instead of storing lifetime data within each tenure class itself,
+ * `Lifetime` is stored in its own class (to prevent excess duplication of properties like `incomeYearly`).
+ */
 export class Lifetime {
     public lifetimeData: LifetimeData[];
 
@@ -167,11 +169,13 @@ export class Lifetime {
             fairholdLandPurchaseResaleValueIterative = fairholdLandPurchaseResaleValueIterative * (1 + params.constructionPriceGrowthPerYear) // TODO: replace variable name with cpiGrowthPerYear
             houseAgeIterative += 1
 
+            // If the mortgage term ongoing (if `i` is less than the term), calculate yearly mortgage payments
             if (i < params.marketPurchase.houseMortgage.termYears - 1) {
                 newbuildHouseMortgageYearlyIterative = params.marketPurchase.houseMortgage.yearlyPaymentBreakdown[i].yearlyPayment;
                 depreciatedHouseMortgageYearlyIterative = params.fairholdLandPurchase.depreciatedHouseMortgage.yearlyPaymentBreakdown[i].yearlyPayment;
                 fairholdLandMortgageYearlyIterative = params.fairholdLandPurchase.discountedLandMortgage.yearlyPaymentBreakdown[i].yearlyPayment
                 marketLandMortgageYearlyIterative = params.marketPurchase.landMortgage.yearlyPaymentBreakdown[i].yearlyPayment;
+            // If the mortgage term has ended, yearly payment is 0
             } else {
                 newbuildHouseMortgageYearlyIterative = 0;
                 depreciatedHouseMortgageYearlyIterative = 0;

--- a/app/models/Mortgage.ts
+++ b/app/models/Mortgage.ts
@@ -17,6 +17,10 @@ type MortgageBreakdown = {
   remainingBalance: number;
 }[];
 
+/** 
+ * The `Mortgage` class is instantiated each time a mortgage needs to be calculated,
+ * meaning per-type of property, eg land or house, per-tenure
+ */
 export class Mortgage {
   propertyValue: number;
   /**
@@ -33,6 +37,7 @@ export class Mortgage {
    */
   principal: number;
   monthlyPayment: number;
+  /** This includes principal and interest */
   totalMortgageCost: number;
   yearlyPaymentBreakdown: MortgageBreakdown;
   totalInterest: number;

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -37,7 +37,7 @@ export class Property {
   numberOfBedrooms: number;
   age: number;
   /**
-   * Size of the house in squares meters
+   * Size of the house in square meters
    */
   size: number;
   maintenancePercentage: MaintenancePercentage;
@@ -48,7 +48,8 @@ export class Property {
   averageMarketPrice: number;
   itl3: string;
   /**
-   *  Price of the house if it was new
+   *  Price of the house if it was new, used for residual land value calculations
+   * and for valuing the house alone in marketPurchase
    */
   newBuildPrice: number;
   /**

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -69,7 +69,7 @@ export class Property {
     this.postcode = params.postcode;
     this.houseType = params.houseType;
     this.numberOfBedrooms = params.numberOfBedrooms;
-    this.age = params.age - 1; // Subtract 1 because years should be indexed to 0
+    this.age = params.age // TODO: update frontend so that newbuild = 0
     this.size = params.size;
     this.maintenancePercentage = params.maintenancePercentage;
     this.newBuildPricePerMetre = params.newBuildPricePerMetre;
@@ -91,8 +91,7 @@ export class Property {
   }
 
   public calculateDepreciatedBuildPrice() {
-    if (this.age === 0) return this.newBuildPrice; // If newbuild, return newBuildPrice and don't depreciate
-    
+    if (this.age === 0) return this.newBuildPrice;
     let depreciatedBuildPrice = 0;
 
   // Calculate for each component using the public method

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -90,7 +90,7 @@ export class Property {
     return newBuildPrice;
   }
 
-  private calculateDepreciatedBuildPrice() {
+  public calculateDepreciatedBuildPrice() {
     if (this.age === 0) return this.newBuildPrice; // If newbuild, return newBuildPrice and don't depreciate
     
     let depreciatedBuildPrice = 0;

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -8,7 +8,7 @@ export type bedWeightsAndCapsType = {
 };
 
 /**
- * multiplying value weight and social rent cap for a property based on number of bed rooms
+ * This is used to weight social rent values by property size based on number of bedrooms
  */
 export const BED_WEIGHTS_AND_CAPS: bedWeightsAndCapsType = {
   numberOfBedrooms: [0, 1, 2, 3, 4, 5, 6],
@@ -23,7 +23,7 @@ export type nationalAverageType = {
 };
 
 /**
- * National average values
+ * National averages from 1999 and 2000 (from MHCLG), used as inputs for calculating social rent
  */
 export const NATIONAL_AVERAGES: nationalAverageType = {
   socialRentWeekly: 54.62,
@@ -31,6 +31,10 @@ export const NATIONAL_AVERAGES: nationalAverageType = {
   earningsWeekly: 316.4,
 };
 
+/** 
+ * Maintenance levels are percentages (represented as decimals),
+ * figures from our own model
+ */
 export const MAINTENANCE_LEVELS = [0.015, 0.02, 0.0375] as const;
 
 /** Type for storing component values and depreciation*/

--- a/app/models/tenure/FairholdLandPurchase.ts
+++ b/app/models/tenure/FairholdLandPurchase.ts
@@ -12,13 +12,18 @@ interface FairholdLandPurchaseParams {
   marketPurchase: MarketPurchase;
 }
 
+/** 
+ * `FairholdLandPurchase` needs different params to FairholdLandRent,
+ * which is why they are separate classes that both instantiate an instance of Fairhold. 
+ * Where `FairholdLandRent` uses other classes (eg `MarketPurchase`, `ForecastParameters`), they are passed in*/
 export class FairholdLandPurchase {
   params: FairholdLandPurchaseParams;
   discountedLandPrice: number;
   discountedLandMortgage: Mortgage;
   depreciatedHouseMortgage: Mortgage;
+  /** All tenure classes have an `interestPaid` property, summed from `Mortgage.totalInterest` (if more than one `Mortgage` class) */
   interestPaid: number;
-  /** interest saved relative to market purchase, pounds */
+  /** Interest saved relative to `MarketPurchase`, pounds */
   interestSaved: number;
 
   constructor(params: FairholdLandPurchaseParams) {

--- a/app/models/tenure/FairholdLandRent.ts
+++ b/app/models/tenure/FairholdLandRent.ts
@@ -16,14 +16,17 @@ interface FairholdLandRentParams {
   marketPurchase: MarketPurchase;
 }
 
+/** 
+ * `FairholdLandRent` needs different params to `FairholdLandPurchase`,
+ * which is why they are separate classes that both instantiate an instance of `Fairhold`. 
+ * Where `FairholdLandRent` uses other classes (eg `MarketPurchase`, `ForecastParameters`), they are passed in*/
 export class FairholdLandRent {
   params: FairholdLandRentParams;
-  /** Mortgage on the depreciated value of the house */
   depreciatedHouseMortgage: Mortgage;
-  /** discounted value of the monthly land rent according to fairhold */
   discountedLandRentMonthly: number;
+  /** All tenure classes have an `interestPaid` property, summed from `Mortgage.totalInterest` (if more than one `Mortgage` class) */
   interestPaid: number;
-  /** interest saved relative to market purchase, pounds */
+  /** Interest saved relative to `MarketPurchase`, pounds */
   interestSaved: number;
 
   constructor(params: FairholdLandRentParams) {
@@ -49,6 +52,8 @@ export class FairholdLandRent {
     averagePrice,
   }: FairholdLandRentParams) {
     const marketRentAffordability = incomeYearly / averageRentYearly;
+    /*TODO: landToTotalRatio is calculated elsewhere too, eg when instantiating socialRent in Property... 
+    can we just calculate it once?*/
     const landToTotalRatio = landPrice / averagePrice;
     const averageRentLandMonthly =
       (averageRentYearly / MONTHS_PER_YEAR) * landToTotalRatio;

--- a/app/models/tenure/MarketPurchase.ts
+++ b/app/models/tenure/MarketPurchase.ts
@@ -11,11 +11,14 @@ interface MarketPurchaseParams {
   forecastParameters: ForecastParameters;
 }
 
+// TODO: decide on language to use (eg freeholdPurchase?)
 export class MarketPurchase {
   params: MarketPurchaseParams;
+  /** Uses the summed mortgages to calculate percentage of GDHI spent on housing monthly */
   public affordability: number;
   public houseMortgage: Mortgage;
   public landMortgage: Mortgage;
+  /** All tenure classes have an `interestPaid` property, summed from `Mortgage.totalInterest` (if more than one Mortgage class) */
   public interestPaid: number;
 
   constructor(params: MarketPurchaseParams) {

--- a/app/models/tenure/MarketRent.ts
+++ b/app/models/tenure/MarketRent.ts
@@ -43,6 +43,7 @@ export class MarketRent {
     averageRentYearly,
   }: MarketRentParams) {
     const averageRentMonthly = averageRentYearly / MONTHS_PER_YEAR;
+    // TODO: landToTotalRatio is calculated multiple times in multiple places, can we just do it once?
     const landToTotalRatio = landPrice / averagePrice;
     const averageRentLandMonthly = averageRentMonthly * landToTotalRatio;
     const averageRentHouseMonthly = averageRentMonthly - averageRentLandMonthly;

--- a/app/models/tenure/SocialRent.ts
+++ b/app/models/tenure/SocialRent.ts
@@ -15,9 +15,9 @@ export class SocialRent {
   /** adjustment factors that take into account the increase of living cost  */
   socialRentAdjustments;
   housePriceIndex;
-  adjustedSocialRentMonthly: number; //adjusted social rent monthly
-  socialRentMonthlyLand: number; // social rent to pay the land
-  socialRentMonthlyHouse: number; // social rent monthly House
+  adjustedSocialRentMonthly: number; 
+  socialRentMonthlyLand: number; 
+  socialRentMonthlyHouse: number; 
   constructor(params: SocialRentParams) {
     this.socialRentAverageEarning = params.socialRentAverageEarning;
     this.socialRentAdjustments = params.socialRentAdjustments;

--- a/app/models/testHelpers.ts
+++ b/app/models/testHelpers.ts
@@ -1,0 +1,461 @@
+import { FairholdLandPurchase } from "./tenure/FairholdLandPurchase";
+import { FairholdLandRent } from "./tenure/FairholdLandRent";
+import { MarketRent } from "./tenure/MarketRent";
+import { SocialRent } from "./tenure/SocialRent";
+
+import { Fairhold } from "./Fairhold";
+import { DEFAULT_FORECAST_PARAMETERS } from "./ForecastParameters"; // TODO: should this be saved to constants.ts instead?
+import { Household } from "./Household";
+import { socialRentAdjustmentTypes } from "../data/socialRentAdjustmentsRepo";
+import { Lifetime } from "./Lifetime";
+import { Mortgage } from "./Mortgage";
+import { Property } from "./Property";
+import { MarketPurchase } from "./tenure/MarketPurchase";
+
+const socialRentAdjustments: socialRentAdjustmentTypes = [
+  {
+    inflation: 3.3,
+    total: 4.3,
+    year: "2001-02",
+    additional: 0,
+  },
+  {
+    inflation: 1.7,
+    total: 2.2,
+    year: "2002-03",
+    additional: 0,
+  },
+  {
+    inflation: 1.7,
+    total: 2.2,
+    year: "2003-04",
+    additional: 0,
+  },
+  {
+    inflation: 2.8,
+    total: 3.3,
+    year: "2004-05",
+    additional: 0,
+  },
+  {
+    inflation: 3.1,
+    total: 3.6,
+    year: "2005-06",
+    additional: 0,
+  },
+  {
+    inflation: 2.7,
+    total: 3.2,
+    year: "2006-07",
+    additional: 0,
+  },
+  {
+    inflation: 3.6,
+    total: 4.1,
+    year: "2007-08",
+    additional: 0,
+  },
+  {
+    inflation: 3.9,
+    total: 4.4,
+    year: "2008-09",
+    additional: 0,
+  },
+  {
+    inflation: 5.0,
+    total: 5.5,
+    year: "2009-10",
+    additional: 0,
+  },
+  {
+    inflation: -1.4,
+    total: -0.9,
+    year: "2010-11",
+    additional: 0,
+  },
+  {
+    inflation: 4.6,
+    total: 5.1,
+    year: "2011-12",
+    additional: 0,
+  },
+  {
+    inflation: 5.6,
+    total: 6.1,
+    year: "2012-13",
+    additional: 0,
+  },
+  {
+    inflation: 2.6,
+    total: 3.1,
+    year: "2013-14",
+    additional: 0,
+  },
+  {
+    inflation: 3.2,
+    total: 3.7,
+    year: "2014-15",
+    additional: 0,
+  },
+  {
+    inflation: 1.2,
+    total: 2.2,
+    year: "2015-16",
+    additional: 0,
+  },
+  {
+    inflation: NaN,
+    total: -1.0,
+    year: "2016-17",
+    additional: 0,
+  },
+  {
+    inflation: NaN,
+    total: -1.0,
+    year: "2017-18",
+    additional: 0,
+  },
+  {
+    inflation: NaN,
+    total: -1.0,
+    year: "2018-19",
+    additional: 0,
+  },
+  {
+    inflation: NaN,
+    total: -1.0,
+    year: "2019-20",
+    additional: 0,
+  },
+  {
+    inflation: 1.7,
+    total: 2.7,
+    year: "2020-21",
+    additional: 0,
+  },
+  {
+    inflation: 0.5,
+    total: 1.5,
+    year: "2021-22",
+    additional: 0,
+  },
+  {
+    inflation: 3.1,
+    total: 4.1,
+    year: "2022-23",
+    additional: 0,
+  },
+  {
+    inflation: 10.1,
+    total: 11.1,
+    year: "2023-24",
+    additional: 0,
+  },
+];
+
+/**
+ * Creates a simplified instance of the `Household` class
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `averageRentYearly: 1200,
+ * socialRentAverageEarning: 354.1,
+ * socialRentAdjustments: socialRentAdjustments,
+ * housePriceIndex: 100000,
+ * incomePerPersonYearly: 30000,
+ * gasBillYearly: 700,
+ * property: createTestProperty(),
+ * forecastParameters: DEFAULT_FORECAST_PARAMETERS,`
+ * @returns 
+ */
+export const createTestHousehold = (overrides = {}) => {
+  return new Household ({
+    averageRentYearly: 1200,
+    socialRentAverageEarning: 354.1,
+    socialRentAdjustments: socialRentAdjustments,
+    housePriceIndex: 100000,
+    incomePerPersonYearly: 30000,
+    gasBillYearly: 700,
+    property: createTestProperty(),
+    forecastParameters: DEFAULT_FORECAST_PARAMETERS,
+    ...overrides
+  })
+}
+
+/**
+ * Creates a simplified instance of the `Property` class with straightforward property values for testing. Assumes newbuild!
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `postcode: "SE15 1TX",
+ * houseType: "T",
+ * numberOfBedrooms: 2,
+ * age: 1,
+ * size: 88,
+ * maintenancePercentage: .015,
+ * newBuildPricePerMetre: 2120,
+ * averageMarketPrice: 500000,
+ * itl3: "TLI44",`
+ * @returns
+ */
+export const createTestProperty = (overrides = {}) => {
+    return new Property ({ 
+      postcode: "SE15 1TX",
+      houseType: "T",
+      numberOfBedrooms: 2,
+      age: 1,
+      size: 88,
+      maintenancePercentage: .015,
+      newBuildPricePerMetre: 2120,
+      averageMarketPrice: 500000,
+      itl3: "TLI44",
+      ...overrides
+    })
+}
+
+/**
+ * Creates a simplified instance of the `Mortgage` class, representing the land portion of `MarketPurchase`. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `propertyValue: 300000,
+ * interestRate: 0.035, 
+ * mortgageTerm: 25,
+ * initialDeposit: 0.1,` 
+ * @returns 
+ */
+export const createTestMarketLandMortgage = (overrides = {}) => {
+    return new Mortgage({
+      propertyValue: 300000,
+      interestRate: 0.035, 
+      mortgageTerm: 25,
+      initialDeposit: 0.1, 
+      ...overrides
+    });
+  };
+
+/**
+ * Creates a simplified instance of the `Mortgage` class, representing the replacement value of a newbuild house in `MarketPurchase`. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `propertyValue: 200000,
+ * interestRate: 0.035, 
+ * mortgageTerm: 25,
+ * initialDeposit: 0.1,`
+ * @returns 
+ */
+export const createTestNewbuildHouseMortgage = (overrides = {}) => {
+  return new Mortgage({
+    propertyValue: 200000,
+    interestRate: 0.035, 
+    mortgageTerm: 25,
+    initialDeposit: 0.1, 
+    ...overrides
+  });
+};
+
+/**
+ * Creates a simplified instance of the `Mortgage` class, representing the depreciated house portion of the Fairhold tenures. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `propertyValue: 150000,
+ * interestRate: 0.035, 
+ * mortgageTerm: 25,
+ * initialDeposit: 0.1, `
+ * @returns 
+ */
+export const createTestDepreciatedHouseMortgage = (overrides = {}) => {
+  return new Mortgage({
+    propertyValue: 150000,
+    interestRate: 0.035, 
+    mortgageTerm: 25,
+    initialDeposit: 0.1, 
+    ...overrides
+  });
+};
+
+/**
+ * Creates a simplified instance of the `Mortgage` class, representing the discounted sale of a `FairholdLandPurchase` lease. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `propertyValue: 45000,
+ * interestRate: 0.035, 
+ * mortgageTerm: 25,
+ * initialDeposit: 0.1,`
+ * @returns 
+ */
+export const createTestFairholdLandMortgage = (overrides = {}) => {
+  return new Mortgage({
+    propertyValue: 45000,
+    interestRate: 0.035, 
+    mortgageTerm: 25,
+    initialDeposit: 0.1, 
+    ...overrides
+  });
+};
+
+/** 
+ * Note that this creates an instance of `Fairhold`, not `FairholdLandPurchase`. The former is needed as part of the latter.
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `affordability: .6,
+ *  landPriceOrRent: 300000,`
+ * @returns
+ */
+export const createTestFairholdForLandPurchase = (overrides = {}) => {
+  return new Fairhold({
+    affordability: .6,
+    landPriceOrRent: 300000,
+    ...overrides
+  })
+}
+
+/** 
+ * Note that this creates an instance of `Fairhold`, not `FairholdLandRent`. The former is needed as part of the latter.
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `affordability: .6,
+ *  landPriceOrRent: 900,`
+ * @returns
+ */
+export const createTestFairholdForLandRent = (overrides = {}) => {
+  return new Fairhold({
+    affordability: .6,
+    landPriceOrRent: 900,
+    ...overrides
+  })
+}
+
+/**
+ * Creates a simplified instance of the `MarketPurchase` class. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `averagePrice: 500000,
+ * newBuildPrice: 200000,
+ * depreciatedBuildPrice: 150000,
+ * landPrice: 300000,
+ * incomeYearly: 30000,
+ * forecastParameters: DEFAULT_FORECAST_PARAMETERS,`
+ * @returns 
+ */
+export const createTestMarketPurchase = (overrides = {}) => {
+  return new MarketPurchase({
+    averagePrice: 500000,
+    newBuildPrice: 200000,
+    depreciatedBuildPrice: 150000,
+    landPrice: 300000,
+    incomeYearly: 30000,
+    forecastParameters: DEFAULT_FORECAST_PARAMETERS,
+    ...overrides
+  })
+}
+
+/**
+ * Creates a simplified instance of the `MarketRent` class. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `averageRentYearly: 18000,
+ * averagePrice: 500000,
+ * newBuildPrice: 200000,
+ * depreciatedBuildPrice: 150000,
+ * landPrice: 300000,
+ * incomeYearly: 30000,
+ * forecastParameters: DEFAULT_FORECAST_PARAMETERS,`
+ * @returns 
+ */
+export const createTestMarketRent = (overrides = {}) => {
+  return new MarketRent({
+    averageRentYearly: 18000,
+    averagePrice: 500000,
+    newBuildPrice: 200000,
+    depreciatedBuildPrice: 150000,
+    landPrice: 300000,
+    incomeYearly: 30000,
+    forecastParameters: DEFAULT_FORECAST_PARAMETERS,
+    ...overrides
+  })
+}
+
+/**
+ * Creates a simplified instance of the `FairholdLandPurchase` class, which includes `Fairhold` and `MarketPurchase` instances. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `newBuildPrice: 200000,
+ * depreciatedBuildPrice: 150000,
+ * affordability: .6,
+ * fairhold: createTestFairholdForLandPurchase(),
+ * forecastParameters: DEFAULT_FORECAST_PARAMETERS,
+ * marketPurchase: createTestMarketPurchase(),`
+ * @returns 
+ */
+export const createTestFairholdLandPurchase = (overrides = {}) => {
+  return new FairholdLandPurchase({
+    newBuildPrice: 200000,
+    depreciatedBuildPrice: 150000,
+    affordability: .6,
+    fairhold: createTestFairholdForLandPurchase(),
+    forecastParameters: DEFAULT_FORECAST_PARAMETERS,
+    marketPurchase: createTestMarketPurchase(),
+    ...overrides
+  })
+}
+
+/**
+ * Creates a simplified instance of the `FairholdLandRent` class, which includes `Fairhold` and `MarketPurchase` instances. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `averageRentYearly: 18000,
+ * averagePrice: 500000,
+ * newBuildPrice: 200000,
+ * depreciatedBuildPrice: 150000,
+ * landPrice: 300000,
+ * incomeYearly: 30000,
+ * fairhold: createTestFairholdForLandRent(),
+ * forecastParameters: DEFAULT_FORECAST_PARAMETERS,
+ * marketPurchase: createTestMarketPurchase(),`
+ * @returns 
+ */
+export const createTestFairholdLandRent = (overrides = {}) => {
+  return new FairholdLandRent({
+    averageRentYearly: 18000,
+    averagePrice: 500000,
+    newBuildPrice: 200000,
+    depreciatedBuildPrice: 150000,
+    landPrice: 300000,
+    incomeYearly: 30000,
+    fairhold: createTestFairholdForLandRent(),
+    forecastParameters: DEFAULT_FORECAST_PARAMETERS,
+    marketPurchase: createTestMarketPurchase(),
+    ...overrides
+  })
+}
+
+/**
+ * Creates a simplified instance of the `SocialRent` class. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are:
+ * `numberOfBedrooms: 2,
+ * socialRentAverageEarning: 354.1,
+ * socialRentAdjustments: socialRentAdjustments,
+ * housePriceIndex: 100000,
+ * landToTotalRatio: .6,`
+ * @returns 
+ */
+export const createTestSocialRent = (overrides = {}) => {
+  return new SocialRent({
+    numberOfBedrooms: 2,
+    socialRentAverageEarning: 354.1,
+    socialRentAdjustments: socialRentAdjustments,
+    housePriceIndex: 100000,
+    landToTotalRatio: .6,
+    ...overrides
+  })
+}
+
+/**
+ * Creates a simplified instance of the `Lifetime` class, which includes instances of all tenure classes and `Property` too. Uses straightforward property values for testing. 
+ * @param overrides Include custom values to overwrite those provided. Default values are from other class helper functions and `DEFAULT_FORECAST_PARAMETERS`. 
+ * @returns 
+ */
+export const createTestLifetime = (overrides = {}) => {
+  return new Lifetime({
+    marketPurchase: createTestMarketPurchase(),
+    marketRent: createTestMarketRent(),
+    fairholdLandPurchase: createTestFairholdLandPurchase(),
+    fairholdLandRent: createTestFairholdLandRent(),
+    property: createTestProperty(),
+    propertyPriceGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear,
+    constructionPriceGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear,
+    rentGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.rentGrowthPerYear,
+    yearsForecast: DEFAULT_FORECAST_PARAMETERS.yearsForecast,
+    maintenancePercentage: DEFAULT_FORECAST_PARAMETERS.maintenancePercentage,
+    incomeGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear,
+    affordabilityThresholdIncomePercentage: DEFAULT_FORECAST_PARAMETERS.affordabilityThresholdIncomePercentage,
+    incomeYearly: 30000,
+    ...overrides
+  })
+}


### PR DESCRIPTION
# What's new in this PR
In `Lifetime.ts`
- Added `depreciatedHouseResaleValue`, `fairholdLandPurchaseResaleValue` and `houseAge` properties for resale values (as these will be calculated over 'lifetimes' as well)
- Adds the above classes to the for loop to iterate through them too & push them to `lifetime` 
- Tidied the file slightly
- Made `calculateDepreciatedBuildPrice()` method in `Property` public because we'll need to call it in `Lifetime`

# Why
For story 4 in the calculator, we'll need resale values. Since they also need to be calculated over longer timespans eg lifetime, I thought it made sense to add them to the `Lifetime` class, as it had the most appropriate data structure. 

I would like to merge #151 first so that I can use the helper functions to write tests for this class (that's why this is still a draft, no test file exists for `Lifetime.ts` yet).

Closes #153 