### PR TITLE
chore: Enable `strictUndefinedChecks` flag on Prisma

### DIFF
--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -50,9 +50,11 @@ const CalculatorInput = () => {
         ? (Number(urlMaintenancePercentage) as 0.015 | 0.02 | 0.0375) // Type assertion
         : 0.015,
       housePostcode: urlPostcode || "",
-      houseSize: Number(urlHouseSize) || undefined,
-      houseAge: Number(urlHouseAge) || undefined,
-      houseBedrooms: Number(urlHouseBedrooms) || undefined,
+      // Apply defaults if provided
+      // Type-safe to account for exactOptionalPropertyTypes propert in tsconfig.json
+      ...(urlHouseSize && { houseSize: Number(urlHouseSize )}),
+      ...(urlHouseAge && { houseAge: Number(urlHouseAge )}),
+      ...(urlHouseBedrooms && { houseBedrooms: Number(urlHouseBedrooms )}),
     },
   });
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["strictUndefinedChecks"]
 }
 
 datasource db {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "exactOptionalPropertyTypes": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/fairhold-dashboard/pull/229 - this should have helped us avoid this issue in the first instance.

Docs: https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/null-and-undefined