### PR TITLE
feat: compare resale values over time chart

### DIFF
--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -1,20 +1,43 @@
+import { useState } from "react";
 import GraphCard from "../../ui/GraphCard";
-import ResaleValuesWrapper from "../../graphs/ResaleValuesWrapper";
+import ResaleValueWrapper from "../../graphs/ResaleValueWrapper";
 import { Drawer } from "../../ui/Drawer";
 import { Household } from "@/app/models/Household";
+import TenureSelector from "../../ui/TenureSelector";
 
 interface DashboardProps {
   data: Household;
 }
 
-export const ResaleValues: React.FC<DashboardProps> = ({ data }) => {
+export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
+  const [selectedTenure, setSelectedTenure] = useState<'landPurchase' | 'landRent'>('landPurchase');
+
   return (
     <GraphCard
       title="How much could I sell it for?"
       subtitle="Estimated sale price at any time"
     >
       <div className="flex flex-col h-full w-3/4 justify-between">
-        <ResaleValuesWrapper household={data} />
+        <div className="flex gap-2 mb-4">
+          <TenureSelector 
+            isSelected={selectedTenure === 'landPurchase'}
+            onClick={() => setSelectedTenure('landPurchase')}
+          >
+            Fairhold Land Purchase
+          </TenureSelector>
+          <TenureSelector 
+            isSelected={selectedTenure === 'landRent'}
+            onClick={() => setSelectedTenure('landRent')}
+          >
+            Fairhold Land Rent
+          </TenureSelector>
+        </div>
+        
+        <ResaleValueWrapper 
+          household={data}
+          tenure={selectedTenure}
+        />
+        
         <Drawer
           buttonTitle="Find out more about how we estimated these"
           title="How we estimated these figures"

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -1,0 +1,26 @@
+import GraphCard from "../../ui/GraphCard";
+import ResaleValuesWrapper from "../../graphs/ResaleValuesWrapper";
+import { Drawer } from "../../ui/Drawer";
+import { Household } from "@/app/models/Household";
+
+interface DashboardProps {
+  data: Household;
+}
+
+export const ResaleValues: React.FC<DashboardProps> = ({ data }) => {
+  return (
+    <GraphCard
+      title="How much could I sell it for?"
+      subtitle="Estimated sale price at any time"
+    >
+      <div className="flex flex-col h-full w-3/4 justify-between">
+        <ResaleValuesWrapper household={data} />
+        <Drawer
+          buttonTitle="Find out more about how we estimated these"
+          title="How we estimated these figures"
+          description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Illum minus eligendi fugit nulla officia dolor inventore nemo ex quo quia, laborum qui ratione aperiam, pariatur explicabo ipsum culpa impedit ad!"
+        />
+      </div>
+    </GraphCard>
+  );
+};

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Label, Legend } from 'recharts';
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatValue } from "@/app/lib/format";
+
+const chartConfig = {
+  noMaintenance: {
+    label: "No Maintenance",
+    color: "rgb(var(--no-maintenance-color-rgb))", // TODO: UPDATE COLOURS
+  },
+  lowMaintenance: {
+    label: "Low Maintenance",
+    color: "rgb(var(--low-maintenance-color-rgb))",
+  },
+  mediumMaintenance: {
+    label: "Medium Maintenance",
+    color: "rgb(var(--medium-maintenance-color-rgb))",
+  },
+  highMaintenance: {
+    label: "High Maintenance",
+    color: "rgb(var(--high-maintenance-color-rgb))",
+  },
+} satisfies ChartConfig;
+
+export interface DataPoint {
+  year: number;
+  noMaintenance: number;
+  lowMaintenance: number;
+  mediumMaintenance: number;
+  highMaintenance: number;
+}
+
+interface ResaleValueLineChartProps {
+  data: DataPoint[];
+  selectedMaintenance: 'noMaintenance' | 'lowMaintenance' | 'mediumMaintenance' | 'highMaintenance';
+}
+
+const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
+  data,
+  selectedMaintenance
+}) => {
+  const renderLine = (dataKey: keyof Omit<DataPoint, 'year'>) => (
+    <Line
+      type="monotone"
+      dataKey={dataKey}
+      stroke={`var(--color-${dataKey})`}
+      strokeWidth={2}
+      strokeDasharray={dataKey === selectedMaintenance ? "0" : "5 5"}
+      dot={false}
+    />
+  );
+
+  return (
+    <Card>
+      <CardHeader></CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig}>
+          <LineChart
+            data={data}
+            margin={{ top: 20, right: 30, left: 20, bottom: 50 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis 
+              dataKey="year"
+              tickLine={false}
+            >
+              <Label
+                value="Years"
+                position="bottom"
+                offset={20}
+                className="label-class"
+              />
+            </XAxis>
+            <YAxis
+              tickFormatter={formatValue}
+              tickLine={false}
+            >
+              <Label
+                value="Resale Value (£)"
+                angle={-90}
+                position="left"
+                offset={0}
+                className="label-class"
+              />
+            </YAxis>
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <Legend />
+            {renderLine('noMaintenance')}
+            {renderLine('lowMaintenance')}
+            {renderLine('mediumMaintenance')}
+            {renderLine('highMaintenance')}
+          </LineChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ResaleValueLineChart;

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -12,19 +12,19 @@ import { formatValue } from "@/app/lib/format";
 const chartConfig = {
   noMaintenance: {
     label: "No Maintenance",
-    color: "rgb(var(--no-maintenance-color-rgb))", // TODO: UPDATE COLOURS
+    color: "rgb(var(--fairhold-land-color-rgb))", 
   },
   lowMaintenance: {
     label: "Low Maintenance",
-    color: "rgb(var(--low-maintenance-color-rgb))",
+    color: "rgb(var(--fairhold-land-color-rgb))",
   },
   mediumMaintenance: {
     label: "Medium Maintenance",
-    color: "rgb(var(--medium-maintenance-color-rgb))",
+    color: "rgb(var(--fairhold-land-color-rgb))",
   },
   highMaintenance: {
     label: "High Maintenance",
-    color: "rgb(var(--high-maintenance-color-rgb))",
+    color: "rgb(var(--fairhold-land-color-rgb))",
   },
 } satisfies ChartConfig;
 

--- a/app/components/graphs/ResaleValueWrapper.tsx
+++ b/app/components/graphs/ResaleValueWrapper.tsx
@@ -1,0 +1,73 @@
+"use client";
+import React from "react";
+import ErrorBoundary from "../ErrorBoundary";
+import { Household } from "@/app/models/Household";
+import ResaleValueLineChart from "./ResaleValueLineChart";
+import type { DataPoint } from "./ResaleValueLineChart"
+
+interface ResaleValueWrapperProps {
+  tenure: 'purchase' | 'rent';
+  household: Household;
+}
+
+const ResaleValueWrapper: React.FC<ResaleValueWrapperProps> = ({
+    tenure,
+    household
+}) => {
+    if (!household) {
+        return <div>No household data available</div>;
+      }
+
+    // Since we want one line (user selected) to be solid, need to map the maintenance percentage to the line type
+    const getSelectedMaintenance = (maintenancePercentage: number): 'noMaintenance' | 'lowMaintenance' | 'mediumMaintenance' | 'highMaintenance' => { // LINE CHANGED
+      switch (maintenancePercentage) {
+        case 0:
+          return 'noMaintenance';
+        case 0.015:
+          return 'lowMaintenance';
+        case 0.019:
+          return 'mediumMaintenance';
+        case 0.025:
+          return 'highMaintenance';
+        default:
+          return 'lowMaintenance';
+      }
+    };
+
+    /** Needs either `rent` or `purchase` to denote Fairhold tenure type; based on this arg, it will determine if land resale value is 0 or FHLP over time */
+    const formatData = (household: Household) => {
+      const lifetime = household.lifetime.lifetimeData 
+      const chartData: DataPoint[] = [];
+
+      for (let i = 0; i < lifetime.length; i++ ) {
+        // Fairhold land rent cannot be sold for anything, assign as 0 
+        const landValue = tenure === 'rent' ? 0 : lifetime[i].fairholdLandPurchaseResaleValue;
+      
+        chartData.push({
+          year: i,
+          noMaintenance: landValue + lifetime[i].depreciatedHouseResaleValueNoMaintenance,
+          lowMaintenance: landValue + lifetime[i].depreciatedHouseResaleValueLowMaintenance,
+          mediumMaintenance: landValue + lifetime[i].depreciatedHouseResaleValueMediumMaintenance,
+          highMaintenance: landValue + lifetime[i].depreciatedHouseResaleValueHighMaintenance
+        })
+        
+      }
+      return chartData
+    }
+
+    const formattedData = formatData(household);
+    const selectedMaintenance = getSelectedMaintenance(household.property.maintenancePercentage)
+    
+    return (
+        <ErrorBoundary>
+        <div>
+          <ResaleValueLineChart 
+            data={formattedData} 
+            selectedMaintenance={selectedMaintenance}
+            />
+        </div>
+      </ErrorBoundary>
+    );
+};
+
+export default ResaleValueWrapper

--- a/app/components/ui/Dashboard.tsx
+++ b/app/components/ui/Dashboard.tsx
@@ -6,6 +6,7 @@ import { WhatWouldYouChoose } from "../Dashboard/Cards/WhatWouldYouChoose";
 import { WhatDifference } from "../Dashboard/Cards/WhatDifference";
 import { HowMuchFHCost } from "../Dashboard/Cards/HowMuchFHCost";
 import { Carousel } from "./Carousel";
+import { ResaleValue } from "../Dashboard/Cards/ResaleValue";
 
 interface DashboardProps {
   processedData: Household;
@@ -40,7 +41,7 @@ const Dashboard: React.FC<DashboardProps> = ({ inputData, processedData }) => {
           <span className="text-red-500">in theory less than Freehold</span>
         </GraphCard>
         <GraphCard title="How would the cost change over my life?"></GraphCard>
-        <GraphCard title="How much could I sell it for?"></GraphCard>
+        <ResaleValue data={processedData}/>
         <WhatDifference />
         <WhatWouldYouChoose />
       </div>

--- a/app/components/ui/TenureSelector.tsx
+++ b/app/components/ui/TenureSelector.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { cn } from "@/lib/utils";
+
+interface TenureSelectorProps {
+  isSelected?: boolean;
+  onClick?: () => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const TenureSelector: React.FC<TenureSelectorProps> = ({
+  isSelected = false,
+  onClick,
+  className,
+  children,
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "px-4 py-2 rounded-lg transition-colors duration-200",
+        "text-sm font-medium",
+        isSelected
+          ? "bg-green-100 text-green-700" // Selected state
+          : "bg-gray-100 text-gray-700 hover:bg-gray-200", // Default state
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default TenureSelector;


### PR DESCRIPTION
# What does this PR do?
- New `ResaleValue` component allows you to toggle between the two Fairhold tenures being compared here
    - There is a new `TenureSelector` button component (that can be reused in 'How would the cost change over my life?')
- `ResaleValueLineChart` renders the graph and `ResaleValueWrapper` formats the data for both
- Adds the graph to the Dashboard

# Why
- All as per Miro design
![image](https://github.com/user-attachments/assets/20fabb17-9e14-4c37-b57a-a962da7e6b59)

Closes #254