### PR TITLE
chore: allow House age to be 0

### DIFF
--- a/app/schemas/calculationSchema.ts
+++ b/app/schemas/calculationSchema.ts
@@ -1,23 +1,25 @@
 import { z } from "zod";
-import {
-  parse as parsePostcode,
-  isValid as isValidPostcode,
-} from "postcode";
+import { parse as parsePostcode, isValid as isValidPostcode } from "postcode";
 import { HOUSE_TYPES, MaintenancePercentage } from "../models/Property";
 import { MAINTENANCE_LEVELS } from "../models/constants";
 
 // Type not exported by postcode lib directly
-export type ValidPostcode = Extract<ReturnType<typeof parsePostcode>, { valid: true }>;
+export type ValidPostcode = Extract<
+  ReturnType<typeof parsePostcode>,
+  { valid: true }
+>;
 
 const HouseTypeEnum = z.enum(HOUSE_TYPES);
 
-export const maintenancePercentageSchema = z.number().refine(
-  (value): value is MaintenancePercentage =>
-    (MAINTENANCE_LEVELS as readonly number[]).includes(value),
-  {
-    message: `Maintenance percentage must be one of: ${MAINTENANCE_LEVELS.join(', ')}`
-  }
-);
+export const maintenancePercentageSchema = z
+  .number()
+  .refine(
+    (value): value is MaintenancePercentage =>
+      (MAINTENANCE_LEVELS as readonly number[]).includes(value),
+    {
+      message: `Maintenance percentage must be one of: ${MAINTENANCE_LEVELS.join(", ")}`,
+    }
+  );
 
 /**
  * Describes the form the user will interact with in the frontend
@@ -30,7 +32,9 @@ export const calculationSchema = z.object({
     .transform(parsePostcode)
     .refine((postcode): postcode is ValidPostcode => postcode.valid),
   houseSize: z.coerce.number().positive("houseSize must be a positive integer"),
-  houseAge: z.coerce.number().positive("houseAge must be a positive integer"),
+  houseAge: z.coerce
+    .number()
+    .nonnegative("houseAge must be a positive integer or 0"),
   houseBedrooms: z.coerce
     .number()
     .positive("houseBedrooms must be a positive integer"),

--- a/app/schemas/calculationSchema.ts
+++ b/app/schemas/calculationSchema.ts
@@ -3,7 +3,6 @@ import { parse as parsePostcode, isValid as isValidPostcode } from "postcode";
 import { HOUSE_TYPES, MaintenancePercentage } from "../models/Property";
 import { MAINTENANCE_LEVELS } from "../models/constants";
 
-// Type not exported by postcode lib directly
 export type ValidPostcode = Extract<
   ReturnType<typeof parsePostcode>,
   { valid: true }
@@ -21,9 +20,6 @@ export const maintenancePercentageSchema = z
     }
   );
 
-/**
- * Describes the form the user will interact with in the frontend
- */
 export const calculationSchema = z.object({
   housePostcode: z
     .string()

--- a/app/schemas/formSchema.ts
+++ b/app/schemas/formSchema.ts
@@ -14,7 +14,9 @@ export const formSchema = z.object({
     .min(1, "Postcode is required")
     .refine(isValidPostcode, "Invalid postcode"),
   houseSize: z.coerce.number().positive("House size must be a positive number"),
-  houseAge: z.coerce.number().positive("House age must be a positive number"),
+  houseAge: z.coerce
+    .number()
+    .nonnegative("House age must be a positive number or 0"),
   houseBedrooms: z.coerce
     .number()
     .positive("House bedrooms must be a positive number"),

--- a/app/schemas/formSchema.ts
+++ b/app/schemas/formSchema.ts
@@ -5,9 +5,6 @@ import { maintenancePercentageSchema } from "../schemas/calculationSchema";
 
 const HouseTypeEnum = z.enum(HOUSE_TYPES);
 
-/**
- * Describes the form the user will interact with in the frontend
- */
 export const formSchema = z.object({
   housePostcode: z
     .string()


### PR DESCRIPTION
# What does this PR do?
It changes the validation schema to allow for a value equal to 0 in the House Age field. This is because now a new house has year equal to 0 and not equal to 1.