### PR TITLE
chore: tidy up migration docs and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ next-env.d.ts
 .vscode
 
 # backups
-backups/*.sql
+backups/

--- a/prisma/docs/how-to-update-prisma-schema.md
+++ b/prisma/docs/how-to-update-prisma-schema.md
@@ -15,6 +15,8 @@ Run `npm run prisma:migrate` - this will apply to the change to your local dev d
 > For example when renaming a column Prisma may drop and recreate the column (thus losing data). Manually writing the correct SQL in the generated migration file (e.g. `ALTER table UPDATE column`) allows us to work around this. You'll then need to run `npm run prisma:migrate` to apply your changes.
 >
 > Docs: https://www.prisma.io/docs/orm/prisma-migrate/workflows/development-and-production#customizing-migrations
+> 
+> Even though you run it with `create-only`, you will _still_ get the warning `√ We need to reset the "public" schema at "localhost:5400"...Do you want to continue? All data will be lost.` and you'll have to proceed with `yes`. 
 
 1. Update Prisma client
 Run `npm run prisma:generate` to update your local client. You should now be able to both interact with the updated Prisma client as well as view the change in your local dev database.


### PR DESCRIPTION
# What does this PR do?
- Adds description of data loss warning to backup docs
- Changes gitignore to ignore whole backups directory (not just sql files)

# Why?
While the docs were super clear and I was able to carry out #166 smoothly, I knew when Daf's demo was less fresh in my mind I'd probably be very alarmed / confused by the data deletion warning, so figured it was best to clarify in the docs. 

I also backed up the db first, and found that it created a `.dump` file (rather than a `.sql` file which our gitignore expected) so just added the whole backups directory to the gitignore. 