### PR TITLE
feat: Create `prices_paid_summary` table

### DIFF
--- a/prisma/migrations/20250107110255_add_prices_paid_summary_table/migration.sql
+++ b/prisma/migrations/20250107110255_add_prices_paid_summary_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "prices_paid_summary" (
+    "id" SERIAL NOT NULL,
+    "postcode" TEXT NOT NULL,
+    "property_type" VARCHAR(250) NOT NULL,
+    "granularity_level" VARCHAR(250) NOT NULL,
+    "average_price" DOUBLE PRECISION NOT NULL,
+    "transaction_count" INTEGER NOT NULL,
+
+    CONSTRAINT "prices_paid_summary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "prices_paid_summary_postcode_property_type_idx" ON "prices_paid_summary"("postcode", "property_type");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "prices_paid_summary_postcode_property_type_granularity_leve_key" ON "prices_paid_summary"("postcode", "property_type", "granularity_level");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,20 @@ model PricesPaid {
   @@map("prices_paid")
 }
 
+model PricesPaidSummary {
+  id               Int   @id @default(autoincrement())
+  postcode         String
+  propertyType     String @map("property_type") @db.VarChar(250)
+  granularityLevel String @map("granularity_level") @db.VarChar(250)
+  averagePrice     Float @map("average_price")
+  transactionCount Int @map("transaction_count")
+
+  @@unique([postcode, propertyType, granularityLevel])
+  @@index([postcode, propertyType])
+
+  @@map("prices_paid_summary")
+}
+
 model Rent {
   id              Int     @id @default(autoincrement())
   itl3            String @db.VarChar(250)


### PR DESCRIPTION
## What does this PR do?
 - Adds a new `PricesPaidSummary` model - this will hold pre-calculated values emulating the business logic used in `pricesPaidRepo.rs`
 - The data will be populated via this script once merged to production https://github.com/theopensystemslab/fairhold-data/pull/1
 - The model is implemented here - https://github.com/theopensystemslab/fairhold-dashboard/pull/241
   - This needs to be a separate, follow-on, PR as it will rely on the table being already populated