### PR TITLE
feat: remove unnecessary columns from db

### DIFF
--- a/prisma/migrations/20241218095140_tidy_schema_for_update/migration.sql
+++ b/prisma/migrations/20241218095140_tidy_schema_for_update/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "gdhi" DROP COLUMN "itl_level";
+
+-- AlterTable
+ALTER TABLE "hpi" DROP COLUMN "lad_code";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,6 @@ model BuildPrices {
 
 model GDHI {
   id       Int     @id @default(autoincrement())
-  itlLevel String  @map("itl_level") @db.VarChar(250)
   itl3     String  @db.VarChar(250)
   region   String  @db.VarChar(250)
   gdhi2020 Float  @map("gdhi_2020")
@@ -32,7 +31,6 @@ model HPI {
   id      Int     @id @default(autoincrement())
   region  String @db.VarChar(250)
   itl3    String @db.VarChar(250)
-  ladCode String @map("lad_code") @db.VarChar(250)
   hpi2000 Float  @map("hpi_2000")
 
   @@map("hpi")


### PR DESCRIPTION
The big data update migration failed because the shape of the incoming data didn't match the schema. This was because we had two unnecessary columns in the db, this PR removes them!

(This is a fixed version of #182)