### PR TITLE
feat: remove `transaction_identifier` column from `prices_paid`

### DIFF
--- a/prisma/migrations/20241218162252_remove_transaction_id_column/migration.sql
+++ b/prisma/migrations/20241218162252_remove_transaction_id_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "prices_paid" DROP COLUMN "transaction_identifier";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,6 @@ model ItlLookup {
 
 model PricesPaid {
   id                    Int     @id @default(autoincrement())
-  transactionIdentifier String @map("transaction_identifier") @db.VarChar(250)
   price                 Float
   postcode              String @db.VarChar(250)
   propertyType          String @map("property_type") @db.VarChar(250)


### PR DESCRIPTION
This migration removes an unused column from the schema that wasn't included in the `fairhold-data` output. 