### PR TITLE
feat: rename district column to region

### DIFF
--- a/prisma/migrations/20241218161553_rename_district_to_region/migration.sql
+++ b/prisma/migrations/20241218161553_rename_district_to_region/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "itl_lookup" RENAME COLUMN "district" TO "region";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,7 +38,7 @@ model HPI {
 
 model ItlLookup {
   postcode String
-  district String
+  region String
   areacode String
   itl3     String
   id       Int     @id @default(autoincrement())


### PR DESCRIPTION
I'm in the process of making sure that all outputs of [`fairhold-data`](https://github.com/theopensystemslab/fairhold-data) match the schema. 

This migration updates the column name `district` to `region` in the `itl_lookup` table (we use `region` in other tables). 