### PR TITLE
feat: make itl_lookup fields required

### DIFF
--- a/app/data/itlRepo.test.ts
+++ b/app/data/itlRepo.test.ts
@@ -27,9 +27,6 @@ describe("itlRepo", () => {
     expect(prisma.itlLookup.findFirstOrThrow).toHaveBeenCalledWith({
       where: {
         postcode: postcodeDistrict,
-        itl3: {
-          not: null,
-        },
       },
       select: {
         itl3: true,

--- a/app/data/itlRepo.ts
+++ b/app/data/itlRepo.ts
@@ -7,9 +7,6 @@ const getItl3ByPostcodeDistrict = async (
     const { itl3 } = await prisma.itlLookup.findFirstOrThrow({
       where: {
         postcode: postcodeDistrict,
-        itl3: {
-          not: null,
-        },
       },
       select: {
         itl3: true,

--- a/prisma/migrations/20241213132621_make_itl_lookup_field_required/migration.sql
+++ b/prisma/migrations/20241213132621_make_itl_lookup_field_required/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "itl_lookup" ALTER COLUMN "postcode" SET NOT NULL,
+ALTER COLUMN "district" SET NOT NULL,
+ALTER COLUMN "areacode" SET NOT NULL,
+ALTER COLUMN "itl3" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,10 +39,10 @@ model HPI {
 }
 
 model ItlLookup {
-  postcode String?
-  district String?
-  areacode String?
-  itl3     String?
+  postcode String
+  district String
+  areacode String
+  itl3     String
   id       Int     @id @default(autoincrement())
 
   @@map("itl_lookup")


### PR DESCRIPTION
No renaming needed in this table. Makes the fields required. 