### PR TITLE
fix: Mortgage class & tests

### DIFF
--- a/app/models/Mortgage.test.ts
+++ b/app/models/Mortgage.test.ts
@@ -7,8 +7,6 @@ const mortgage = new Mortgage({
   initialDeposit: 0.1,
 });
 
-console.log({mortgage})
-
 it("can be instantiated", () => {
   expect(mortgage).toBeDefined();
 });
@@ -27,7 +25,6 @@ it("correctly calculates the total mortgage cost", () => {
 
 it("correctly calculates the split between interest and principal", () => {
   const breakdown = mortgage.yearlyPaymentBreakdown;
-  console.log({breakdown})
   
   expect(breakdown[0].yearlyPayment).toBeCloseTo(16313.56); // Higher figure because it includes the deposit
   expect(breakdown[0].cumulativePaid).toBeCloseTo(16313.56);

--- a/app/models/Mortgage.test.ts
+++ b/app/models/Mortgage.test.ts
@@ -1,32 +1,40 @@
 import { Mortgage } from "./Mortgage";
 
+const mortgage = new Mortgage({
+  propertyValue: 100000,
+  interestRate: 0.05,
+  mortgageTerm: 25,
+  initialDeposit: 0.1,
+});
+
+console.log({mortgage})
+
 it("can be instantiated", () => {
-  const mortgage = new Mortgage({
-    propertyValue: 100,
-    interestRate: 0.05,
-    mortgageTerm: 25,
-    initialDeposit: 0.1,
-  });
   expect(mortgage).toBeDefined();
 });
 
 it("correctly calculates the amount of the mortgage ", () => {
-  const mortgage = new Mortgage({
-    propertyValue: 100,
-    interestRate: 0.05,
-    mortgageTerm: 25,
-    initialDeposit: 0.1,
-  });
-
-  expect(mortgage.principal).toBeCloseTo(90);
+  expect(mortgage.principal).toBeCloseTo(90000);
 });
 
 it("correctly calculates the amount of monthly payment ", () => {
-  const mortgage = new Mortgage({
-    propertyValue: 100,
-    interestRate: 0.05,
-    mortgageTerm: 25,
-    initialDeposit: 0.1,
-  });
-  expect(mortgage.monthlyPayment).toBeCloseTo(0.53);
+  expect(mortgage.monthlyPayment).toBeCloseTo(526.13);
 });
+
+it("correctly calculates the total mortgage cost", () => {
+  expect(mortgage.totalMortgageCost).toBeCloseTo(157839.31);
+})
+
+it("correctly calculates the split between interest and principal", () => {
+  const breakdown = mortgage.yearlyPaymentBreakdown;
+  console.log({breakdown})
+  
+  expect(breakdown[0].yearlyPayment).toBeCloseTo(16313.56); // Higher figure because it includes the deposit
+  expect(breakdown[0].cumulativePaid).toBeCloseTo(16313.56);
+  expect(breakdown[0].remainingBalance).toBeCloseTo(88144.3);
+
+  expect(breakdown.length).toBe(25);})
+
+it("correctly calculates the total interest paid", () => {
+  expect(mortgage.totalInterest).toBeCloseTo(67839.31)
+})

--- a/app/models/Mortgage.test.ts
+++ b/app/models/Mortgage.test.ts
@@ -30,7 +30,8 @@ it("correctly calculates the split between interest and principal", () => {
   expect(breakdown[0].cumulativePaid).toBeCloseTo(16313.56);
   expect(breakdown[0].remainingBalance).toBeCloseTo(88144.3);
 
-  expect(breakdown.length).toBe(25);})
+  expect(breakdown.length).toBe(25);
+})
 
 it("correctly calculates the total interest paid", () => {
   expect(mortgage.totalInterest).toBeCloseTo(67839.31)


### PR DESCRIPTION
This PR rewrites `calculateYearlyPaymentBreakdown()` and adds tests for the `Mortgage` class

While writing more class tests in another branch, I realised that the `Mortgage` method `calculateYearlyPaymentBreakdown()` was incorrectly calculating interest paid, principal paid, etc.