### PR TITLE
feat: costs over lifetime graphs

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -2,14 +2,19 @@ import { useState } from "react";
 import GraphCard from "../../ui/GraphCard";
 import CostOverTimeWrapper, { TenureType } from "../../graphs/CostOverTimeWrapper";
 import { Drawer } from "../../ui/Drawer";
-import { Household } from "@/app/models/Household";
 import TenureSelector from "../../ui/TenureSelector";
+import { DashboardProps } from "../../ui/Dashboard";
 
-interface DashboardProps {
-  data: Household;
+const TENURES = ['marketPurchase', 'marketRent', 'fairholdLandPurchase', 'fairholdLandRent', 'socialRent'] as const
+const TENURE_LABELS = {
+  marketPurchase: 'Freehold',
+  marketRent: 'Private rent',
+  fairholdLandPurchase: 'Fairhold Land Purchase',
+  fairholdLandRent: 'Fairhold Land Rent',
+  socialRent: 'Social rent'
 }
 
-export const CostOverTime: React.FC<DashboardProps> = ({ data }) => {
+export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const [selectedTenure, setSelectedTenure] = useState<TenureType>('marketPurchase');
 
   return (
@@ -19,40 +24,19 @@ export const CostOverTime: React.FC<DashboardProps> = ({ data }) => {
     >
       <div className="flex flex-col h-full w-3/4 justify-between">
         <div className="flex gap-2 mb-4">
-          <TenureSelector 
-            isSelected={selectedTenure === 'marketPurchase'}
-            onClick={() => setSelectedTenure('marketPurchase')}
+        {TENURES.map(tenure => (
+          <TenureSelector
+            key={tenure}
+            isSelected={selectedTenure === tenure}
+            onClick={() => setSelectedTenure(tenure)}
           >
-            Market Purchase
+            {TENURE_LABELS[tenure]}
           </TenureSelector>
-          <TenureSelector 
-            isSelected={selectedTenure === 'marketRent'}
-            onClick={() => setSelectedTenure('marketRent')}
-          >
-            Market Rent
-          </TenureSelector>
-          <TenureSelector 
-            isSelected={selectedTenure === 'fairholdLandPurchase'}
-            onClick={() => setSelectedTenure('fairholdLandPurchase')}
-          >
-            Fairhold Land Purchase
-          </TenureSelector>
-          <TenureSelector 
-            isSelected={selectedTenure === 'fairholdLandRent'}
-            onClick={() => setSelectedTenure('fairholdLandRent')}
-          >
-            Fairhold Land Rent
-          </TenureSelector>
-          <TenureSelector 
-            isSelected={selectedTenure === 'socialRent'}
-            onClick={() => setSelectedTenure('socialRent')}
-          >
-            Social Rent
-          </TenureSelector>
+        ))}
         </div>
 
         <CostOverTimeWrapper 
-          household={data}
+          household={processedData}
           tenure={selectedTenure}
         />
 

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import GraphCard from "../../ui/GraphCard";
+import CostOverTimeWrapper, { TenureType } from "../../graphs/CostOverTimeWrapper";
+import { Drawer } from "../../ui/Drawer";
+import { Household } from "@/app/models/Household";
+import TenureSelector from "../../ui/TenureSelector";
+
+interface DashboardProps {
+  data: Household;
+}
+
+export const CostOverTime: React.FC<DashboardProps> = ({ data }) => {
+  const [selectedTenure, setSelectedTenure] = useState<TenureType>('marketPurchase');
+
+  return (
+    <GraphCard
+      title="How would the cost change over my life?"
+      subtitle="Over x years, the home would cost £y" // TODO: interpolate
+    >
+      <div className="flex flex-col h-full w-3/4 justify-between">
+        <div className="flex gap-2 mb-4">
+          <TenureSelector 
+            isSelected={selectedTenure === 'marketPurchase'}
+            onClick={() => setSelectedTenure('marketPurchase')}
+          >
+            Market Purchase
+          </TenureSelector>
+          <TenureSelector 
+            isSelected={selectedTenure === 'marketRent'}
+            onClick={() => setSelectedTenure('marketRent')}
+          >
+            Market Rent
+          </TenureSelector>
+          <TenureSelector 
+            isSelected={selectedTenure === 'fairholdLandPurchase'}
+            onClick={() => setSelectedTenure('fairholdLandPurchase')}
+          >
+            Fairhold Land Purchase
+          </TenureSelector>
+          <TenureSelector 
+            isSelected={selectedTenure === 'fairholdLandRent'}
+            onClick={() => setSelectedTenure('fairholdLandRent')}
+          >
+            Fairhold Land Rent
+          </TenureSelector>
+          <TenureSelector 
+            isSelected={selectedTenure === 'socialRent'}
+            onClick={() => setSelectedTenure('socialRent')}
+          >
+            Social Rent
+          </TenureSelector>
+        </div>
+
+        <CostOverTimeWrapper 
+          household={data}
+          tenure={selectedTenure}
+        />
+
+        <Drawer
+          buttonTitle="Find out more about how we calculated these"
+          title="How we calculated these figures"
+          description="..."
+        />
+      </div>
+    </GraphCard>
+  );
+};

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend, Tooltip } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export interface LifetimeBarData {
+  year: number;
+  land: number;
+  house: number;
+  maintenance?: number;
+}
+
+  interface CostOverTimeStackedBarChartProps {
+    data: LifetimeBarData[];
+    config: {
+      colors: {
+        land: string;
+        house: string;
+        maintenance?: string;
+      };
+      showMaintenance: boolean;
+    };
+  }
+
+const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = ({
+  data,
+  config
+}) => {
+    const chartConfig: Record<string, { label: string; color: string }> = { // LINE CHANGED
+        land: {
+          label: "Land",
+          color: config.colors.land,
+        },
+        house: {
+          label: "House",
+          color: config.colors.house,
+        },
+      };
+    
+      if (config.colors.maintenance) { // LINE CHANGED
+        chartConfig.maintenance = { // LINE CHANGED
+          label: "Maintenance", // LINE CHANGED
+          color: config.colors.maintenance, // LINE CHANGED
+        }; // LINE CHANGED
+      }
+  return (
+    <Card>
+      <CardContent>
+        <ChartContainer config={chartConfig}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="year" />
+            <YAxis />
+            <Tooltip content={<ChartTooltipContent />} />
+            <Legend />
+            
+            <Bar dataKey="land" stackId="a" fill={config.colors.land} name="Land" />
+            <Bar dataKey="house" stackId="a" fill={config.colors.house} name="House" />
+            {config.showMaintenance && config.colors.maintenance && (
+              <Bar 
+                dataKey="maintenance" 
+                stackId="a" 
+                fill={config.colors.maintenance} 
+                name="Maintenance" 
+              />
+            )}
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CostOverTimeStackedBarChart

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -16,6 +16,7 @@ export interface LifetimeBarData {
 
   interface CostOverTimeStackedBarChartProps {
     data: LifetimeBarData[];
+    maxY: number;
     config: {
       colors: {
         land: string;
@@ -24,10 +25,12 @@ export interface LifetimeBarData {
       };
       showMaintenance: boolean;
     };
+
   }
 
 const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = ({
   data,
+  maxY,
   config
 }) => {
     const chartConfig: Record<string, { label: string; color: string }> = { // LINE CHANGED
@@ -54,7 +57,8 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
           <BarChart data={data}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="year" />
-            <YAxis />
+            <YAxis 
+              domain={[0, maxY]}/>
             <Tooltip content={<ChartTooltipContent />} />
             <Legend />
             

--- a/app/components/graphs/CostOverTimeWrapper.tsx
+++ b/app/components/graphs/CostOverTimeWrapper.tsx
@@ -11,17 +11,17 @@ const TENURE_COLORS = {
     marketPurchase: {
       land: "rgb(var(--freehold-land-color-rgb))",
       house: "rgb(var(--freehold-house-color-rgb))",
-      maintenance: "rgb(var(--maintenance-color-rgb))",
+      maintenance: "rgb(var(--freehold-maintenance-color-rgb))",
     },
     fairholdLandPurchase: {
       land: "rgb(var(--fairhold-land-color-rgb))",
       house: "rgb(var(--fairhold-house-color-rgb))",
-      maintenance: "rgb(var(--maintenance-color-rgb))",
+      maintenance: "rgb(var(--fairhold-maintenance-color-rgb))",
     },
     fairholdLandRent: {
       land: "rgb(var(--fairhold-land-color-rgb))",
       house: "rgb(var(--fairhold-house-color-rgb))",
-      maintenance: "rgb(var(--maintenance-color-rgb))",
+      maintenance: "rgb(var(--fairhold-maintenance-color-rgb))",
     },
     marketRent: {
       land: "rgb(var(--private-rent-land-color-rgb))",

--- a/app/components/graphs/CostOverTimeWrapper.tsx
+++ b/app/components/graphs/CostOverTimeWrapper.tsx
@@ -1,0 +1,105 @@
+"use client";
+import React from "react";
+import ErrorBoundary from "../ErrorBoundary";
+import { Household } from "@/app/models/Household";
+import CostOverTimeStackedBarChart, { LifetimeBarData } from "./CostOverTimeStackedBarChart";
+import { MaintenanceLevel } from "@/app/models/constants";
+
+export type TenureType = 'marketPurchase' | 'fairholdLandPurchase' | 'fairholdLandRent' | 'marketRent' | 'socialRent';
+
+const TENURE_COLORS = {
+    marketPurchase: {
+      land: "rgb(var(--freehold-land-color-rgb))",
+      house: "rgb(var(--freehold-house-color-rgb))",
+      maintenance: "rgb(var(--maintenance-color-rgb))",
+    },
+    fairholdLandPurchase: {
+      land: "rgb(var(--fairhold-land-color-rgb))",
+      house: "rgb(var(--fairhold-house-color-rgb))",
+      maintenance: "rgb(var(--maintenance-color-rgb))",
+    },
+    fairholdLandRent: {
+      land: "rgb(var(--fairhold-land-color-rgb))",
+      house: "rgb(var(--fairhold-house-color-rgb))",
+      maintenance: "rgb(var(--maintenance-color-rgb))",
+    },
+    marketRent: {
+      land: "rgb(var(--private-rent-land-color-rgb))",
+      house: "rgb(var(--private-rent-house-color-rgb))",
+    },
+    socialRent: {
+      land: "rgb(var(--social-rent-land-color-rgb))",
+      house: "rgb(var(--social-rent-house-color-rgb))",
+    }
+  } as const;
+interface CostOverTimeWrapperProps {
+    tenure: TenureType;
+    household: Household;
+}
+
+const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
+    tenure,
+    household
+}) => {
+    const formatData = (tenure: TenureType, household: Household, maintenanceLevel: MaintenanceLevel): LifetimeBarData[] => {
+        const lifetimeData = household.lifetime.lifetimeData;
+
+        return lifetimeData.map((yearData, index) => {
+            switch (tenure) {
+                case 'marketPurchase': 
+                    return {
+                        year: index,
+                        land: yearData.marketLandMortgageYearly,
+                        house: yearData.newbuildHouseMortgageYearly,
+                        maintenance: yearData.maintenanceCost[maintenanceLevel]
+                    }
+                case 'marketRent':
+                    return {
+                        year: index,
+                        land: yearData.marketLandRentYearly,
+                        house: yearData.marketHouseRentYearly,
+                    };                
+                case 'fairholdLandPurchase':
+                    return {
+                        year: index,
+                        land: yearData.fairholdLandMortgageYearly,
+                        house: yearData.depreciatedHouseMortgageYearly,
+                        maintenance: yearData.maintenanceCost[maintenanceLevel]
+                    }
+                case 'fairholdLandRent':
+                    return {
+                        year: index,
+                        land: yearData.fairholdLandRentYearly,
+                        house: yearData.depreciatedHouseMortgageYearly,
+                        maintenance: yearData.maintenanceCost[maintenanceLevel]
+                    }
+                case 'socialRent':
+                    return {
+                        year: index,
+                        land: yearData.socialRentLandYearly,
+                        house: yearData.socialRentHouseYearly
+                    }
+            }
+        })
+        
+    }
+    const chartConfig = {
+        colors: TENURE_COLORS[tenure],
+        showMaintenance: ['marketPurchase', 'fairholdLandPurchase', 'fairholdLandRent'].includes(tenure)
+    }
+
+    const maintenanceLevel = household.property.maintenanceLevel
+
+    const formattedData = formatData(tenure, household, maintenanceLevel);
+
+    return (
+        <ErrorBoundary>
+      <CostOverTimeStackedBarChart 
+        data={formattedData}
+        config={chartConfig}
+      />
+    </ErrorBoundary>
+    )
+};
+
+export default CostOverTimeWrapper;

--- a/app/components/graphs/CostOverTimeWrapper.tsx
+++ b/app/components/graphs/CostOverTimeWrapper.tsx
@@ -91,12 +91,17 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
     const maintenanceLevel = household.property.maintenanceLevel
 
     const formattedData = formatData(tenure, household, maintenanceLevel);
+    
+    // We want a constant y value across the graphs so we can compare costs between them
+    const firstYear = household.lifetime.lifetimeData[0]
+    const maxY = Math.ceil((1 * (firstYear.marketLandMortgageYearly + firstYear.newbuildHouseMortgageYearly)) / 100000) * 100000 // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred thousand to make things tidy
 
     return (
         <ErrorBoundary>
       <CostOverTimeStackedBarChart 
         data={formattedData}
         config={chartConfig}
+        maxY={maxY}
       />
     </ErrorBoundary>
     )

--- a/app/components/graphs/TenureComparisonBarChart.tsx
+++ b/app/components/graphs/TenureComparisonBarChart.tsx
@@ -41,7 +41,7 @@ const TenureComparisonBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
       land: data[0].marketRent,
       house: data[1].marketRent,
       monthly: data[0].marketRent + data[1].marketRent,
-      fill: "rgb(var(--private-rent-color-rgb))",
+      fill: "rgb(var(--private-rent-land-color-rgb))",
     },
 
     {
@@ -64,7 +64,7 @@ const TenureComparisonBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
       land: data[0].socialRent,
       house: data[1].socialRent,
       monthly: data[0].socialRent + data[1].socialRent,
-      fill: "rgb(var(--social-rent-color-rgb))",
+      fill: "rgb(var(--social-rent-land-color-rgb))",
     },
   ];
 

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -7,7 +7,7 @@ import Dashboard from "./Dashboard";
 import { formSchema, FormFrontend } from "@/app/schemas/formSchema";
 import { useSearchParams } from "next/navigation";
 import { DEFAULT_INTEREST_RATE, DEFAULT_MORTGAGE_TERM, DEFAULT_INITIAL_DEPOSIT, MAINTENANCE_LEVELS } from "../../models/constants"
-import type { MaintenanceLevel } from "../../models/constants";
+import { MaintenanceLevel } from "../../models/constants";
 
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { ClipLoader } from "react-spinners";
@@ -273,13 +273,13 @@ const CalculatorInput = () => {
 
                   <FormControl>
                     <RadioGroup
-                      value={String(field.value)} // Convert number to string for RadioGroup
-                      onValueChange={(value) => field.onChange(Number(value))} // Convert back to number for form
+                      value={field.value}
+                      onValueChange={field.onChange}
                       className="flex space-x-4"
                     >
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS.low.toString()}
+                          value="low"
                           id="radio-option-low"
                           className="radio-button-style"
                         />
@@ -292,7 +292,7 @@ const CalculatorInput = () => {
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS.medium.toString()}
+                          value="medium"
                           id="radio-option-medium"
                           className="radio-button-style"
                         />
@@ -305,7 +305,7 @@ const CalculatorInput = () => {
                       </div>
                       <div className="flex items-center space-x-2">
                         <RadioGroupItem
-                          value={MAINTENANCE_LEVELS.high.toString()}
+                          value="high"
                           id="radio-option-high"
                           className="radio-button-style"
                         />

--- a/app/components/ui/Dashboard.tsx
+++ b/app/components/ui/Dashboard.tsx
@@ -11,7 +11,7 @@ import { CostOverTime } from "../Dashboard/Cards/CostOverTime";
 
 export interface DashboardProps {
   processedData: Household;
-  inputData: FormFrontend;
+  inputData?: FormFrontend;
 }
 
 const Dashboard: React.FC<DashboardProps> = ({ inputData, processedData }) => {
@@ -39,7 +39,7 @@ const Dashboard: React.FC<DashboardProps> = ({ inputData, processedData }) => {
       >
         <HowMuchFHCost data={processedData} />
         <HowMuchPerMonth processedData={processedData} />
-        <CostOverTime data={processedData} />
+        <CostOverTime processedData={processedData} />
         <ResaleValue data={processedData} />
         <WhatDifference />
         <WhatWouldYouChoose />

--- a/app/components/ui/Dashboard.tsx
+++ b/app/components/ui/Dashboard.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from "react";
-import GraphCard from "./GraphCard";
 import { Household } from "@/app/models/Household";
 import { FormFrontend } from "@/app/schemas/formSchema";
 import { WhatWouldYouChoose } from "../Dashboard/Cards/WhatWouldYouChoose";
@@ -8,6 +7,7 @@ import { HowMuchFHCost } from "../Dashboard/Cards/HowMuchFHCost";
 import { Carousel } from "./Carousel";
 import { HowMuchPerMonth } from "../Dashboard/Cards/HowMuchPerMonth";
 import { ResaleValue } from "../Dashboard/Cards/ResaleValue";
+import { CostOverTime } from "../Dashboard/Cards/CostOverTime";
 
 export interface DashboardProps {
   processedData: Household;
@@ -39,7 +39,7 @@ const Dashboard: React.FC<DashboardProps> = ({ inputData, processedData }) => {
       >
         <HowMuchFHCost data={processedData} />
         <HowMuchPerMonth processedData={processedData} />
-        <GraphCard title="How would the cost change over my life?"></GraphCard>
+        <CostOverTime data={processedData} />
         <ResaleValue data={processedData} />
         <WhatDifference />
         <WhatWouldYouChoose />

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,14 +15,14 @@
 
   --freehold-land-color-rgb: 66 75 179;
   --freehold-house-color-rgb: 131 164 255;
+  --freehold-maintenance-color-rgb: 190 201 232;
   --fairhold-land-color-rgb: 74 179 91;
   --fairhold-house-color-rgb: 159 211 166;
-  --fairhold-house-alpha: 0.5;
+  --fairhold-maintenance-color-rgb: 207 227 209;
   --private-rent-land-color-rgb: 45 155 240;
   --private-rent-house-color-rgb: 119 188 242;
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
-  --maintenance-color-rgb: 184 184 184;
 }
 
 @layer utilities {

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,9 +18,11 @@
   --fairhold-land-color-rgb: 74 179 91;
   --fairhold-house-color-rgb: 159 211 166;
   --fairhold-house-alpha: 0.5;
-  --private-rent-color-rgb: 131 164 255;
-  --affordable-rent-color-rgb: 255 97 118 0.5;
-  --social-rent-color-rgb: 255, 97, 118;
+  --private-rent-land-color-rgb: 45 155 240;
+  --private-rent-house-color-rgb: 74 179 91 0.5;
+  --social-rent-land-color-rgb: 255, 97, 118;
+  --social-rent-house-color-rgb: 242, 160, 171;
+  --maintenance-color-rgb: 245, 245, 245;
 }
 
 @layer utilities {

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,10 +19,10 @@
   --fairhold-house-color-rgb: 159 211 166;
   --fairhold-house-alpha: 0.5;
   --private-rent-land-color-rgb: 45 155 240;
-  --private-rent-house-color-rgb: 74 179 91 0.5;
-  --social-rent-land-color-rgb: 255, 97, 118;
-  --social-rent-house-color-rgb: 242, 160, 171;
-  --maintenance-color-rgb: 245, 245, 245;
+  --private-rent-house-color-rgb: 119 188 242;
+  --social-rent-land-color-rgb: 255 97 118;
+  --social-rent-house-color-rgb: 242 160 171;
+  --maintenance-color-rgb: 184 184 184;
 }
 
 @layer utilities {

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -5,7 +5,7 @@ import { FairholdLandPurchase } from "./tenure/FairholdLandPurchase";
 import { FairholdLandRent } from "./tenure/FairholdLandRent";
 import { Fairhold } from "./Fairhold";
 import { Property } from "./Property";
-import { MONTHS_PER_YEAR, MAINTENANCE_LEVELS, MaintenanceLevel } from "./constants";
+import { MONTHS_PER_YEAR, MAINTENANCE_LEVELS, MaintenanceLevel, SOCIAL_RENT_ADJUSTMENT_FORECAST } from "./constants";
 
 export interface LifetimeParams {
     household: Household;
@@ -265,8 +265,8 @@ export class Lifetime {
             }).discountedLandPriceOrRent;
 
             // Increase monthly social rent by the average inflation adjustment (2.83%)
-            socialRentHouseYearlyIterative *= 1.0283; // TODO: decide if this is the best way to increase social rent or if we should preserve the changing land-house ratio as land costs inflate
-            socialRentLandYearlyIterative *= 1.0283;
+            socialRentHouseYearlyIterative *= SOCIAL_RENT_ADJUSTMENT_FORECAST;
+            socialRentLandYearlyIterative *= SOCIAL_RENT_ADJUSTMENT_FORECAST;
             
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -25,6 +25,7 @@ export interface LifetimeParams {
 }
 
 export interface MaintenanceCosts {
+    none: 0;
     low: number;
     medium: number;
     high: number;
@@ -153,6 +154,7 @@ export class Lifetime {
             marketLandMortgageYearly: marketLandMortgageYearlyIterative,
             fairholdLandRentYearly: fairholdLandRentIterative,
             maintenanceCost: {
+                none: 0,
                 low: maintenanceCostLowIterative,
                 medium: maintenanceCostMediumIterative,
                 high: maintenanceCostHighIterative
@@ -275,6 +277,7 @@ export class Lifetime {
                 marketLandMortgageYearly: marketLandMortgageYearlyIterative,
                 fairholdLandRentYearly: fairholdLandRentIterative,
                 maintenanceCost: {
+                    none: 0,
                     low: maintenanceCostLowIterative,
                     medium: maintenanceCostMediumIterative,
                     high: maintenanceCostHighIterative

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -51,8 +51,8 @@ export interface LifetimeData {
     gasBillNewBuildOrRetrofitYearly: number;
     depreciatedHouseResaleValue: DepreciatedHouseByMaintenanceLevel;
     fairholdLandPurchaseResaleValue: number;
-    socialRentMonthlyLand: number;
-    socialRentMonthlyHouse: number;
+    socialRentYearlyLand: number;
+    socialRentYearlyHouse: number;
     houseAge: number;
     [key: number]: number;
 }
@@ -118,8 +118,8 @@ export class Lifetime {
 
         /** Resale value increases with `ForecastParameters.constructionPriceGrowthPerYear` */
         let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
-        let socialRentMonthlyLandIterative = params.household.tenure.socialRent.socialRentMonthlyLand; 
-        let socialRentMonthlyHouseIterative = params.household.tenure.socialRent.socialRentMonthlyHouse;
+        let socialRentYearlyLandIterative = params.household.tenure.socialRent.socialRentMonthlyLand * 12; 
+        let socialRentYearlyHouseIterative = params.household.tenure.socialRent.socialRentMonthlyHouse * 12;
         
         /** Initialises as user input house age and increments by one */
         let houseAgeIterative = params.property.age;
@@ -166,8 +166,8 @@ export class Lifetime {
                 high: depreciatedHouseResaleValueHighMaintenanceIterative
             },
             fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
-            socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
-            socialRentMonthlyLand: socialRentMonthlyLandIterative,
+            socialRentYearlyHouse: socialRentYearlyHouseIterative,
+            socialRentYearlyLand: socialRentYearlyLandIterative,
             houseAge: houseAgeIterative,
             gasBillExistingBuildYearly: gasBillExistingBuildIterative,
             gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative
@@ -263,8 +263,8 @@ export class Lifetime {
             }).discountedLandPriceOrRent;
 
             // Increase monthly social rent by the average inflation adjustment (2.83%)
-            socialRentMonthlyHouseIterative *= 1.0283;
-            socialRentMonthlyLandIterative *= 1.0283;
+            socialRentYearlyHouseIterative *= 1.0283;
+            socialRentYearlyLandIterative *= 1.0283;
             
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,
@@ -288,8 +288,8 @@ export class Lifetime {
                     high: depreciatedHouseResaleValueHighMaintenanceIterative
                 },
                 fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
-                socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
-                socialRentMonthlyLand: socialRentMonthlyLandIterative,
+                socialRentYearlyHouse: socialRentYearlyHouseIterative,
+                socialRentYearlyLand: socialRentYearlyLandIterative,
                 houseAge: houseAgeIterative,
                 gasBillExistingBuildYearly: gasBillExistingBuildIterative,
                 gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -51,6 +51,8 @@ export interface LifetimeData {
     gasBillNewBuildOrRetrofitYearly: number;
     depreciatedHouseResaleValue: DepreciatedHouseByMaintenanceLevel;
     fairholdLandPurchaseResaleValue: number;
+    socialRentMonthlyLand: number;
+    socialRentMonthlyHouse: number;
     houseAge: number;
     [key: number]: number;
 }
@@ -116,6 +118,9 @@ export class Lifetime {
 
         /** Resale value increases with `ForecastParameters.constructionPriceGrowthPerYear` */
         let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
+        let socialRentMonthlyLandIterative = params.household.tenure.socialRent.socialRentMonthlyLand; 
+        let socialRentMonthlyHouseIterative = params.household.tenure.socialRent.socialRentMonthlyHouse;
+        
         /** Initialises as user input house age and increments by one */
         let houseAgeIterative = params.property.age;
 
@@ -161,6 +166,8 @@ export class Lifetime {
                 high: depreciatedHouseResaleValueHighMaintenanceIterative
             },
             fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
+            socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
+            socialRentMonthlyLand: socialRentMonthlyLandIterative,
             houseAge: houseAgeIterative,
             gasBillExistingBuildYearly: gasBillExistingBuildIterative,
             gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative
@@ -254,6 +261,10 @@ export class Lifetime {
                 affordability: marketRentAffordabilityIterative,
                 landPriceOrRent: marketRentLandYearlyIterative,
             }).discountedLandPriceOrRent;
+
+            // Increase monthly social rent by the average inflation adjustment (2.83%)
+            socialRentMonthlyHouseIterative *= 1.0283;
+            socialRentMonthlyLandIterative *= 1.0283;
             
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,
@@ -277,6 +288,8 @@ export class Lifetime {
                     high: depreciatedHouseResaleValueHighMaintenanceIterative
                 },
                 fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
+                socialRentMonthlyHouse: socialRentMonthlyHouseIterative,
+                socialRentMonthlyLand: socialRentMonthlyLandIterative,
                 houseAge: houseAgeIterative,
                 gasBillExistingBuildYearly: gasBillExistingBuildIterative,
                 gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -51,8 +51,8 @@ export interface LifetimeData {
     gasBillNewBuildOrRetrofitYearly: number;
     depreciatedHouseResaleValue: DepreciatedHouseByMaintenanceLevel;
     fairholdLandPurchaseResaleValue: number;
-    socialRentYearlyLand: number;
-    socialRentYearlyHouse: number;
+    socialRentLandYearly: number;
+    socialRentHouseYearly: number;
     houseAge: number;
     [key: number]: number;
 }
@@ -118,8 +118,8 @@ export class Lifetime {
 
         /** Resale value increases with `ForecastParameters.constructionPriceGrowthPerYear` */
         let fairholdLandPurchaseResaleValueIterative = params.fairholdLandPurchase.discountedLandPrice;
-        let socialRentYearlyLandIterative = params.household.tenure.socialRent.socialRentMonthlyLand * 12; 
-        let socialRentYearlyHouseIterative = params.household.tenure.socialRent.socialRentMonthlyHouse * 12;
+        let socialRentLandYearlyIterative = params.household.tenure.socialRent.socialRentMonthlyLand * 12; 
+        let socialRentHouseYearlyIterative = params.household.tenure.socialRent.socialRentMonthlyHouse * 12;
         
         /** Initialises as user input house age and increments by one */
         let houseAgeIterative = params.property.age;
@@ -166,8 +166,8 @@ export class Lifetime {
                 high: depreciatedHouseResaleValueHighMaintenanceIterative
             },
             fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
-            socialRentYearlyHouse: socialRentYearlyHouseIterative,
-            socialRentYearlyLand: socialRentYearlyLandIterative,
+            socialRentHouseYearly: socialRentHouseYearlyIterative,
+            socialRentLandYearly: socialRentLandYearlyIterative,
             houseAge: houseAgeIterative,
             gasBillExistingBuildYearly: gasBillExistingBuildIterative,
             gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative
@@ -263,8 +263,8 @@ export class Lifetime {
             }).discountedLandPriceOrRent;
 
             // Increase monthly social rent by the average inflation adjustment (2.83%)
-            socialRentYearlyHouseIterative *= 1.0283;
-            socialRentYearlyLandIterative *= 1.0283;
+            socialRentHouseYearlyIterative *= 1.0283; // TODO: decide if this is the best way to increase social rent or if we should preserve the changing land-house ratio as land costs inflate
+            socialRentLandYearlyIterative *= 1.0283;
             
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,
@@ -288,8 +288,8 @@ export class Lifetime {
                     high: depreciatedHouseResaleValueHighMaintenanceIterative
                 },
                 fairholdLandPurchaseResaleValue: fairholdLandPurchaseResaleValueIterative,
-                socialRentYearlyHouse: socialRentYearlyHouseIterative,
-                socialRentYearlyLand: socialRentYearlyLandIterative,
+                socialRentHouseYearly: socialRentHouseYearlyIterative,
+                socialRentLandYearly: socialRentLandYearlyIterative,
                 houseAge: houseAgeIterative,
                 gasBillExistingBuildYearly: gasBillExistingBuildIterative,
                 gasBillNewBuildOrRetrofitYearly: gasBillNewBuildOrRetrofitIterative

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -22,6 +22,8 @@ export const BED_WEIGHTS_AND_CAPS: BedWeightsAndCaps = {
   socialRentCap: [155.73, 155.73, 164.87, 174.03, 183.18, 192.35, 201.5],
 };
 
+export const SOCIAL_RENT_ADJUSTMENT_FORECAST = 1.0283  // TODO: decide if this is the best way to increase social rent or if we should preserve the changing land-house ratio as land costs inflate
+
 export type NationalAverage = {
   socialRentWeekly: number;
   propertyValue: number;


### PR DESCRIPTION
# What's new in this PR?
- Calculates social rent over lifetime (I closed #292 because I needed this functionality in this PR)
- Components for CostOverTime chart, wrapper and card 
- Adds CostOverTime graph to the dashboard
- Updated colours for house values too

886cdee is a cherry-pick of #291 which I needed to fix an error. Unsure what the best git practice should have been here! 