### PR TITLE
fix(ci): Add correct Prisma secrets

### DIFF
--- a/.github/workflows/deploy-migrations.yaml
+++ b/.github/workflows/deploy-migrations.yaml
@@ -20,4 +20,5 @@ jobs:
       - name: Apply all pending migrations to the database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+          POSTGRES_PRISMA_URL: ${{ secrets.PRODUCTION_POSTGRES_PRISMA_URL }}
+          POSTGRES_URL_NON_POOLING: ${{ secrets.PRODUCTION_POSTGRES_URL_NON_POOLING }}


### PR DESCRIPTION
The latest merge to `main` failed with the following error -

![image](https://github.com/user-attachments/assets/c03a6deb-d926-4ce2-8f80-26db1ab37fb0)

Link to CI run - https://github.com/theopensystemslab/fairhold-dashboard/actions/runs/12197345446/job/34026789936

The GH action is now configured with the variables listed here -

https://github.com/theopensystemslab/fairhold-dashboard/blob/e91c7177809ebca0cc95d18305a00b8b1079df82/prisma/schema.prisma#L5-L9

Which are configured in the repo in Settings > Secrets

![image](https://github.com/user-attachments/assets/5115a4f0-8af4-4a2b-a282-07e4095f3a54)
