### PR TITLE
chore: calculate `landToTotalRatio` once and pass it to relevant classes

### DIFF
--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -65,11 +65,10 @@ export class Household {
 
     const marketRent = new MarketRent({
       averageRentYearly: averageRentYearly,
-      averagePrice: this.property.averageMarketPrice,
       newBuildPrice: this.property.newBuildPrice,
       depreciatedBuildPrice: this.property.depreciatedBuildPrice,
-      landPrice: this.property.landPrice,
       incomeYearly: this.incomeYearly,
+      landToTotalRatio: this.property.landToTotalRatio,
       forecastParameters: this.forecastParameters,
     });
 
@@ -95,11 +94,10 @@ export class Household {
 
     const fairholdLandRent = new FairholdLandRent({
       averageRentYearly: averageRentYearly,
-      averagePrice: this.property.averageMarketPrice, 
       newBuildPrice: this.property.newBuildPrice,
       depreciatedBuildPrice: this.property.depreciatedBuildPrice, 
-      landPrice: this.property.landPrice,
       incomeYearly: this.incomeYearly,
+      landToTotalRatio: this.property.landToTotalRatio,
       forecastParameters: this.forecastParameters,
 
       fairhold: new Fairhold({

--- a/app/models/tenure/FairholdLandRent.test.ts
+++ b/app/models/tenure/FairholdLandRent.test.ts
@@ -18,10 +18,9 @@ beforeEach(() => {
   tenureFairholdLandRent = new FairholdLandRent({
     averageRentYearly: 20000,
     incomeYearly: 45816,
-    averagePrice: 218091.58,
     newBuildPrice: 186560,
     depreciatedBuildPrice: 110717.45,
-    landPrice: 31531.579,
+    landToTotalRatio: 0.1446,
     ...DEFAULT_FORECAST_PARAMETERS,
     fairhold: new Fairhold({
       affordability: 0.2,

--- a/app/models/tenure/FairholdLandRent.ts
+++ b/app/models/tenure/FairholdLandRent.ts
@@ -6,11 +6,10 @@ import { MarketPurchase } from "./MarketPurchase";
 
 interface FairholdLandRentParams {
   averageRentYearly: number;
-  averagePrice: number;
   newBuildPrice: number;
   depreciatedBuildPrice: number;
-  landPrice: number;
   incomeYearly: number;
+  landToTotalRatio: number;
   fairhold: Fairhold;
   forecastParameters: ForecastParameters;
   marketPurchase: MarketPurchase;
@@ -48,13 +47,9 @@ export class FairholdLandRent {
   private calculateDiscountedLandRentMonthly({
     incomeYearly,
     averageRentYearly,
-    landPrice,
-    averagePrice,
+    landToTotalRatio,
   }: FairholdLandRentParams) {
     const marketRentAffordability = incomeYearly / averageRentYearly;
-    /*TODO: landToTotalRatio is calculated elsewhere too, eg when instantiating socialRent in Property... 
-    can we just calculate it once?*/
-    const landToTotalRatio = landPrice / averagePrice;
     const averageRentLandMonthly =
       (averageRentYearly / MONTHS_PER_YEAR) * landToTotalRatio;
 

--- a/app/models/tenure/MarketRent.test.ts
+++ b/app/models/tenure/MarketRent.test.ts
@@ -11,10 +11,9 @@ beforeEach(() => {
   tenureMarketRent = new MarketRent({
     averageRentYearly: 20000,
     incomeYearly: 45816,
-    averagePrice: 218091.58,
     newBuildPrice: 186560,
     depreciatedBuildPrice: 110717.45,
-    landPrice: 31531.579,
+    landToTotalRatio: 0.1446,
     forecastParameters: forecastParameters,
   });
 });

--- a/app/models/tenure/MarketRent.ts
+++ b/app/models/tenure/MarketRent.ts
@@ -2,11 +2,10 @@ import { MONTHS_PER_YEAR } from "../constants";
 import { ForecastParameters,  DEFAULT_FORECAST_PARAMETERS } from '../ForecastParameters'; 
 interface MarketRentParams {
   averageRentYearly: number;
-  averagePrice: number;
   newBuildPrice: number;
   depreciatedBuildPrice: number;
-  landPrice: number;
   incomeYearly: number;
+  landToTotalRatio: number;
   forecastParameters: ForecastParameters;
 }
 
@@ -37,14 +36,11 @@ export class MarketRent {
   }
 
   private calculateAverageRentLandAndHouse({
-    landPrice,
-    averagePrice,
+    landToTotalRatio,
     incomeYearly,
     averageRentYearly,
   }: MarketRentParams) {
     const averageRentMonthly = averageRentYearly / MONTHS_PER_YEAR;
-    // TODO: landToTotalRatio is calculated multiple times in multiple places, can we just do it once?
-    const landToTotalRatio = landPrice / averagePrice;
     const averageRentLandMonthly = averageRentMonthly * landToTotalRatio;
     const averageRentHouseMonthly = averageRentMonthly - averageRentLandMonthly;
     const affordability = averageRentYearly / incomeYearly;


### PR DESCRIPTION
# What's new in this PR?
- Removes `averagePrice` and `landPrice` from tenure classes `MarketRent` and `FairholdLandRent` because they were only there to be used to calculate `landToTotalRatio`, which gets calculated in Property` anyway
- Pass `landToTotalRatio` to `MarketRent` and `FairholdLandRent`
- Update tests accordingly (to fit the new params shape)

# Why?
- `landToTotalRatio` was being calculated multiple times and could just be calculated once and passed where needed.

Closes #150