### PR TITLE
feat: calculate house depreciation for all maintenance levels

### DIFF
--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -53,7 +53,7 @@ const CalculatorInput = () => {
           : "D", // Default value for house type
       maintenancePercentage: (MAINTENANCE_LEVELS as readonly number[]).includes(Number(urlMaintenancePercentage))
         ? Number(urlMaintenancePercentage) as z.infer<typeof maintenancePercentageSchema> 
-        : MAINTENANCE_LEVELS[0],
+        : MAINTENANCE_LEVELS[1],
       housePostcode: urlPostcode || "",
       // Apply defaults if provided
       // Type-safe to account for exactOptionalPropertyTypes propert in tsconfig.json
@@ -280,7 +280,7 @@ const CalculatorInput = () => {
                     >
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS[0].toString()}
+                          value={MAINTENANCE_LEVELS[1].toString()}
                           id="radio-option-low"
                           className="radio-button-style"
                         />
@@ -288,12 +288,12 @@ const CalculatorInput = () => {
                           htmlFor="radio-option-low"
                           className="radio-label-style"
                         >
-                          Low ({MAINTENANCE_LEVELS[0] * 100}%)
+                          Low ({MAINTENANCE_LEVELS[1] * 100}%)
                         </Label>
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS[1].toString()}
+                          value={MAINTENANCE_LEVELS[2].toString()}
                           id="radio-option-medium"
                           className="radio-button-style"
                         />
@@ -301,12 +301,12 @@ const CalculatorInput = () => {
                           htmlFor="radio-option-medium"
                           className="radio-label-style"
                         >
-                          Medium ({MAINTENANCE_LEVELS[1] * 100}%)
+                          Medium ({MAINTENANCE_LEVELS[2] * 100}%)
                         </Label>
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS[2].toString()}
+                          value={MAINTENANCE_LEVELS[3].toString()}
                           id="radio-option-high"
                           className="radio-button-style"
                         />
@@ -314,7 +314,7 @@ const CalculatorInput = () => {
                           htmlFor="radio-option-high"
                           className="radio-label-style"
                         >
-                          High ({MAINTENANCE_LEVELS[2] * 100}%)
+                          High ({MAINTENANCE_LEVELS[3] * 100}%)
                         </Label>
                       </div>
                     </RadioGroup>

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -51,9 +51,9 @@ const CalculatorInput = () => {
         urlHouseType === "S"
           ? urlHouseType
           : "D", // Default value for house type
-      maintenancePercentage: (MAINTENANCE_LEVELS as readonly number[]).includes(Number(urlMaintenancePercentage))
-        ? Number(urlMaintenancePercentage) as z.infer<typeof maintenancePercentageSchema> 
-        : MAINTENANCE_LEVELS[1],
+        maintenancePercentage: urlMaintenancePercentage && (MAINTENANCE_LEVELS as readonly number[]).includes(Number(urlMaintenancePercentage))
+          ? Number(urlMaintenancePercentage) as z.infer<typeof maintenancePercentageSchema>
+          : MAINTENANCE_LEVELS[1],
       housePostcode: urlPostcode || "",
       // Apply defaults if provided
       // Type-safe to account for exactOptionalPropertyTypes propert in tsconfig.json

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -47,10 +47,10 @@ export class Household {
     this.property = params.property;
     this.forecastParameters = params.forecastParameters;
     this.incomeYearly = HEADS_PER_HOUSEHOLD * params.incomePerPersonYearly;
-    this.tenure = this.calculateTenures(params);
-    this.lifetime = this.calculateLifetime(params);
     this.gasBillExistingBuildYearly = this.calculateGasBillExistingBuild(params);
     this.gasBillNewBuildOrRetrofitYearly = this.calculateGasBillNewBuildOrRetrofit(params);
+    this.tenure = this.calculateTenures(params);
+    this.lifetime = this.calculateLifetime(params);
   }
 
   private calculateTenures({

--- a/app/models/Lifetime.test.ts
+++ b/app/models/Lifetime.test.ts
@@ -28,7 +28,11 @@ describe("resale values", () => {
         lifetime = createTestLifetime({
             property: createTestProperty({ age: 0 })
         });
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueNoMaintenance).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueLowMaintenance).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueMediumMaintenance).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueHighMaintenance).toBe(186560);
+
     });
     it("correctly calculates for a 10-year old house", () => {    // Test 10-year-old house
         lifetime = createTestLifetime({
@@ -45,15 +49,33 @@ describe("resale values", () => {
             size: 88 
         })           
         const depreciatedHouseY10 = houseY10.calculateDepreciatedBuildPrice()
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue).toBe(depreciatedHouseY10);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueLowMaintenance).toBe(depreciatedHouseY10);
     });
     it("depreciates the house over time", () => {
         // Test value changes over time
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue).toBeGreaterThan(
-            lifetime.lifetimeData[10].depreciatedHouseResaleValue);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueNoMaintenance).toBeGreaterThan(
+            lifetime.lifetimeData[10].depreciatedHouseResaleValueNoMaintenance);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueLowMaintenance).toBeGreaterThan(
+            lifetime.lifetimeData[10].depreciatedHouseResaleValueLowMaintenance);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueMediumMaintenance).toBeGreaterThan(
+            lifetime.lifetimeData[10].depreciatedHouseResaleValueMediumMaintenance);
+        // depreciatedHouseResaleValueHighMaintenance isn't tested here because the addition of a major work causes price to rise
     })
 });
 
