### PR TITLE
feat: rename `social_rent_adjustments` table and make fields required

### DIFF
--- a/prisma/migrations/20241213133842_rename_social_rent_adjustments/migration.sql
+++ b/prisma/migrations/20241213133842_rename_social_rent_adjustments/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "soc_rent_adjustments" RENAME TO "social_rent_adjustments";

--- a/prisma/migrations/20241213134106_rename_social_rent_adjustments_constraint/migration.sql
+++ b/prisma/migrations/20241213134106_rename_social_rent_adjustments_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "social_rent_adjustments" RENAME CONSTRAINT "soc_rent_adjustments_pkey" TO "social_rent_adjustments_pkey";

--- a/prisma/migrations/20241213134224_make_social_rent_adjustments_field_required/migration.sql
+++ b/prisma/migrations/20241213134224_make_social_rent_adjustments_field_required/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "social_rent_adjustments" ALTER COLUMN "year" SET NOT NULL,
+ALTER COLUMN "inflation" SET NOT NULL,
+ALTER COLUMN "additional" SET NOT NULL,
+ALTER COLUMN "total" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,7 +76,7 @@ model SocialRentAdjustments {
   total      Float?
   id         Int     @id @default(autoincrement())
 
-  @@map("soc_rent_adjustments")
+  @@map("social_rent_adjustments")
 }
 
 model SocialRent {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,10 +70,10 @@ model Rent {
 }
 
 model SocialRentAdjustments {
-  year       String? @db.VarChar(10)
-  inflation  Float?
-  additional Float?
-  total      Float?
+  year       String @db.VarChar(10)
+  inflation  Float
+  additional Float
+  total      Float
   id         Int     @id @default(autoincrement())
 
   @@map("social_rent_adjustments")


### PR DESCRIPTION
Renamed what was `soc_rent_adjustements` to `social_rent_adjustments` (for consistency, didn't abbreviate the other one).

Also makes fields required.

I believe this is the last table that needs updating so when this merges it closes #168 