### PR TITLE
feat: rename `rent` table and make fields non-nullable

### DIFF
--- a/prisma/migrations/20241212122143_rename_rent_table_columns/migration.sql
+++ b/prisma/migrations/20241212122143_rename_rent_table_columns/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "rent" RENAME COLUMN "ladcode" TO "lad_code";
+ALTER TABLE "rent" RENAME COLUMN "monthlymeanrent" TO "monthly_mean_rent";

--- a/prisma/migrations/20241212122332_make_rent_fields_required/migration.sql
+++ b/prisma/migrations/20241212122332_make_rent_fields_required/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "rent" ALTER COLUMN "itl3" SET NOT NULL,
+ALTER COLUMN "lad_code" SET NOT NULL,
+ALTER COLUMN "region" SET NOT NULL,
+ALTER COLUMN "monthly_mean_rent" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,10 +61,10 @@ model PricesPaid {
 
 model Rent {
   id              Int     @id @default(autoincrement())
-  itl3            String? @db.VarChar(250)
-  ladCode         String? @map("ladcode") @db.VarChar(250)
-  region          String? @db.VarChar(250)
-  monthlyMeanRent Float?  @map("monthlymeanrent")
+  itl3            String @db.VarChar(250)
+  ladCode         String @map("lad_code") @db.VarChar(250)
+  region          String @db.VarChar(250)
+  monthlyMeanRent Float  @map("monthly_mean_rent")
 
   @@map("rent")
 }


### PR DESCRIPTION
Changes table and column names to Postgres convention snake_case for the `rent` table
Makes fields required

Basically follows #162!