### PR TITLE
feat: migration rename columns in `gas_bills` table

### DIFF
--- a/app/data/gasBillRepo.test.ts
+++ b/app/data/gasBillRepo.test.ts
@@ -18,14 +18,14 @@ describe("gasBillRepo", () => {
     const mockGasBill = 150; // Example gas bill amount
 
     (prisma.gasBills.findFirstOrThrow as jest.Mock).mockResolvedValueOnce({
-      kwh_cost_pence: mockGasBill,
+      kwhCostPence: mockGasBill,
     });
 
     const result = await gasBillRepo.getGasBillByITL3(itl);
     expect(result).toBe(mockGasBill);
     expect(prisma.gasBills.findFirstOrThrow).toHaveBeenCalledWith({
       where: { itl1: { startsWith: itl.substring(0, 3) } },
-      select: { kwh_cost_pence: true },
+      select: { kwhCostPence: true },
     });
   });
 

--- a/app/data/gasBillRepo.test.ts
+++ b/app/data/gasBillRepo.test.ts
@@ -18,14 +18,14 @@ describe("gasBillRepo", () => {
     const mockGasBill = 150; // Example gas bill amount
 
     (prisma.gasBills.findFirstOrThrow as jest.Mock).mockResolvedValueOnce({
-      bill: mockGasBill,
+      kwh_cost_pence: mockGasBill,
     });
 
     const result = await gasBillRepo.getGasBillByITL3(itl);
     expect(result).toBe(mockGasBill);
     expect(prisma.gasBills.findFirstOrThrow).toHaveBeenCalledWith({
-      where: { itl: { startsWith: itl.substring(0, 3) } },
-      select: { bill: true },
+      where: { itl1: { startsWith: itl.substring(0, 3) } },
+      select: { kwh_cost_pence: true },
     });
   });
 

--- a/app/data/gasBillRepo.ts
+++ b/app/data/gasBillRepo.ts
@@ -2,14 +2,14 @@ import prisma from "./db";
 
 const getGasBillByITL3 = async (itl: string): Promise<number> => {
     try {
-        const { bill } = await prisma.gasBills.findFirstOrThrow({
+        const { kwh_cost_pence } = await prisma.gasBills.findFirstOrThrow({
             where: {
-                itl: { startsWith: itl.substring(0, 3) },
+                itl1: { startsWith: itl.substring(0, 3) },
             },
-            select: { bill: true },
+            select: { kwh_cost_pence: true },
         });
 
-        return bill as number;
+        return kwh_cost_pence;
     } catch (error) {
         throw Error(`Data error: Unable to find gas_bills_2020 for itl3 ${itl}`);
     }

--- a/app/data/gasBillRepo.ts
+++ b/app/data/gasBillRepo.ts
@@ -2,14 +2,14 @@ import prisma from "./db";
 
 const getGasBillByITL3 = async (itl: string): Promise<number> => {
     try {
-        const { kwh_cost_pence } = await prisma.gasBills.findFirstOrThrow({
+        const { kwhCostPence } = await prisma.gasBills.findFirstOrThrow({
             where: {
                 itl1: { startsWith: itl.substring(0, 3) },
             },
-            select: { kwh_cost_pence: true },
+            select: { kwhCostPence: true },
         });
 
-        return kwh_cost_pence;
+        return kwhCostPence;
     } catch (error) {
         throw Error(`Data error: Unable to find gas_bills_2020 for itl3 ${itl}`);
     }

--- a/prisma/migrations/20241211152923_rename_gasbills_column/migration.sql
+++ b/prisma/migrations/20241211152923_rename_gasbills_column/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "gas_bills" RENAME COLUMN "bill" TO "kwh_cost_pence";
+ALTER TABLE "gas_bills" RENAME COLUMN "itl" TO "itl1";
+ALTER TABLE "gas_bills" ALTER COLUMN "kwh_cost_pence" SET NOT NULL;
+ALTER TABLE "gas_bills" ALTER COLUMN "itl1" SET NOT NULL;

--- a/prisma/migrations/20241211152923_rename_gasbills_column/migration.sql
+++ b/prisma/migrations/20241211152923_rename_gasbills_column/migration.sql
@@ -1,5 +1,6 @@
 -- AlterTable
 ALTER TABLE "gas_bills" RENAME COLUMN "bill" TO "kwh_cost_pence";
 ALTER TABLE "gas_bills" RENAME COLUMN "itl" TO "itl1";
+ALTER TABLE "gas_bills" RENAME COLUMN "Region" TO "region";
 ALTER TABLE "gas_bills" ALTER COLUMN "kwh_cost_pence" SET NOT NULL;
 ALTER TABLE "gas_bills" ALTER COLUMN "itl1" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,8 +91,8 @@ model SocialRent {
 model GasBills {
   id     Int    @id
   region String @map("Region") @db.VarChar
-  itl    String @db.VarChar
-  bill   Float
+  itl1    String @db.VarChar
+  kwh_cost_pence   Float
 
   @@map("gas_bills")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,7 +90,7 @@ model SocialRent {
 
 model GasBills {
   id     Int    @id
-  region String @map("Region") @db.VarChar
+  region String @map("region") @db.VarChar
   itl1    String @db.VarChar
   kwh_cost_pence   Float
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,7 +92,7 @@ model GasBills {
   id     Int    @id
   region String @map("region") @db.VarChar
   itl1    String @db.VarChar
-  kwh_cost_pence   Float
+  kwhCostPence   Float @map("kwh_cost_pence")
 
   @@map("gas_bills")
 }


### PR DESCRIPTION
# What does this PR do?
- Creates a new migration renaming some of the `gas_bills` columns
- Updates the schema accordingly

# Why?
I was starting on the data update migration and realised the shape of the gas bills data will change. It seemed like this would need to happen in two steps anyway (data change and schema change) so I figured we could rename the columns first, as the supplied CSVs are already in the next shape. 

# Questions
...do I need to update the tests to get everything passing even if we're just about to update the data anyway? 😅 