### PR TITLE
feat: Rename social_rent_earnings table, make fields non-nullable 

### DIFF
--- a/app/data/socialRentEarningsRepo.test.ts
+++ b/app/data/socialRentEarningsRepo.test.ts
@@ -18,7 +18,7 @@ describe("socialRentEarningsRepo", () => {
     const mockEarnings = 500; // Example average earnings
 
     // Mock the Prisma client response
-    (prisma.socialRent.aggregate as jest.Mock).mockResolvedValueOnce({
+    (prisma.socialRentEarnings.aggregate as jest.Mock).mockResolvedValueOnce({
       _avg: { earningsPerWeek: mockEarnings },
     });
 
@@ -26,7 +26,7 @@ describe("socialRentEarningsRepo", () => {
       await socialRentEarningsRepo.getSocialRentEarningsByITL3(itl3);
 
     expect(result).toBe(mockEarnings);
-    expect(prisma.socialRent.aggregate).toHaveBeenCalledWith({
+    expect(prisma.socialRentEarnings.aggregate).toHaveBeenCalledWith({
       where: {
         itl3: {
           startsWith: itl3.substring(0, 3),
@@ -42,7 +42,7 @@ describe("socialRentEarningsRepo", () => {
     const itl3 = "XYZ123";
 
     // Mock the Prisma client response to return null for earningsPerWeek
-    (prisma.socialRent.aggregate as jest.Mock).mockResolvedValueOnce({
+    (prisma.socialRentEarnings.aggregate as jest.Mock).mockResolvedValueOnce({
       _avg: { earningsPerWeek: null },
     });
 
@@ -57,7 +57,7 @@ describe("socialRentEarningsRepo", () => {
     const itl3 = "XYZ123";
 
     // Mock the Prisma client to throw an error
-    (prisma.socialRent.aggregate as jest.Mock).mockRejectedValueOnce(
+    (prisma.socialRentEarnings.aggregate as jest.Mock).mockRejectedValueOnce(
       new Error("Database error")
     );
 

--- a/app/data/socialRentEarningsRepo.test.ts
+++ b/app/data/socialRentEarningsRepo.test.ts
@@ -3,7 +3,7 @@ import { socialRentEarningsRepo } from "./socialRentEarningsRepo"; // Adjust the
 import prisma from "./db"; // Your Prisma setup file
 
 jest.mock("./db", () => ({
-  socialRent: {
+  socialRentEarnings: {
     aggregate: jest.fn(), // Mock the aggregate method
   },
 }));

--- a/app/data/socialRentEarningsRepo.ts
+++ b/app/data/socialRentEarningsRepo.ts
@@ -2,7 +2,7 @@ import prisma from "./db";
 
 const getSocialRentEarningsByITL3 = async (itl3: string): Promise<number> => {
     try {
-        const result = await prisma.socialRent.aggregate({ 
+        const result = await prisma.socialRentEarnings.aggregate({ 
             where: {
               itl3: {
                 startsWith: itl3.substring(0, 3),

--- a/prisma/migrations/20241212112723_rename_social_rent_earnings/migration.sql
+++ b/prisma/migrations/20241212112723_rename_social_rent_earnings/migration.sql
@@ -1,0 +1,5 @@
+-- Alter table
+ALTER TABLE "socialrent" RENAME TO "social_rent_earnings";
+
+-- Alter table
+ALTER TABLE "social_rent_earnings" RENAME COLUMN "earningsperweek" TO "earnings_per_week";

--- a/prisma/migrations/20241212112833_social_rent_earnings_rename_constraint/migration.sql
+++ b/prisma/migrations/20241212112833_social_rent_earnings_rename_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "social_rent_earnings" RENAME CONSTRAINT "socialrent_pkey" TO "social_rent_earnings_pkey";

--- a/prisma/migrations/20241212113106_make_social_rent_earnings_fields_required/migration.sql
+++ b/prisma/migrations/20241212113106_make_social_rent_earnings_fields_required/migration.sql
@@ -1,0 +1,5 @@
+
+-- AlterTable
+ALTER TABLE "social_rent_earnings" ALTER COLUMN "county" SET NOT NULL,
+ALTER COLUMN "itl3" SET NOT NULL,
+ALTER COLUMN "earnings_per_week" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,9 +81,9 @@ model SocialRentAdjustments {
 
 model SocialRentEarnings {
   id              Int     @id @default(autoincrement())
-  county          String? @db.VarChar(250)
-  itl3            String? @db.VarChar(250)
-  earningsPerWeek Float?  @map("earnings_per_week")
+  county          String @db.VarChar(250)
+  itl3            String @db.VarChar(250)
+  earningsPerWeek Float  @map("earnings_per_week")
 
   @@map("social_rent_earnings")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,13 +79,13 @@ model SocialRentAdjustments {
   @@map("soc_rent_adjustments")
 }
 
-model SocialRent {
+model SocialRentEarnings {
   id              Int     @id @default(autoincrement())
   county          String? @db.VarChar(250)
   itl3            String? @db.VarChar(250)
-  earningsPerWeek Float?  @map("earningsperweek")
+  earningsPerWeek Float?  @map("earnings_per_week")
 
-  @@map("socialrent")
+  @@map("social_rent_earnings")
 }
 
 model GasBills {


### PR DESCRIPTION
# What does this PR do?
Changes table and column names to Postgres convention snake_case for the `socialrent` table (which held social rent _earnings_ data anyway), so updated that for accuracy)
Updates code to reflect these fields as non-nullable

Basically follows #162! Closes #169