### PR TITLE
feat: rename gdhi column

### DIFF
--- a/app/data/gdhiRepo.test.ts
+++ b/app/data/gdhiRepo.test.ts
@@ -19,11 +19,11 @@ describe("gdhiRepo", () => {
 
     // Mock the Prisma client response
     (prisma.gDHI.findFirstOrThrow as jest.Mock).mockResolvedValueOnce({
-      gdhi2020: mockGDHI,
+      gdhi: mockGDHI,
     });
 
     // Call the function
-    const result = await gdhiRepo.getGDHI2020ByITL3(itl3);
+    const result = await gdhiRepo.getGDHIByITL3(itl3);
 
     // Assertions
     expect(result).toBe(mockGDHI);
@@ -33,7 +33,7 @@ describe("gdhiRepo", () => {
           itl3: { equals: itl3 },
         },
       },
-      select: { gdhi2020: true },
+      select: { gdhi: true },
     });
   });
 
@@ -46,8 +46,8 @@ describe("gdhiRepo", () => {
     );
 
     // Call the function and expect an error
-    await expect(gdhiRepo.getGDHI2020ByITL3(itl3)).rejects.toThrow(
-      `Data error: Unable to find gdhi2020 for itl3 ${itl3}`
+    await expect(gdhiRepo.getGDHIByITL3(itl3)).rejects.toThrow(
+      `Data error: Unable to find gdhi for itl3 ${itl3}`
     );
   });
 
@@ -60,8 +60,8 @@ describe("gdhiRepo", () => {
     );
 
     // Call the function and expect an error
-    await expect(gdhiRepo.getGDHI2020ByITL3(itl3)).rejects.toThrow(
-      `Data error: Unable to find gdhi2020 for itl3 ${itl3}`
+    await expect(gdhiRepo.getGDHIByITL3(itl3)).rejects.toThrow(
+      `Data error: Unable to find gdhi for itl3 ${itl3}`
     );
   });
 });

--- a/app/data/gdhiRepo.ts
+++ b/app/data/gdhiRepo.ts
@@ -10,7 +10,6 @@ const getGDHIByITL3 = async (itl3: string): Promise<number> => {
       },
       select: { gdhi: true },
     });
-    console.log('Result:', gdhi); 
     return gdhi;
   } catch (error) {
     throw Error(`Data error: Unable to find gdhi for itl3 ${itl3}`);

--- a/app/data/gdhiRepo.ts
+++ b/app/data/gdhiRepo.ts
@@ -1,23 +1,23 @@
 import prisma from "./db";
 
-const getGDHI2020ByITL3 = async (itl3: string): Promise<number> => {
+const getGDHIByITL3 = async (itl3: string): Promise<number> => {
   try {
-    const { gdhi2020 } = await prisma.gDHI.findFirstOrThrow({
+    const { gdhi } = await prisma.gDHI.findFirstOrThrow({
       where: {
         AND: {
           itl3: { equals: itl3 },
         },
       },
-      select: { gdhi2020: true },
+      select: { gdhi: true },
     });
-
-    return gdhi2020;
+    console.log('Result:', gdhi); 
+    return gdhi;
   } catch (error) {
-    throw Error(`Data error: Unable to find gdhi2020 for itl3 ${itl3}`);
+    throw Error(`Data error: Unable to find gdhi for itl3 ${itl3}`);
   }
 };
 
 export const gdhiRepo = {
-  getGDHI2020ByITL3,
+  getGDHIByITL3,
 };
 

--- a/app/services/gdhiService.test.ts
+++ b/app/services/gdhiService.test.ts
@@ -14,20 +14,20 @@ describe("gdhiService.getByITL3", () => {
   it("should return GDHI for a valid ITL3", async () => {
     // Arrange
     const itl3 = "ITL3-123";
-    (gdhiRepo.getGDHI2020ByITL3 as jest.Mock).mockResolvedValueOnce(mockGDHI);
+    (gdhiRepo.getGDHIByITL3 as jest.Mock).mockResolvedValueOnce(mockGDHI);
 
     // Act
     const result = await gdhiService.getByITL3(itl3);
 
     // Assert
-    expect(gdhiRepo.getGDHI2020ByITL3).toHaveBeenCalledWith(itl3);
+    expect(gdhiRepo.getGDHIByITL3).toHaveBeenCalledWith(itl3);
     expect(result).toBe(mockGDHI);
   });
 
   it("should throw an error when the repo fails", async () => {
     // Arrange
     const errorMessage = "Failed to fetch GDHI";
-    (gdhiRepo.getGDHI2020ByITL3 as jest.Mock).mockRejectedValueOnce(
+    (gdhiRepo.getGDHIByITL3 as jest.Mock).mockRejectedValueOnce(
       new Error(errorMessage)
     );
 

--- a/app/services/gdhiService.ts
+++ b/app/services/gdhiService.ts
@@ -1,7 +1,7 @@
 import { gdhiRepo } from "../data/gdhiRepo";
 
 const getByITL3 = async (itl3: string) => {
-  return await gdhiRepo.getGDHI2020ByITL3(itl3);
+  return await gdhiRepo.getGDHIByITL3(itl3);
 };
 
 export const gdhiService = {

--- a/prisma/migrations/20241218105236_rename_gdhi_column/migration.sql
+++ b/prisma/migrations/20241218105236_rename_gdhi_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "gdhi" RENAME COLUMN "gdhi_2020" TO "gdhi";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model GDHI {
   itlLevel String  @map("itl_level") @db.VarChar(250)
   itl3     String  @db.VarChar(250)
   region   String  @db.VarChar(250)
-  gdhi2020 Float  @map("gdhi_2020")
+  gdhi Float  @map("gdhi")
 
   @@map("gdhi")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model GDHI {
   itlLevel String  @map("itl_level") @db.VarChar(250)
   itl3     String  @db.VarChar(250)
   region   String  @db.VarChar(250)
-  gdhi Float  @map("gdhi")
+  gdhi Float 
 
   @@map("gdhi")
 }


### PR DESCRIPTION
While updating data I realised data naming pattern was inconsistent. I think we should stick to the pattern where there is no year suffix when the data is for the relevant year (2022) since that is what we are doing across all other tables, and only include a year suffix when the data is from a specific, older year (eg hpi_2000 because the social rent formula uses values from 2000).

Fixed (updated repo & renamed) version of #184