### PR TITLE
feat: rename gdhi_2020 to gdhi

### DIFF
--- a/prisma/migrations/20241218105236_rename_gdhi_column/migration.sql
+++ b/prisma/migrations/20241218105236_rename_gdhi_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "gdhi" RENAME COLUMN "gdhi_2020" TO "gdhi";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model GDHI {
   itlLevel String  @map("itl_level") @db.VarChar(250)
   itl3     String  @db.VarChar(250)
   region   String  @db.VarChar(250)
-  gdhi2020 Float  @map("gdhi_2020")
+  gdhi Float  @map("gdhi")
 
   @@map("gdhi")
 }


### PR DESCRIPTION
While updating data I realised data naming pattern was inconsistent. I think we should stick to the pattern where there is _no year suffix_ when the data is for the relevant year (2022) since that is what we are doing across all other tables, and only include a year suffix when the data is from a specific, older year (eg `hpi_2000` because the social rent formula uses values from 2000). 