### PR TITLE
feat: Rename `build_prices` table, make fields non-nullable

### DIFF
--- a/app/data/buildPriceRepo.ts
+++ b/app/data/buildPriceRepo.ts
@@ -9,8 +9,7 @@ const getBuildPriceByHouseType = async (houseType: string): Promise<number> => {
       select: { priceMid: true },
     });
 
-    // Cast to string as 'not: null' clause in Prisma query does not type narrow
-    return buildPrice as number;
+    return buildPrice;
   } catch (error) {
     throw new Error(
       `Data error: Unable to get buildPrice for houseType ${houseType}`

--- a/prisma/migrations/20241206160747_update_build_prices_names/migration.sql
+++ b/prisma/migrations/20241206160747_update_build_prices_names/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the `buildprices` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- Alter table
+ALTER TABLE "buildprices" RENAME TO "build_prices";
+
+-- Alter table
+ALTER TABLE "build_prices" RENAME COLUMN "housetype" TO "house_type";
+ALTER TABLE "build_prices" RENAME COLUMN "pricerange" TO "price_range";
+ALTER TABLE "build_prices" RENAME COLUMN "pricemid" TO "price_mid";

--- a/prisma/migrations/20241206160747_update_build_prices_names/migration.sql
+++ b/prisma/migrations/20241206160747_update_build_prices_names/migration.sql
@@ -1,9 +1,3 @@
-/*
-  Warnings:
-
-  - You are about to drop the `buildprices` table. If the table is not empty, all the data it contains will be lost.
-
-*/
 -- Alter table
 ALTER TABLE "buildprices" RENAME TO "build_prices";
 

--- a/prisma/migrations/20241206161309_rename_constraint/migration.sql
+++ b/prisma/migrations/20241206161309_rename_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "build_prices" RENAME CONSTRAINT "buildprices_pkey" TO "build_prices_pkey";

--- a/prisma/migrations/20241206161734_make_build_prices_fields_required/migration.sql
+++ b/prisma/migrations/20241206161734_make_build_prices_fields_required/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Made the column `house_type_description` on table `build_prices` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `house_type` on table `build_prices` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `price_range` on table `build_prices` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `price_mid` on table `build_prices` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "build_prices" ALTER COLUMN "house_type_description" SET NOT NULL,
+ALTER COLUMN "house_type" SET NOT NULL,
+ALTER COLUMN "price_range" SET NOT NULL,
+ALTER COLUMN "price_mid" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,12 +10,12 @@ datasource db {
 
 model BuildPrices {
   id                   Int     @id @default(autoincrement())
-  houseTypeDescription String? @map("house_type_description") @db.VarChar(250)
-  houseType            String? @map("housetype") @db.VarChar(1)
-  priceRange           String? @map("pricerange") @db.VarChar(50)
-  priceMid             Float?  @map("pricemid")
+  houseTypeDescription String @map("house_type_description") @db.VarChar(250)
+  houseType            String @map("house_type") @db.VarChar(1)
+  priceRange           String @map("price_range") @db.VarChar(50)
+  priceMid             Float  @map("price_mid")
 
-  @@map("buildprices")
+  @@map("build_prices")
 }
 
 model GDHI {


### PR DESCRIPTION
## What does this PR do?
 - Changes table and column names to Postgres convention snake_case for the `buildprices` table
 - Updates code to reflect these fields as non-nullable