### PR TITLE
feat: update column name to hpi1999

### DIFF
--- a/app/data/hpiRepo.test.ts
+++ b/app/data/hpiRepo.test.ts
@@ -1,5 +1,5 @@
 // __tests__/hpiRepo.test.ts
-import { hpi2000Repo } from "./hpiRepo"; // Adjust the import according to your file structure
+import { hpi1999Repo } from "./hpiRepo"; // Adjust the import according to your file structure
 import prisma from "./db"; // Your Prisma setup file
 
 jest.mock("./db", () => ({
@@ -8,7 +8,7 @@ jest.mock("./db", () => ({
   },
 }));
 
-describe("hpi2000Repo", () => {
+describe("hpi1999Repo", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -19,11 +19,11 @@ describe("hpi2000Repo", () => {
 
     // Mock the Prisma client response
     (prisma.hPI.aggregate as jest.Mock).mockResolvedValueOnce({
-      _avg: { hpi2000: mockAverageHpi },
+      _avg: { hpi1999: mockAverageHpi },
     });
 
     // Call the function
-    const result = await hpi2000Repo.getHPIByITL3(itl3);
+    const result = await hpi1999Repo.getHPIByITL3(itl3);
 
     // Assertions
     expect(result).toBe(mockAverageHpi);
@@ -34,7 +34,7 @@ describe("hpi2000Repo", () => {
         },
       },
       _avg: {
-        hpi2000: true,
+        hpi1999: true,
       },
     });
   });
@@ -44,12 +44,12 @@ describe("hpi2000Repo", () => {
 
     // Mock rejection of the Prisma client
     (prisma.hPI.aggregate as jest.Mock).mockResolvedValueOnce({
-      _avg: { hpi2000: null },
+      _avg: { hpi1999: null },
     });
 
     // Call the function and expect an error
-    await expect(hpi2000Repo.getHPIByITL3(itl3)).rejects.toThrow(
-      `Data error: Unable to find hpi2000 for itl3 ${itl3}`
+    await expect(hpi1999Repo.getHPIByITL3(itl3)).rejects.toThrow(
+      `Data error: Unable to find hpi1999 for itl3 ${itl3}`
     );
   });
 
@@ -62,8 +62,8 @@ describe("hpi2000Repo", () => {
     );
 
     // Call the function and expect an error
-    await expect(hpi2000Repo.getHPIByITL3(itl3)).rejects.toThrow(
-      `Data error: Unable to find hpi2000 for itl3 ${itl3}`
+    await expect(hpi1999Repo.getHPIByITL3(itl3)).rejects.toThrow(
+      `Data error: Unable to find hpi1999 for itl3 ${itl3}`
     );
   });
 });

--- a/app/data/hpiRepo.test.ts
+++ b/app/data/hpiRepo.test.ts
@@ -1,6 +1,5 @@
-// __tests__/hpiRepo.test.ts
-import { hpi1999Repo } from "./hpiRepo"; // Adjust the import according to your file structure
-import prisma from "./db"; // Your Prisma setup file
+import { hpi1999Repo } from "./hpiRepo";
+import prisma from "./db";
 
 jest.mock("./db", () => ({
   hPI: {

--- a/app/data/hpiRepo.ts
+++ b/app/data/hpiRepo.ts
@@ -3,7 +3,7 @@ import prisma from "./db";
 const getHPIByITL3 = async (itl3: string): Promise<number> => {
   try {
     const {
-      _avg: { hpi2000: averageHpi },
+      _avg: { hpi1999: averageHpi },
     } = await prisma.hPI.aggregate({
       // TODO: Should there be a relationship on ITL3?
       where: {
@@ -12,21 +12,21 @@ const getHPIByITL3 = async (itl3: string): Promise<number> => {
         },
       },
       _avg: {
-        hpi2000: true,
+        hpi1999: true,
       },
     });
 
     // Check if the average HPI is null and throw an error
     if (averageHpi === null) {
-      throw new Error(`Data error: Unable to find hpi2000 for itl3 ${itl3}`);
+      throw new Error(`Data error: Unable to find hpi1999 for itl3 ${itl3}`);
     }
 
     return averageHpi;
   } catch (error) {
-    throw Error(`Data error: Unable to find hpi2000 for itl3 ${itl3}`);
+    throw Error(`Data error: Unable to find hpi1999 for itl3 ${itl3}`);
   }
 };
 
-export const hpi2000Repo = {
+export const hpi1999Repo = {
   getHPIByITL3,
 };

--- a/app/services/hpiService.test.ts
+++ b/app/services/hpiService.test.ts
@@ -1,6 +1,6 @@
 // __tests__/hpiService.test.ts
 import { hpiService } from "../services/hpiService"; // Adjust the path according to your structure
-import { hpi2000Repo } from "../data/hpiRepo"; // Adjust the path according to your structure
+import { hpi1999Repo } from "../data/hpiRepo"; // Adjust the path according to your structure
 
 jest.mock("../data/hpiRepo");
 
@@ -14,20 +14,20 @@ describe("hpiService.getByITL3", () => {
   it("should return HPI for a valid ITL3", async () => {
     // Arrange
     const itl3 = "ITL3-123";
-    (hpi2000Repo.getHPIByITL3 as jest.Mock).mockResolvedValueOnce(mockHPI);
+    (hpi1999Repo.getHPIByITL3 as jest.Mock).mockResolvedValueOnce(mockHPI);
 
     // Act
     const result = await hpiService.getByITL3(itl3);
 
     // Assert
-    expect(hpi2000Repo.getHPIByITL3).toHaveBeenCalledWith(itl3);
+    expect(hpi1999Repo.getHPIByITL3).toHaveBeenCalledWith(itl3);
     expect(result).toBe(mockHPI);
   });
 
   it("should throw an error when the repo fails", async () => {
     // Arrange
     const errorMessage = "Failed to fetch HPI";
-    (hpi2000Repo.getHPIByITL3 as jest.Mock).mockRejectedValueOnce(
+    (hpi1999Repo.getHPIByITL3 as jest.Mock).mockRejectedValueOnce(
       new Error(errorMessage)
     );
 

--- a/app/services/hpiService.ts
+++ b/app/services/hpiService.ts
@@ -1,7 +1,7 @@
-import { hpi2000Repo } from "../data/hpiRepo";
+import { hpi1999Repo } from "../data/hpiRepo";
 
 const getByITL3 = async (itl3: string) => {
-  return await hpi2000Repo.getHPIByITL3(itl3);
+  return await hpi1999Repo.getHPIByITL3(itl3);
 };
 
 export const hpiService = {

--- a/prisma/migrations/20241218155911_update_hpi_year/migration.sql
+++ b/prisma/migrations/20241218155911_update_hpi_year/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "hpi" RENAME COLUMN "hpi_2000" TO "hpi_1999";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,7 @@ model HPI {
   id      Int     @id @default(autoincrement())
   region  String @db.VarChar(250)
   itl3    String @db.VarChar(250)
-  hpi2000 Float  @map("hpi_2000")
+  hpi1999 Float  @map("hpi_1999")
 
   @@map("hpi")
 }


### PR DESCRIPTION
The data update changes HPI values from 2000 to 1999, the correct input for social rent calculations.

This migration makes that change in the schema and relevant repo / service. 