### PR TITLE
feat: Rename `HPI` table columns, add not null constraints

### DIFF
--- a/app/data/hpiRepo.ts
+++ b/app/data/hpiRepo.ts
@@ -5,6 +5,7 @@ const getHPIByITL3 = async (itl3: string): Promise<number> => {
     const {
       _avg: { hpi2000: averageHpi },
     } = await prisma.hPI.aggregate({
+      // TODO: Should there be a relationship on ITL3?
       where: {
         itl3: {
           endsWith: itl3,
@@ -20,8 +21,7 @@ const getHPIByITL3 = async (itl3: string): Promise<number> => {
       throw new Error(`Data error: Unable to find hpi2000 for itl3 ${itl3}`);
     }
 
-
-    return averageHpi as number;
+    return averageHpi;
   } catch (error) {
     throw Error(`Data error: Unable to find hpi2000 for itl3 ${itl3}`);
   }

--- a/prisma/migrations/20241206165018_update_hpi_table/migration.sql
+++ b/prisma/migrations/20241206165018_update_hpi_table/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "hpi" 
+RENAME COLUMN "ladcode" TO "lad_code";
+
+-- AlterTable
+ALTER TABLE "hpi"
+ALTER COLUMN "region" SET NOT NULL,
+ALTER COLUMN "itl3" SET NOT NULL,
+ALTER COLUMN "hpi_2000" SET NOT NULL;

--- a/prisma/migrations/20241206165140_lad_code_not_null/migration.sql
+++ b/prisma/migrations/20241206165140_lad_code_not_null/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `lad_code` on table `hpi` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "hpi" ALTER COLUMN "lad_code" SET NOT NULL;

--- a/prisma/migrations/20241206165140_lad_code_not_null/migration.sql
+++ b/prisma/migrations/20241206165140_lad_code_not_null/migration.sql
@@ -1,8 +1,2 @@
-/*
-  Warnings:
-
-  - Made the column `lad_code` on table `hpi` required. This step will fail if there are existing NULL values in that column.
-
-*/
 -- AlterTable
 ALTER TABLE "hpi" ALTER COLUMN "lad_code" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,10 +30,10 @@ model GDHI {
 
 model HPI {
   id      Int     @id @default(autoincrement())
-  region  String? @db.VarChar(250)
-  itl3    String? @db.VarChar(250)
-  ladCode String? @map("ladcode") @db.VarChar(250)
-  hpi2000 Float?  @map("hpi_2000")
+  region  String @db.VarChar(250)
+  itl3    String @db.VarChar(250)
+  ladCode String @map("lad_code") @db.VarChar(250)
+  hpi2000 Float  @map("hpi_2000")
 
   @@map("hpi")
 }


### PR DESCRIPTION
## What does this PR do?
 - Renames `ladcode` to `lad_code`
 - Adds `NOT NULL` constraints to columns
 - Updates code to account for this constraint