### PR TITLE
chore: tsconfig linting

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,8 +22,11 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "target": "ES2017"
   },
   "include": [
     "next-env.d.ts",
@@ -28,5 +35,7 @@
     ".next/types/**/*.ts",
     "app/api/getData.jsx"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
~~Not sure if anyone else had this lingering change locally (I believe it happened after a dependabt eslint update) but `tsconfi.json` was updated and I didn't want to lump that commit into another PR. Here's a separate PR for the minor changes!~~

Ah-ha, I think we have a conflict between what eslint wants the `tsconfig.json` to look lkike and what `dev:db` wants it to look like. Let's discuss later! 