### PR TITLE
feat: remove unnecessary bed weight calcs

### DIFF
--- a/app/models/Property.test.ts
+++ b/app/models/Property.test.ts
@@ -25,10 +25,6 @@ describe('Property', () => {
   it("correctly calculates the newBuildPrice", () => {
     expect(property.newBuildPrice).toBeCloseTo(186560);
   });
-
-  it("correctly calculates the bedWeightedAveragePrice", () => {
-    expect(property.bedWeightedAveragePrice).toBeCloseTo(219135);
-  });
   
   it("correctly calculates the landPrice", () => {
     expect(property.landPrice).toBeCloseTo(32575);

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -1,4 +1,4 @@
-import { BED_WEIGHTS_AND_CAPS, MAINTENANCE_LEVELS, HOUSE_BREAKDOWN_PERCENTAGES } from "./constants";
+import { MAINTENANCE_LEVELS, HOUSE_BREAKDOWN_PERCENTAGES } from "./constants";
 import { houseBreakdownType } from "./constants";
 /**
  * Number of decimal places to use when rounding numerical values
@@ -53,16 +53,14 @@ export class Property {
    */
   newBuildPrice: number;
   /**
-   * Price of the house according to the depreciation regression
+   * Since Fairhold treats homes as consumer durables, we need to depreciate homes over time.
+   * The calculations use our custom depreciation method
    */
   depreciatedBuildPrice: number;
-  /**
-   * Price of the house weighted by the number of bedrooms
-   */
-  bedWeightedAveragePrice: number;
   landPrice: number;
   /**
-   * Ratio of the land price to the total price
+   * This shows the % of the market price that land accounts for (`land value / market value`)
+   * Used to break other rental tenure costs into land vs house
    */
   landToTotalRatio: number;
 
@@ -80,9 +78,8 @@ export class Property {
     // Computed properties, order is significant
     this.newBuildPrice = this.calculateNewBuildPrice();
     this.depreciatedBuildPrice = this.calculateDepreciatedBuildPrice();
-    this.bedWeightedAveragePrice = this.calculateBedWeightedAveragePrice();
     this.landPrice = this.averageMarketPrice - this.newBuildPrice;
-    this.landToTotalRatio = this.landPrice / this.bedWeightedAveragePrice;
+    this.landToTotalRatio = this.landPrice / this.averageMarketPrice;
   }
 
   private calculateNewBuildPrice() {
@@ -143,29 +140,5 @@ export class Property {
       maintenanceAddition,
       depreciatedComponentValue
     };
-  }
-
-  private calculateBedWeightedAveragePrice() {
-    const bedWeights = BED_WEIGHTS_AND_CAPS.weight;
-    let bedWeight;
-
-    if (
-      this.numberOfBedrooms <
-      BED_WEIGHTS_AND_CAPS.numberOfBedrooms[
-        BED_WEIGHTS_AND_CAPS.numberOfBedrooms.length - 1
-      ]
-    ) {
-      // assign the weight based on the number of beds
-      bedWeight = BED_WEIGHTS_AND_CAPS.weight[this.numberOfBedrooms];
-    } else {
-      // assign the last value if out of scale
-      bedWeight = BED_WEIGHTS_AND_CAPS.weight[bedWeights.length - 1];
-    }
-
-    bedWeight = parseFloat(
-      (bedWeight * this.averageMarketPrice).toFixed(PRECISION)
-    );
-
-    return bedWeight;
   }
 }


### PR DESCRIPTION
I'm not 100% sure about this one so thoughts appreciated! 

While rewriting class tests, I realised the `calculateBedWeightedAveragePrice()` method and `bedWeightedAveragePrice` property were relics of an earlier calc approach. I think removing it is the right way to go. 

# Why was it used? (or why should it be used?)
- The social rent calculations weight rent levels according to # of bedrooms
- Since we had a table of # of bedrooms and price weighting factors, I tried using it for the market prices too (this was back in team of 1 days and it was a relatively uninformed decision that I just wanted to try out and not necessarily keep)
- The price paid dataset distinguishes between house type, but not size (whether in m2 or bedrooms) so this was a potential way of making price estimates reflective of size

# Why shouldn't we use it?
- Its application was inconsistent 
    - The other option here is to apply it everywhere. For example, the weighted figure would be used in the graphs and other calculations too: the weighted market price should be used, and not `averageMarketPrice`
- Extending the social rent weights to market prices did not feel particularly scientific--what do others think? 