### PR TITLE
feat: calculate social rent over lifetime 

### DIFF
--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -7,7 +7,7 @@ import Dashboard from "./Dashboard";
 import { formSchema, FormFrontend } from "@/app/schemas/formSchema";
 import { useSearchParams } from "next/navigation";
 import { DEFAULT_INTEREST_RATE, DEFAULT_MORTGAGE_TERM, DEFAULT_INITIAL_DEPOSIT, MAINTENANCE_LEVELS } from "../../models/constants"
-import type { MaintenanceLevel } from "../../models/constants";
+import { MaintenanceLevel } from "../../models/constants";
 
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { ClipLoader } from "react-spinners";
@@ -273,13 +273,13 @@ const CalculatorInput = () => {
 
                   <FormControl>
                     <RadioGroup
-                      value={String(field.value)} // Convert number to string for RadioGroup
-                      onValueChange={(value) => field.onChange(Number(value))} // Convert back to number for form
+                      value={field.value}
+                      onValueChange={field.onChange}
                       className="flex space-x-4"
                     >
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS.low.toString()}
+                          value="low"
                           id="radio-option-low"
                           className="radio-button-style"
                         />
@@ -292,7 +292,7 @@ const CalculatorInput = () => {
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS.medium.toString()}
+                          value="medium"
                           id="radio-option-medium"
                           className="radio-button-style"
                         />
@@ -305,7 +305,7 @@ const CalculatorInput = () => {
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS.high.toString()}
+                          value="high"
                           id="radio-option-high"
                           className="radio-button-style"
                         />

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -44,6 +44,8 @@ export interface LifetimeData {
     depreciatedHouseResaleValueMediumMaintenance: number;
     depreciatedHouseResaleValueHighMaintenance: number;
     fairholdLandPurchaseResaleValue: number;
+    socialRentMonthlyLand: number;
+    socialRentMonthlyHouse: number;
     houseAge: number;
     [key: number]: number;
 }
@@ -109,6 +111,9 @@ export class Lifetime {
 
         /** Resale value increases with `ForecastParameters.constructionPriceGrowthPerYear` */
         let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
+        let socialRentMonthlyLandIterative = params.household.tenure.socialRent.socialRentMonthlyLand; 
+        let socialRentMonthlyHouseIterative = params.household.tenure.socialRent.socialRentMonthlyHouse;
+        
         /** Initialises as user input house age and increments by one */
         let houseAgeIterative = params.property.age;
 
@@ -150,6 +155,8 @@ export class Lifetime {
             depreciatedHouseResaleValueMediumMaintenance: depreciatedHouseResaleValueMediumMaintenanceIterative,
             depreciatedHouseResaleValueHighMaintenance: depreciatedHouseResaleValueHighMaintenanceIterative,
             fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
+            socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
+            socialRentMonthlyLand: socialRentMonthlyLandIterative,
             houseAge: houseAgeIterative,
             gasBillExistingBuildYearly: gasBillExistingBuildIterative,
             gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative
@@ -243,6 +250,10 @@ export class Lifetime {
                 affordability: marketRentAffordabilityIterative,
                 landPriceOrRent: marketRentLandYearlyIterative,
             }).discountedLandPriceOrRent;
+
+            // Increase monthly social rent by the average inflation adjustment (2.83%)
+            socialRentMonthlyHouseIterative *= 1.0283;
+            socialRentMonthlyLandIterative *= 1.0283;
             
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,
@@ -262,6 +273,8 @@ export class Lifetime {
                 depreciatedHouseResaleValueMediumMaintenance: depreciatedHouseResaleValueMediumMaintenanceIterative,
                 depreciatedHouseResaleValueHighMaintenance: depreciatedHouseResaleValueHighMaintenanceIterative,
                 fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
+                socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
+                socialRentMonthlyLand: socialRentMonthlyLandIterative,
                 houseAge: houseAgeIterative,
                 gasBillExistingBuildYearly: gasBillExistingBuildIterative,
                 gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -44,8 +44,8 @@ export interface LifetimeData {
     depreciatedHouseResaleValueMediumMaintenance: number;
     depreciatedHouseResaleValueHighMaintenance: number;
     fairholdLandPurchaseResaleValue: number;
-    socialRentMonthlyLand: number;
-    socialRentMonthlyHouse: number;
+    socialRentYearlyLand: number;
+    socialRentYearlyHouse: number;
     houseAge: number;
     [key: number]: number;
 }
@@ -111,8 +111,8 @@ export class Lifetime {
 
         /** Resale value increases with `ForecastParameters.constructionPriceGrowthPerYear` */
         let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
-        let socialRentMonthlyLandIterative = params.household.tenure.socialRent.socialRentMonthlyLand; 
-        let socialRentMonthlyHouseIterative = params.household.tenure.socialRent.socialRentMonthlyHouse;
+        let socialRentYearlyLandIterative = params.household.tenure.socialRent.socialRentMonthlyLand * 12; 
+        let socialRentYearlyHouseIterative = params.household.tenure.socialRent.socialRentMonthlyHouse * 12;
         
         /** Initialises as user input house age and increments by one */
         let houseAgeIterative = params.property.age;
@@ -155,8 +155,8 @@ export class Lifetime {
             depreciatedHouseResaleValueMediumMaintenance: depreciatedHouseResaleValueMediumMaintenanceIterative,
             depreciatedHouseResaleValueHighMaintenance: depreciatedHouseResaleValueHighMaintenanceIterative,
             fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
-            socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
-            socialRentMonthlyLand: socialRentMonthlyLandIterative,
+            socialRentYearlyHouse: socialRentYearlyHouseIterative,
+            socialRentYearlyLand: socialRentYearlyLandIterative,
             houseAge: houseAgeIterative,
             gasBillExistingBuildYearly: gasBillExistingBuildIterative,
             gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative
@@ -252,8 +252,8 @@ export class Lifetime {
             }).discountedLandPriceOrRent;
 
             // Increase monthly social rent by the average inflation adjustment (2.83%)
-            socialRentMonthlyHouseIterative *= 1.0283;
-            socialRentMonthlyLandIterative *= 1.0283;
+            socialRentYearlyHouseIterative *= 1.0283;
+            socialRentYearlyLandIterative *= 1.0283;
             
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,
@@ -273,8 +273,8 @@ export class Lifetime {
                 depreciatedHouseResaleValueMediumMaintenance: depreciatedHouseResaleValueMediumMaintenanceIterative,
                 depreciatedHouseResaleValueHighMaintenance: depreciatedHouseResaleValueHighMaintenanceIterative,
                 fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
-                socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
-                socialRentMonthlyLand: socialRentMonthlyLandIterative,
+                socialRentYearlyHouse: socialRentYearlyHouseIterative,
+                socialRentYearlyLand: socialRentYearlyLandIterative,
                 houseAge: houseAgeIterative,
                 gasBillExistingBuildYearly: gasBillExistingBuildIterative,
                 gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative


### PR DESCRIPTION
# What does this PR do?
- Adds properties to `lifetimeData` that calculate social rent forecast each year
    - Instead of instantiating a new class each year, we're taking the input figure and inflating it by 2.83% each year (the average adjustment in the social rent formula data that we have)

This PR also cherry picks db33a69 just to get local deployment working. 

# Why?
We needed to forecast social rent over time for the lifetime comparison graph (see below)
![image](https://github.com/user-attachments/assets/8ced58e4-4f05-4d95-a105-920b99aa9a9a)
