### PR TITLE
feat: Optional floor area

### DIFF
--- a/app/api/route.test.ts
+++ b/app/api/route.test.ts
@@ -1,11 +1,11 @@
 import { POST } from "../api/route";
 import * as calculationService from "../services/calculationService";
-import calculateFairhold from "../models/testClasses";
+import calculateFairhold from "../models/calculateFairhold";
 import { NextResponse } from "next/server";
 
 // Mock dependencies
 jest.mock("../services/calculationService");
-jest.mock("../models/testClasses", () => jest.fn()); // Mock calculateFairhold
+jest.mock("../models/calculateFairhold", () => jest.fn()); // Mock calculateFairhold
 jest.mock("next/server", () => ({
   NextResponse: {
     json: jest.fn((data) => ({ data })),

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { calculationSchema } from "../schemas/calculationSchema";
 import * as calculationService from "../services/calculationService";
-import calculateFairhold from "../models/testClasses";
+import calculateFairhold from "../models/calculateFairhold";
 import { APIError } from "../lib/exceptions";
 
 export async function POST(req: Request) {
@@ -16,16 +16,13 @@ export async function POST(req: Request) {
     console.log("ERROR: API - ", (error as Error).message);
 
     if (error instanceof APIError) {
-      return NextResponse.json(
-        { error },
-        { status: error.status },
-      );
+      return NextResponse.json({ error }, { status: error.status });
     }
 
     const response = {
-      error: { 
-        message: (error as Error).message, 
-        code: "UNHANDLED_EXCEPTION" 
+      error: {
+        message: (error as Error).message,
+        code: "UNHANDLED_EXCEPTION",
       },
     };
     return NextResponse.json(response, { status: 500 });

--- a/app/models/Property.test.ts
+++ b/app/models/Property.test.ts
@@ -1,49 +1,48 @@
 import { Property } from "./Property";
-import { MAINTENANCE_LEVELS } from './constants';
-import { createTestProperty } from "./testHelpers"; 
+import { MAINTENANCE_LEVELS } from "./constants";
+import { createTestProperty } from "./testHelpers";
 
 let property = createTestProperty();
 
-describe('Property', () => {
+describe("Property", () => {
   beforeEach(() => {
-    property = createTestProperty() 
+    property = createTestProperty();
   });
 
   it("can be instantiated", () => {
     expect(property).toBeInstanceOf(Property);
   });
-  
+
   it("correctly calculates the newBuildPrice", () => {
     expect(property.newBuildPrice).toBeCloseTo(186560);
   });
-  
+
   it("correctly calculates the landPrice", () => {
     expect(property.landPrice).toBeCloseTo(313440);
   });
-  
+
   it("correctly calculates the landToTotalRatio", () => {
     expect(property.landToTotalRatio).toBeCloseTo(0.62688);
   });
-  
+
   it("correctly calculates the values even for number of bedroooms exceeding the max ", () => {
     property = createTestProperty({
-      numberOfBedrooms: 20
-    })
+      numberOfBedrooms: 20,
+    });
   });
 
   it("correctly returns newBuildPrice if newbuild", () => {
     property = createTestProperty({
-      age: 0
-    })
+      age: 0,
+    });
 
     expect(property.depreciatedBuildPrice).toBe(property.newBuildPrice);
   });
 
-  describe('depreciation calculations (existing build)', () => {
-
+  describe("depreciation calculations (existing build)", () => {
     it("correctly calculates newComponentValue for foundations", () => {
       const result = property.calculateComponentValue(
-        'foundations',
+        "foundations",
         property.newBuildPrice,
         property.age,
         MAINTENANCE_LEVELS[1]
@@ -55,18 +54,18 @@ describe('Property', () => {
 
     it("correctly calculates depreciationFactor for internal linings", () => {
       const result = property.calculateComponentValue(
-        'internalLinings',
+        "internalLinings",
         property.newBuildPrice,
         property.age,
         MAINTENANCE_LEVELS[1]
       );
 
-      expect(result.depreciationFactor).toBe(.968);
+      expect(result.depreciationFactor).toBe(0.968);
     });
 
     it("correctly calculates maintenanceAddition for electrical appliances", () => {
       const result = property.calculateComponentValue(
-        'electricalAppliances',
+        "electricalAppliances",
         property.newBuildPrice,
         property.age,
         MAINTENANCE_LEVELS[1]
@@ -77,7 +76,7 @@ describe('Property', () => {
 
     it("correctly calculates depreciatedComponentValue for ventilation services", () => {
       const result = property.calculateComponentValue(
-        'ventilationServices',
+        "ventilationServices",
         property.newBuildPrice,
         property.age,
         MAINTENANCE_LEVELS[1]
@@ -88,7 +87,7 @@ describe('Property', () => {
 
     it("ensures depreciatedComponentValue never goes below 0", () => {
       const result = property.calculateComponentValue(
-        'ventilationServices',
+        "ventilationServices",
         property.newBuildPrice,
         100, // High age to test possible negative values
         MAINTENANCE_LEVELS[1]
@@ -97,10 +96,10 @@ describe('Property', () => {
       expect(result.depreciatedComponentValue).toBeGreaterThanOrEqual(0);
     });
 
-    it('should calculate correct depreciation for a 10-year-old house', () => {
+    it("should calculate correct depreciation for a 10-year-old house", () => {
       property = createTestProperty({
-        age: 10
-      })
+        age: 10,
+      });
       expect(property.depreciatedBuildPrice).toBeCloseTo(171467.3);
     });
   });

--- a/app/models/calculateFairhold.test.ts
+++ b/app/models/calculateFairhold.test.ts
@@ -1,0 +1,93 @@
+import calculateFairhold from "./calculateFairhold";
+import { ResponseData } from "./calculateFairhold";
+import { Household } from "./Household";
+import { ValidPostcode } from "../schemas/calculationSchema";
+import { parse as parsePostcode } from "postcode";
+import { socialRentAdjustments } from "./testHelpers";
+
+jest.mock("./Household", () => {
+  return {
+    Household: jest.fn().mockImplementation((data) => data),
+  };
+});
+
+jest.mock("./Property", () => {
+  return {
+    Property: jest.fn().mockImplementation((data) => data),
+  };
+});
+
+jest.mock("./ForecastParameters", () => {
+  return {
+    createForecastParameters: jest.fn((maintenancePercentage) => ({
+      maintenancePercentage,
+    })),
+  };
+});
+
+describe("calculateFairhold", () => {
+  const validResponseData: ResponseData = {
+    postcode: parsePostcode("SE17 1PE") as ValidPostcode,
+    houseType: "D",
+    houseBedrooms: 3,
+    buildPrice: 2000,
+    houseAge: 10,
+    houseSize: 95,
+    maintenancePercentage: 0.015,
+    averagePrice: 300000,
+    itl3: "UKI3",
+    gdhi: 25000,
+    averageRentMonthly: 800,
+    socialRentAverageEarning: 0.8,
+    socialRentAdjustments: socialRentAdjustments,
+    hpi: 1.5,
+    kwhCostPence: 30,
+  };
+
+  it("throws an error if itl3 is missing or empty", () => {
+    const invalidData = { ...validResponseData, itl3: "" };
+    expect(() => calculateFairhold(invalidData)).toThrow(
+      "itl3 data is missing or empty"
+    );
+  });
+
+  it("creates a Household instance with correct parameters", () => {
+    const household = calculateFairhold(validResponseData);
+    expect(household).toBeDefined();
+  });
+
+  it("calculates houseSize if it is undefined", () => {
+    const responseDataWithUndefinedSize = {
+      ...validResponseData,
+      houseSize: undefined,
+    };
+
+    calculateFairhold(responseDataWithUndefinedSize);
+
+    expect(Household).toHaveBeenCalledWith(
+      expect.objectContaining({
+        property: expect.objectContaining({
+          size: 95,
+        }),
+      })
+    );
+  });
+
+  it("assigns max size for bedrooms > 6", () => {
+    const responseDataWithLargeBedrooms = {
+      ...validResponseData,
+      houseBedrooms: 7,
+      houseSize: undefined,
+    };
+
+    calculateFairhold(responseDataWithLargeBedrooms);
+
+    expect(Household).toHaveBeenCalledWith(
+      expect.objectContaining({
+        property: expect.objectContaining({
+          size: 135,
+        }),
+      })
+    );
+  });
+});

--- a/app/models/calculateFairhold.test.ts
+++ b/app/models/calculateFairhold.test.ts
@@ -4,6 +4,10 @@ import { Household } from "./Household";
 import { ValidPostcode } from "../schemas/calculationSchema";
 import { parse as parsePostcode } from "postcode";
 import { socialRentAdjustments } from "./testHelpers";
+import { maintenancePercentageSchema } from "../schemas/calculationSchema";
+import { z } from "zod";
+
+type MaintenancePercentage = z.infer<typeof maintenancePercentageSchema>;
 
 jest.mock("./Household", () => {
   return {
@@ -48,6 +52,23 @@ describe("calculateFairhold", () => {
     const invalidData = { ...validResponseData, itl3: "" };
     expect(() => calculateFairhold(invalidData)).toThrow(
       "itl3 data is missing or empty"
+    );
+  });
+
+  it("throws an error if buildPrice is missing or empty", () => {
+    const invalidData = { ...validResponseData, buildPrice: NaN };
+    expect(() => calculateFairhold(invalidData)).toThrow(
+      "buildPrice data is missing or empty"
+    );
+  });
+
+  it("throws an error if maintenancePercentage is missing or empty", () => {
+    const invalidData = {
+      ...validResponseData,
+      maintenancePercentage: "" as unknown as MaintenancePercentage,
+    };
+    expect(() => calculateFairhold(invalidData)).toThrow(
+      "maintenancePercentage data is missing or empty"
     );
   });
 

--- a/app/models/calculateFairhold.ts
+++ b/app/models/calculateFairhold.ts
@@ -1,4 +1,4 @@
-import { ValidPostcode } from './../schemas/calculationSchema';
+import { ValidPostcode } from "../schemas/calculationSchema";
 import { createForecastParameters } from "./ForecastParameters";
 import { Household } from "./Household";
 import { HouseType, MaintenancePercentage, Property } from "./Property";
@@ -12,7 +12,7 @@ export interface ResponseData {
   houseBedrooms: number;
   buildPrice: number;
   houseAge: number;
-  houseSize: number;
+  houseSize: number | undefined;
   maintenancePercentage: MaintenancePercentage;
   averagePrice: number;
   itl3: string;
@@ -35,13 +35,27 @@ function calculateFairhold(responseData: ResponseData) {
     throw new Error("maintenancePercentage data is missing or empty");
   }
 
+  function assignHouseSize(numberOfBedrooms: number) {
+    const sizeMapping: { [key: number]: number } = {
+      1: 55,
+      2: 70,
+      3: 95,
+      4: 110,
+      5: 125,
+      6: 135,
+    };
+
+    const size = numberOfBedrooms > 6 ? 135 : sizeMapping[numberOfBedrooms];
+    return size;
+  }
+
   // define the property object
   const property = new Property({
     postcode: responseData.postcode.postcode,
     houseType: responseData.houseType,
     numberOfBedrooms: responseData.houseBedrooms,
     age: responseData.houseAge,
-    size: responseData.houseSize,
+    size: responseData.houseSize ?? assignHouseSize(responseData.houseBedrooms),
     maintenancePercentage: responseData.maintenancePercentage,
     newBuildPricePerMetre: responseData.buildPrice,
     averageMarketPrice: responseData.averagePrice,
@@ -57,9 +71,11 @@ function calculateFairhold(responseData: ResponseData) {
     housePriceIndex: responseData.hpi,
     kwhCostPence: responseData.kwhCostPence,
     property: property,
-    forecastParameters: createForecastParameters(responseData.maintenancePercentage),
+    forecastParameters: createForecastParameters(
+      responseData.maintenancePercentage
+    ),
   });
-  
+
   return household;
 }
 

--- a/app/models/testHelpers.ts
+++ b/app/models/testHelpers.ts
@@ -12,7 +12,7 @@ import { Lifetime } from "./Lifetime";
 import { Property } from "./Property";
 import { MarketPurchase } from "./tenure/MarketPurchase";
 
-const socialRentAdjustments: socialRentAdjustmentTypes = [
+export const socialRentAdjustments: socialRentAdjustmentTypes = [
   {
     inflation: 3.3,
     total: 4.3,
@@ -164,10 +164,10 @@ const socialRentAdjustments: socialRentAdjustmentTypes = [
  * kwhCostPence: 8,
  * property: createTestProperty(),
  * forecastParameters: DEFAULT_FORECAST_PARAMETERS,`
- * @returns 
+ * @returns
  */
-export const createTestHousehold = (overrides = {}) => { 
-  return new Household ({
+export const createTestHousehold = (overrides = {}) => {
+  return new Household({
     averageRentYearly: 1200,
     socialRentAverageEarning: 354.1,
     socialRentAdjustments: socialRentAdjustments,
@@ -176,9 +176,9 @@ export const createTestHousehold = (overrides = {}) => {
     kwhCostPence: 7,
     property: createTestProperty(),
     forecastParameters: DEFAULT_FORECAST_PARAMETERS,
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};
 
 /**
  * Creates a simplified instance of the `Property` class with straightforward property values for testing. Assumes newbuild!
@@ -195,97 +195,97 @@ export const createTestHousehold = (overrides = {}) => {
  * @returns
  */
 export const createTestProperty = (overrides = {}) => {
-    return new Property ({ 
-      postcode: "SE15 1TX",
-      houseType: "T",
-      numberOfBedrooms: 2,
-      age: 1,
-      size: 88,
-      maintenancePercentage: .015,
-      newBuildPricePerMetre: 2120,
-      averageMarketPrice: 500000,
-      itl3: "TLI44",
-      ...overrides
-    })
-}
+  return new Property({
+    postcode: "SE15 1TX",
+    houseType: "T",
+    numberOfBedrooms: 2,
+    age: 1,
+    size: 88,
+    maintenancePercentage: 0.015,
+    newBuildPricePerMetre: 2120,
+    averageMarketPrice: 500000,
+    itl3: "TLI44",
+    ...overrides,
+  });
+};
 
 /**
- * Creates a simplified instance of the `Mortgage` class, representing the land portion of `MarketPurchase`. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `Mortgage` class, representing the land portion of `MarketPurchase`. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `propertyValue: 300000,
- * interestRate: 0.035, 
+ * interestRate: 0.035,
  * mortgageTerm: 25,
- * initialDeposit: 0.1,` 
- * @returns 
+ * initialDeposit: 0.1,`
+ * @returns
  */
-// export const createTestMarketLandMortgage = (overrides = {}) => { 
+// export const createTestMarketLandMortgage = (overrides = {}) => {
 //     return new Mortgage({
 //       propertyValue: 300000,
-//       interestRate: 0.035, 
+//       interestRate: 0.035,
 //       mortgageTerm: 25,
-//       initialDeposit: 0.1, 
+//       initialDeposit: 0.1,
 //       ...overrides
 //     });
 //   };
 
 /**
- * Creates a simplified instance of the `Mortgage` class, representing the replacement value of a newbuild house in `MarketPurchase`. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `Mortgage` class, representing the replacement value of a newbuild house in `MarketPurchase`. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `propertyValue: 200000,
- * interestRate: 0.035, 
+ * interestRate: 0.035,
  * mortgageTerm: 25,
  * initialDeposit: 0.1,`
- * @returns 
+ * @returns
  */
 // export const createTestNewbuildHouseMortgage = (overrides = {}) => { TODO: write tests; commenting out the function for now because of test coverage issue
 //   return new Mortgage({
 //     propertyValue: 200000,
-//     interestRate: 0.035, 
+//     interestRate: 0.035,
 //     mortgageTerm: 25,
-//     initialDeposit: 0.1, 
+//     initialDeposit: 0.1,
 //     ...overrides
 //   });
 // };
 
 /**
- * Creates a simplified instance of the `Mortgage` class, representing the depreciated house portion of the Fairhold tenures. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `Mortgage` class, representing the depreciated house portion of the Fairhold tenures. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `propertyValue: 150000,
- * interestRate: 0.035, 
+ * interestRate: 0.035,
  * mortgageTerm: 25,
  * initialDeposit: 0.1, `
- * @returns 
+ * @returns
  */
 // export const createTestDepreciatedHouseMortgage = (overrides = {}) => { TODO: write tests; commenting out the function for now because of test coverage issue
 //   return new Mortgage({
 //     propertyValue: 150000,
-//     interestRate: 0.035, 
+//     interestRate: 0.035,
 //     mortgageTerm: 25,
-//     initialDeposit: 0.1, 
+//     initialDeposit: 0.1,
 //     ...overrides
 //   });
 // };
 
 /**
- * Creates a simplified instance of the `Mortgage` class, representing the discounted sale of a `FairholdLandPurchase` lease. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `Mortgage` class, representing the discounted sale of a `FairholdLandPurchase` lease. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `propertyValue: 45000,
- * interestRate: 0.035, 
+ * interestRate: 0.035,
  * mortgageTerm: 25,
  * initialDeposit: 0.1,`
- * @returns 
+ * @returns
  */
 // export const createTestFairholdLandMortgage = (overrides = {}) => { TODO: write tests; commenting out the function for now because of test coverage issue
 //   return new Mortgage({
 //     propertyValue: 45000,
-//     interestRate: 0.035, 
+//     interestRate: 0.035,
 //     mortgageTerm: 25,
-//     initialDeposit: 0.1, 
+//     initialDeposit: 0.1,
 //     ...overrides
 //   });
 // };
 
-/** 
+/**
  * Note that this creates an instance of `Fairhold`, not `FairholdLandPurchase`. The former is needed as part of the latter.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `affordability: .6,
@@ -294,13 +294,13 @@ export const createTestProperty = (overrides = {}) => {
  */
 export const createTestFairholdForLandPurchase = (overrides = {}) => {
   return new Fairhold({
-    affordability: .6,
+    affordability: 0.6,
     landPriceOrRent: 300000,
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};
 
-/** 
+/**
  * Note that this creates an instance of `Fairhold`, not `FairholdLandRent`. The former is needed as part of the latter.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `affordability: .6,
@@ -309,14 +309,14 @@ export const createTestFairholdForLandPurchase = (overrides = {}) => {
  */
 export const createTestFairholdForLandRent = (overrides = {}) => {
   return new Fairhold({
-    affordability: .6,
+    affordability: 0.6,
     landPriceOrRent: 900,
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};
 
 /**
- * Creates a simplified instance of the `MarketPurchase` class. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `MarketPurchase` class. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `averagePrice: 500000,
  * newBuildPrice: 200000,
@@ -324,7 +324,7 @@ export const createTestFairholdForLandRent = (overrides = {}) => {
  * landPrice: 300000,
  * incomeYearly: 30000,
  * forecastParameters: DEFAULT_FORECAST_PARAMETERS,`
- * @returns 
+ * @returns
  */
 export const createTestMarketPurchase = (overrides = {}) => {
   return new MarketPurchase({
@@ -334,12 +334,12 @@ export const createTestMarketPurchase = (overrides = {}) => {
     landPrice: 300000,
     incomeYearly: 30000,
     forecastParameters: DEFAULT_FORECAST_PARAMETERS,
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};
 
 /**
- * Creates a simplified instance of the `MarketRent` class. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `MarketRent` class. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `averageRentYearly: 18000,
  * averagePrice: 500000,
@@ -348,7 +348,7 @@ export const createTestMarketPurchase = (overrides = {}) => {
  * landPrice: 300000,
  * incomeYearly: 30000,
  * forecastParameters: DEFAULT_FORECAST_PARAMETERS,`
- * @returns 
+ * @returns
  */
 export const createTestMarketRent = (overrides = {}) => {
   return new MarketRent({
@@ -356,14 +356,14 @@ export const createTestMarketRent = (overrides = {}) => {
     newBuildPrice: 200000,
     depreciatedBuildPrice: 150000,
     incomeYearly: 30000,
-    landToTotalRatio: .6,
+    landToTotalRatio: 0.6,
     forecastParameters: DEFAULT_FORECAST_PARAMETERS,
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};
 
 /**
- * Creates a simplified instance of the `FairholdLandPurchase` class, which includes `Fairhold` and `MarketPurchase` instances. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `FairholdLandPurchase` class, which includes `Fairhold` and `MarketPurchase` instances. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `newBuildPrice: 200000,
  * depreciatedBuildPrice: 150000,
@@ -371,22 +371,22 @@ export const createTestMarketRent = (overrides = {}) => {
  * fairhold: createTestFairholdForLandPurchase(),
  * forecastParameters: DEFAULT_FORECAST_PARAMETERS,
  * marketPurchase: createTestMarketPurchase(),`
- * @returns 
+ * @returns
  */
 export const createTestFairholdLandPurchase = (overrides = {}) => {
   return new FairholdLandPurchase({
     newBuildPrice: 200000,
     depreciatedBuildPrice: 150000,
-    affordability: .6,
+    affordability: 0.6,
     fairhold: createTestFairholdForLandPurchase(),
     forecastParameters: DEFAULT_FORECAST_PARAMETERS,
     marketPurchase: createTestMarketPurchase(),
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};
 
 /**
- * Creates a simplified instance of the `FairholdLandRent` class, which includes `Fairhold` and `MarketPurchase` instances. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `FairholdLandRent` class, which includes `Fairhold` and `MarketPurchase` instances. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `averageRentYearly: 18000,
  * averagePrice: 500000,
@@ -397,7 +397,7 @@ export const createTestFairholdLandPurchase = (overrides = {}) => {
  * fairhold: createTestFairholdForLandRent(),
  * forecastParameters: DEFAULT_FORECAST_PARAMETERS,
  * marketPurchase: createTestMarketPurchase(),`
- * @returns 
+ * @returns
  */
 export const createTestFairholdLandRent = (overrides = {}) => {
   return new FairholdLandRent({
@@ -406,22 +406,22 @@ export const createTestFairholdLandRent = (overrides = {}) => {
     depreciatedBuildPrice: 150000,
     incomeYearly: 30000,
     fairhold: createTestFairholdForLandRent(),
-    landToTotalRatio: .6,
+    landToTotalRatio: 0.6,
     forecastParameters: DEFAULT_FORECAST_PARAMETERS,
     marketPurchase: createTestMarketPurchase(),
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};
 
 /**
- * Creates a simplified instance of the `SocialRent` class. Uses straightforward property values for testing. 
+ * Creates a simplified instance of the `SocialRent` class. Uses straightforward property values for testing.
  * @param overrides Include custom values to overwrite those provided. Default values are:
  * `numberOfBedrooms: 2,
  * socialRentAverageEarning: 354.1,
  * socialRentAdjustments: socialRentAdjustments,
  * housePriceIndex: 100000,
  * landToTotalRatio: .6,`
- * @returns 
+ * @returns
  */
 export const createTestSocialRent = (overrides = {}) => {
   return new SocialRent({
@@ -429,15 +429,15 @@ export const createTestSocialRent = (overrides = {}) => {
     socialRentAverageEarning: 354.1,
     socialRentAdjustments: socialRentAdjustments,
     housePriceIndex: 100000,
-    landToTotalRatio: .6,
-    ...overrides
-  })
-}
+    landToTotalRatio: 0.6,
+    ...overrides,
+  });
+};
 
 /**
- * Creates a simplified instance of the `Lifetime` class, which includes instances of all tenure classes and `Property` too. Uses straightforward property values for testing. 
- * @param overrides Include custom values to overwrite those provided. Default values are from other class helper functions and `DEFAULT_FORECAST_PARAMETERS`. 
- * @returns 
+ * Creates a simplified instance of the `Lifetime` class, which includes instances of all tenure classes and `Property` too. Uses straightforward property values for testing.
+ * @param overrides Include custom values to overwrite those provided. Default values are from other class helper functions and `DEFAULT_FORECAST_PARAMETERS`.
+ * @returns
  */
 export const createTestLifetime = (overrides = {}) => {
   return new Lifetime({
@@ -447,14 +447,17 @@ export const createTestLifetime = (overrides = {}) => {
     fairholdLandPurchase: createTestFairholdLandPurchase(),
     fairholdLandRent: createTestFairholdLandRent(),
     property: createTestProperty(),
-    propertyPriceGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear,
-    constructionPriceGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear,
+    propertyPriceGrowthPerYear:
+      DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear,
+    constructionPriceGrowthPerYear:
+      DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear,
     rentGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.rentGrowthPerYear,
     yearsForecast: DEFAULT_FORECAST_PARAMETERS.yearsForecast,
     maintenancePercentage: DEFAULT_FORECAST_PARAMETERS.maintenancePercentage,
     incomeGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear,
-    affordabilityThresholdIncomePercentage: DEFAULT_FORECAST_PARAMETERS.affordabilityThresholdIncomePercentage,
+    affordabilityThresholdIncomePercentage:
+      DEFAULT_FORECAST_PARAMETERS.affordabilityThresholdIncomePercentage,
     incomeYearly: 30000,
-    ...overrides
-  })
-}
+    ...overrides,
+  });
+};

--- a/app/schemas/calculationSchema.ts
+++ b/app/schemas/calculationSchema.ts
@@ -1,23 +1,25 @@
 import { z } from "zod";
-import {
-  parse as parsePostcode,
-  isValid as isValidPostcode,
-} from "postcode";
+import { parse as parsePostcode, isValid as isValidPostcode } from "postcode";
 import { HOUSE_TYPES, MaintenancePercentage } from "../models/Property";
 import { MAINTENANCE_LEVELS } from "../models/constants";
 
 // Type not exported by postcode lib directly
-export type ValidPostcode = Extract<ReturnType<typeof parsePostcode>, { valid: true }>;
+export type ValidPostcode = Extract<
+  ReturnType<typeof parsePostcode>,
+  { valid: true }
+>;
 
 const HouseTypeEnum = z.enum(HOUSE_TYPES);
 
-export const maintenancePercentageSchema = z.number().refine(
-  (value): value is MaintenancePercentage =>
-    (MAINTENANCE_LEVELS as readonly number[]).includes(value),
-  {
-    message: `Maintenance percentage must be one of: ${MAINTENANCE_LEVELS.join(', ')}`
-  }
-);
+export const maintenancePercentageSchema = z
+  .number()
+  .refine(
+    (value): value is MaintenancePercentage =>
+      (MAINTENANCE_LEVELS as readonly number[]).includes(value),
+    {
+      message: `Maintenance percentage must be one of: ${MAINTENANCE_LEVELS.join(", ")}`,
+    }
+  );
 
 /**
  * Describes the form the user will interact with in the frontend
@@ -29,7 +31,12 @@ export const calculationSchema = z.object({
     .refine(isValidPostcode, "Invalid postcode")
     .transform(parsePostcode)
     .refine((postcode): postcode is ValidPostcode => postcode.valid),
-  houseSize: z.coerce.number().positive("houseSize must be a positive integer"),
+  houseSize: z
+    .number()
+    .optional()
+    .refine((value) => value === undefined || value > 0, {
+      message: "House size must be a positive number",
+    }),
   houseAge: z.coerce.number().positive("houseAge must be a positive integer"),
   houseBedrooms: z.coerce
     .number()

--- a/app/schemas/formSchema.ts
+++ b/app/schemas/formSchema.ts
@@ -13,7 +13,12 @@ export const formSchema = z.object({
     .string()
     .min(1, "Postcode is required")
     .refine(isValidPostcode, "Invalid postcode"),
-  houseSize: z.coerce.number().positive("House size must be a positive number"),
+  houseSize: z.coerce
+    .number()
+    .optional()
+    .refine((value) => value === undefined || value > 0, {
+      message: "House size must be a positive number",
+    }),
   houseAge: z.coerce.number().positive("House age must be a positive number"),
   houseBedrooms: z.coerce
     .number()


### PR DESCRIPTION
# What does this PR do?
Following #270 , it allows `houseSize` in the input to be undefined, so that it becomes an optional parameter. If `undefined`, the value is then mapped to the number of bedrooms.

#How?
The value is made optional in the `formSchema` and `calculationSchema`. Note that `houseSize` is not necessary to fetch the data in the API. Later, when the `Property` class is actually constructed, there is an if condition that checks if `houseSize` exists or needs to be mapped.

#Anything else?
We used to have a file named `testClasses.ts` but it was not a test. The main function within it was called `calculateFairhold`. I think the name was confusing, so I renamed it `calculateFairhold.ts`. Last, I added a series on unit tests in `calculateFairhold.test.ts`