### PR TITLE
feat: new `maintenanceCost` and `depreciatedHouseResaleValue` objects in `Lifetime`

### DIFF
--- a/app/components/graphs/ResaleValueWrapper.tsx
+++ b/app/components/graphs/ResaleValueWrapper.tsx
@@ -26,10 +26,10 @@ const ResaleValueWrapper: React.FC<ResaleValueWrapperProps> = ({
       
         chartData.push({
           year: i + 1,
-          none: landValue + lifetime[i].depreciatedHouseResaleValueNoMaintenance,
-          low: landValue + lifetime[i].depreciatedHouseResaleValueLowMaintenance,
-          medium: landValue + lifetime[i].depreciatedHouseResaleValueMediumMaintenance,
-          high: landValue + lifetime[i].depreciatedHouseResaleValueHighMaintenance
+          none: landValue + lifetime[i].depreciatedHouseResaleValue.none,
+          low: landValue + lifetime[i].depreciatedHouseResaleValue.low,
+          medium: landValue + lifetime[i].depreciatedHouseResaleValue.medium,
+          high: landValue + lifetime[i].depreciatedHouseResaleValue.high
         })
         
       }
@@ -40,7 +40,7 @@ const ResaleValueWrapper: React.FC<ResaleValueWrapperProps> = ({
 
     // We want a constant y value across the graphs so we can compare resale values between them
     const finalYear = household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1]
-    const maxY = Math.ceil((1.1 * (finalYear.fairholdLandPurchaseResaleValue + finalYear.depreciatedHouseResaleValueHighMaintenance)) / 100000) * 100000 // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred thousand to make things tidy
+    const maxY = Math.ceil((1.1 * (finalYear.fairholdLandPurchaseResaleValue + finalYear.depreciatedHouseResaleValue.high)) / 100000) * 100000 // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred thousand to make things tidy
 
     if (!household) {
       return <div>No household data available</div>;

--- a/app/models/Lifetime.test.ts
+++ b/app/models/Lifetime.test.ts
@@ -28,10 +28,10 @@ describe("resale values", () => {
         lifetime = createTestLifetime({
             property: createTestProperty({ age: 0 })
         });
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueNoMaintenance).toBe(186560);
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueLowMaintenance).toBe(186560);
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueMediumMaintenance).toBe(186560);
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueHighMaintenance).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.none).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.low).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.medium).toBe(186560);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.high).toBe(186560);
 
     });
     it("correctly calculates for a 10-year old house", () => {    // Test 10-year-old house
@@ -49,32 +49,32 @@ describe("resale values", () => {
             size: 88 
         })           
         const depreciatedHouseY10 = houseY10.calculateDepreciatedBuildPrice()
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueLowMaintenance).toBe(depreciatedHouseY10);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.low).toBe(depreciatedHouseY10);
     });
     it("depreciates the house over time", () => {
         // Test value changes over time
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueNoMaintenance).toBeGreaterThan(
-            lifetime.lifetimeData[10].depreciatedHouseResaleValueNoMaintenance);
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueLowMaintenance).toBeGreaterThan(
-            lifetime.lifetimeData[10].depreciatedHouseResaleValueLowMaintenance);
-        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValueMediumMaintenance).toBeGreaterThan(
-            lifetime.lifetimeData[10].depreciatedHouseResaleValueMediumMaintenance);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.none).toBeGreaterThan(
+            lifetime.lifetimeData[10].depreciatedHouseResaleValue.none);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.low).toBeGreaterThan(
+            lifetime.lifetimeData[10].depreciatedHouseResaleValue.low);
+        expect(lifetime.lifetimeData[0].depreciatedHouseResaleValue.medium).toBeGreaterThan(
+            lifetime.lifetimeData[10].depreciatedHouseResaleValue.medium);
         // depreciatedHouseResaleValueHighMaintenance isn't tested here because the addition of a major work causes price to rise
     })
 });
 
 it("correctly calculates depreciated house value for all maintenance levels", () => {
-    expect(lifetime.lifetimeData[3].depreciatedHouseResaleValueNoMaintenance).toBeCloseTo(173636.99)
-    expect(lifetime.lifetimeData[20].depreciatedHouseResaleValueLowMaintenance).toBeCloseTo(157202.92)
-    expect(lifetime.lifetimeData[27].depreciatedHouseResaleValueMediumMaintenance).toBeCloseTo(168197.27)
-    expect(lifetime.lifetimeData[39].depreciatedHouseResaleValueHighMaintenance).toBeCloseTo(203777.25) 
+    expect(lifetime.lifetimeData[3].depreciatedHouseResaleValue.none).toBeCloseTo(173636.99)
+    expect(lifetime.lifetimeData[20].depreciatedHouseResaleValue.low).toBeCloseTo(157202.92)
+    expect(lifetime.lifetimeData[27].depreciatedHouseResaleValue.medium).toBeCloseTo(168197.27)
+    expect(lifetime.lifetimeData[39].depreciatedHouseResaleValue.high).toBeCloseTo(203777.25) 
 
-    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValueNoMaintenance).toBeLessThan(
-        lifetime.lifetimeData[5].depreciatedHouseResaleValueLowMaintenance);
-    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValueLowMaintenance).toBeLessThan(
-        lifetime.lifetimeData[5].depreciatedHouseResaleValueMediumMaintenance);
-    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValueMediumMaintenance).toBeLessThan(
-        lifetime.lifetimeData[5].depreciatedHouseResaleValueHighMaintenance);
+    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValue.none).toBeLessThan(
+        lifetime.lifetimeData[5].depreciatedHouseResaleValue.low);
+    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValue.low).toBeLessThan(
+        lifetime.lifetimeData[5].depreciatedHouseResaleValue.medium);
+    expect(lifetime.lifetimeData[5].depreciatedHouseResaleValue.medium).toBeLessThan(
+        lifetime.lifetimeData[5].depreciatedHouseResaleValue.high);
 })
 
 it("correctly ages the house", () => {

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -24,6 +24,18 @@ export interface LifetimeParams {
     incomeYearly: number;
 }
 
+export interface MaintenanceCosts {
+    low: number;
+    medium: number;
+    high: number;
+}
+
+export interface DepreciatedHouseByMaintenanceLevel {
+    none: number;
+    low: number;
+    medium: number;
+    high: number;
+}
 export interface LifetimeData {
     incomeYearly: number;
     affordabilityThresholdIncome: number;
@@ -32,17 +44,12 @@ export interface LifetimeData {
     fairholdLandMortgageYearly: number;
     marketLandMortgageYearly: number;
     fairholdLandRentYearly: number;
-    maintenanceCostLow: number;
-    maintenanceCostMedium: number;
-    maintenanceCostHigh: number;
+    maintenanceCost: MaintenanceCosts;
     marketLandRentYearly: number;
     marketHouseRentYearly: number;
     gasBillExistingBuildYearly: number;
     gasBillNewBuildOrRetrofitYearly: number;
-    depreciatedHouseResaleValueNoMaintenance: number;
-    depreciatedHouseResaleValueLowMaintenance: number;
-    depreciatedHouseResaleValueMediumMaintenance: number;
-    depreciatedHouseResaleValueHighMaintenance: number;
+    depreciatedHouseResaleValue: DepreciatedHouseByMaintenanceLevel;
     fairholdLandPurchaseResaleValue: number;
     houseAge: number;
     [key: number]: number;
@@ -140,15 +147,19 @@ export class Lifetime {
             fairholdLandMortgageYearly: fairholdLandMortgageYearlyIterative,
             marketLandMortgageYearly: marketLandMortgageYearlyIterative,
             fairholdLandRentYearly: fairholdLandRentIterative,
-            maintenanceCostLow: maintenanceCostLowIterative,
-            maintenanceCostMedium: maintenanceCostMediumIterative,
-            maintenanceCostHigh: maintenanceCostHighIterative,
+            maintenanceCost: {
+                low: maintenanceCostLowIterative,
+                medium: maintenanceCostMediumIterative,
+                high: maintenanceCostHighIterative
+            },
             marketLandRentYearly: marketRentLandYearlyIterative,
             marketHouseRentYearly: marketRentHouseYearlyIterative,
-            depreciatedHouseResaleValueNoMaintenance: depreciatedHouseResaleValueNoMaintenanceIterative,
-            depreciatedHouseResaleValueLowMaintenance: depreciatedHouseResaleValueLowMaintenanceIterative,
-            depreciatedHouseResaleValueMediumMaintenance: depreciatedHouseResaleValueMediumMaintenanceIterative,
-            depreciatedHouseResaleValueHighMaintenance: depreciatedHouseResaleValueHighMaintenanceIterative,
+            depreciatedHouseResaleValue: {
+                none: depreciatedHouseResaleValueNoMaintenanceIterative,
+                low: depreciatedHouseResaleValueLowMaintenanceIterative,
+                medium: depreciatedHouseResaleValueMediumMaintenanceIterative,
+                high: depreciatedHouseResaleValueHighMaintenanceIterative
+            },
             fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
             houseAge: houseAgeIterative,
             gasBillExistingBuildYearly: gasBillExistingBuildIterative,
@@ -252,15 +263,19 @@ export class Lifetime {
                 fairholdLandMortgageYearly: fairholdLandMortgageYearlyIterative,
                 marketLandMortgageYearly: marketLandMortgageYearlyIterative,
                 fairholdLandRentYearly: fairholdLandRentIterative,
-                maintenanceCostLow: maintenanceCostLowIterative,
-                maintenanceCostMedium: maintenanceCostMediumIterative,
-                maintenanceCostHigh: maintenanceCostHighIterative,
+                maintenanceCost: {
+                    low: maintenanceCostLowIterative,
+                    medium: maintenanceCostMediumIterative,
+                    high: maintenanceCostHighIterative
+                },
                 marketLandRentYearly: marketRentLandYearlyIterative,
                 marketHouseRentYearly: marketRentHouseYearlyIterative,
-                depreciatedHouseResaleValueNoMaintenance: depreciatedHouseResaleValueNoMaintenanceIterative,
-                depreciatedHouseResaleValueLowMaintenance: depreciatedHouseResaleValueLowMaintenanceIterative,
-                depreciatedHouseResaleValueMediumMaintenance: depreciatedHouseResaleValueMediumMaintenanceIterative,
-                depreciatedHouseResaleValueHighMaintenance: depreciatedHouseResaleValueHighMaintenanceIterative,
+                depreciatedHouseResaleValue: {
+                    none: depreciatedHouseResaleValueNoMaintenanceIterative,
+                    low: depreciatedHouseResaleValueLowMaintenanceIterative,
+                    medium: depreciatedHouseResaleValueMediumMaintenanceIterative,
+                    high: depreciatedHouseResaleValueHighMaintenanceIterative
+                },
                 fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
                 houseAge: houseAgeIterative,
                 gasBillExistingBuildYearly: gasBillExistingBuildIterative,


### PR DESCRIPTION
# What does this PR do?
Makes previous properties into objects to tidy up the `Lifetime` class

# Why?
Having multiple similar properties seemed verbose (eg `maintenanceCostLow`, `maintenanceCostMedium`, `maintenanceCostHigh`) but also placing them in objects with `MaintenanceType` type keys will make them easier to access elsewhere. This came up when working on graph 2, which is why I'm doing it now! 