+it("correctly calculates depreciated house value for all maintenance levels", () => {
+    expect(lifetime.lifetimeData[3].depreciatedHouseResaleValueNoMaintenance).toBeCloseTo(173636.99)
+    expect(lifetime.lifetimeData[20].depreciatedHouseResaleValueLowMaintenance).toBeCloseTo(157202.92)
+    expect(lifetime.lifetimeData[27].depreciatedHouseResaleValueMediumMaintenance).toBeCloseTo(168197.27)
+    expect(lifetime.lifetimeData[39].depreciatedHouseResaleValueHighMaintenance).toBeCloseTo(203777.25) 
+
+    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValueNoMaintenance).toBeLessThan(
+        lifetime.lifetimeData[5].depreciatedHouseResaleValueLowMaintenance);
+    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValueLowMaintenance).toBeLessThan(
+        lifetime.lifetimeData[5].depreciatedHouseResaleValueMediumMaintenance);
+    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValueMediumMaintenance).toBeLessThan(
+        lifetime.lifetimeData[5].depreciatedHouseResaleValueHighMaintenance);
+})
 
 it("correctly ages the house", () => {
     lifetime = createTestLifetime({

--- a/app/models/Property.test.ts
+++ b/app/models/Property.test.ts
@@ -46,7 +46,7 @@ describe('Property', () => {
         'foundations',
         property.newBuildPrice,
         property.age,
-        MAINTENANCE_LEVELS[0]
+        MAINTENANCE_LEVELS[1]
       );
 
       expect(result.newComponentValue).toBe(39177.6);
@@ -58,7 +58,7 @@ describe('Property', () => {
         'internalLinings',
         property.newBuildPrice,
         property.age,
-        MAINTENANCE_LEVELS[0]
+        MAINTENANCE_LEVELS[1]
       );
 
       expect(result.depreciationFactor).toBe(.968);
@@ -69,7 +69,7 @@ describe('Property', () => {
         'electricalAppliances',
         property.newBuildPrice,
         property.age,
-        MAINTENANCE_LEVELS[0]
+        MAINTENANCE_LEVELS[1]
       );
 
       expect(result.maintenanceAddition).toBe(207.0816);
@@ -80,7 +80,7 @@ describe('Property', () => {
         'ventilationServices',
         property.newBuildPrice,
         property.age,
-        MAINTENANCE_LEVELS[0]
+        MAINTENANCE_LEVELS[1]
       );
 
       expect(result.depreciatedComponentValue).toBeCloseTo(7171.739);
@@ -91,7 +91,7 @@ describe('Property', () => {
         'ventilationServices',
         property.newBuildPrice,
         100, // High age to test possible negative values
-        MAINTENANCE_LEVELS[0]
+        MAINTENANCE_LEVELS[1]
       );
 
       expect(result.depreciatedComponentValue).toBeGreaterThanOrEqual(0);

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -98,7 +98,7 @@ export class Property {
       key, 
       this.newBuildPrice, 
       this.age, 
-      MAINTENANCE_LEVELS[0]
+      MAINTENANCE_LEVELS[1]
     );
 
     depreciatedBuildPrice += result.depreciatedComponentValue;

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -98,7 +98,7 @@ export class Property {
       key, 
       this.newBuildPrice, 
       this.age, 
-      MAINTENANCE_LEVELS[1]
+      this.maintenancePercentage
     );
 
     depreciatedBuildPrice += result.depreciatedComponentValue;

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -41,7 +41,7 @@ export const NATIONAL_AVERAGES: NationalAverage = {
  * Maintenance levels are percentages (represented as decimals),
  * figures from our own model
  */
-export const MAINTENANCE_LEVELS = [0.015, 0.019, 0.025] as const;
+export const MAINTENANCE_LEVELS = [0, 0.015, 0.019, 0.025] as const;
 
 /** Type for storing component values and depreciation*/
 export type componentBreakdownType = {


### PR DESCRIPTION
# What
- Adds 'none' option to `MAINTENANCE_LEVELS` constant
- Adds new properties to the `Lifetime` class to calculate how `maintenanceCost` changes over time and thus `depreicatedHouseResaleValue` does (for all maintenance levels: none, low, medium and high
- Creates tests for the new calcs
- I think my last PR managed to remove a default value for the maintenance selector, so fixes that

# Why
So that we can graph them
![image](https://github.com/user-attachments/assets/b2682424-242e-4d48-ba6c-cf3d28467e31)

# Questions
Does this make the `Lifetime` class a bit too messy? Should we instead just use `maintenanceCost` and `depreciatedHouseResaleValue` properties that store objects, instead of multiple properties (eg `maintenanceCostLow`, `maintenanceCostMedium` and `maintenanceCostHigh`? 

Closes #240 and #239