### PR TITLE
feat: Add background assumptions button

### DIFF
--- a/app/components/ui/BackgroundAssumptions.tsx
+++ b/app/components/ui/BackgroundAssumptions.tsx
@@ -1,0 +1,8 @@
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
+
+export const BackgroundAssumptions: React.FC = () =>  (
+  <a href="#" className="flex text-sm items-center">
+    <QuestionMarkCircledIcon className="mr-2"/>
+    Explore other background assumptions we have made in this calculator
+  </a>
+)

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { APIError } from "@/app/lib/exceptions";
+import { BackgroundAssumptions } from "./BackgroundAssumptions";
 
 type View = "form" | "loading" | "dashboard";
 
@@ -343,11 +344,13 @@ const CalculatorInput = () => {
               </div>
             </div>
 
-            <Button type="submit" className="calculate-button-style">
+            <Button type="submit" className="calculate-button-style px-20">
               Calculate
             </Button>
           </form>
         </Form>
+        <hr className="my-8 text-gray-300"/>
+        <BackgroundAssumptions/>
       </div>
     );
   }


### PR DESCRIPTION
![Screenshot 2025-01-09 at 17 09 33](https://github.com/user-attachments/assets/a9d10e1e-78cb-493d-8dbb-debf8dbe32dc)

This PR adds a link as seen in Miro - the link is currently empty.