### PR TITLE
feat: add gas object to Household

### DIFF
--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -165,9 +165,4 @@ export class Household {
       const gasBillExistingBuildYearly = this.kwhCostPence * kwhYearly / 100
       return gasBillExistingBuildYearly
     }
-
-    private calculateGasBillNewBuildOrRetrofit() {
-      const gasBillNewBuildOrRetrofitYearly = this.kwhCostPence * this.gasDemand.kwhNewBuildOrRetrofitYearly / 100
-      return gasBillNewBuildOrRetrofitYearly
-    }
   }

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -146,23 +146,23 @@ export class Household {
     }
 
     private calculateGasDemand(params: ConstructorParams) {
-      return {
-        kwhExistingBuildYearly: this.calculateKwh(params, "existingBuild"),
-        kwhNewBuildOrRetrofitYearly: this.calculateKwh(params, "newBuild"),
-        billExistingBuildYearly: this.calculateGasBill("existingBuild"),
-        billNewBuildOrRetrofitYearly: this.calculateGasBill("newBuild")
+      const kwhExistingBuildYearly = this.calculateKwhExistingBuildYearly(params);
+      const kwhNewBuildOrRetrofitYearly = this.calculateKwhNewBuildOrRetrofitYearly(params);
+        return {
+          kwhExistingBuildYearly,
+          kwhNewBuildOrRetrofitYearly,
+          billExistingBuildYearly: this.kwhCostPence * kwhExistingBuildYearly / 100,
+          billNewBuildOrRetrofitYearly: this.kwhCostPence * kwhNewBuildOrRetrofitYearly / 100
       }
       }
 
-    private calculateKwh(params: ConstructorParams, newOrExisting: string) {
-      const kwhM2 = newOrExisting === "existingBuild" ? KWH_M2_YR_EXISTING_BUILDS : KWH_M2_YR_NEWBUILDS_RETROFIT
-      const kwhYearly = params.property.size * kwhM2[params.property.houseType]
+    private calculateKwhExistingBuildYearly(params: ConstructorParams) {
+      const kwhYearly = params.property.size * KWH_M2_YR_EXISTING_BUILDS[params.property.houseType]
       return kwhYearly
     }
-    
-    private calculateGasBill(newOrExisting: string) {
-      const kwhYearly = newOrExisting === "existingBuild" ? this.gasDemand.kwhExistingBuildYearly : this.gasDemand.kwhNewBuildOrRetrofitYearly
-      const gasBillExistingBuildYearly = this.kwhCostPence * kwhYearly / 100
-      return gasBillExistingBuildYearly
+
+    private calculateKwhNewBuildOrRetrofitYearly(params: ConstructorParams) {
+      const kwhYearly = params.property.size * KWH_M2_YR_NEWBUILDS_RETROFIT[params.property.houseType]
+      return kwhYearly
     }
   }

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -38,11 +38,11 @@ export class Household {
     fairholdLandRent: FairholdLandRent;
   };
   public lifetime: Lifetime;
-  public gasDemand = {
-    kwhExistingBuildYearly: 0,
-    kwhNewBuildOrRetrofitYearly: 0,
-    billExistingBuildYearly: 0,
-    billNewBuildOrRetrofitYearly: 0
+  public gasDemand: {
+    kwhExistingBuildYearly: number;
+    kwhNewBuildOrRetrofitYearly: number;
+    billExistingBuildYearly: number;
+    billNewBuildOrRetrofitYearly: number;
   }
 
   constructor(params: ConstructorParams) {

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -125,8 +125,8 @@ export class Lifetime {
         /** Initialises as user input house age and increments by one */
         let houseAgeIterative = params.property.age;
 
-        let gasBillExistingBuildIterative = params.household.gasBillExistingBuildYearly;
-        let gasBillNewBuildOrRetrofitIterative = params.household.gasBillNewBuildOrRetrofitYearly;
+        let gasBillExistingBuildIterative = params.household.gasDemand.billExistingBuildYearly;
+        let gasBillNewBuildOrRetrofitIterative = params.household.gasDemand.billNewBuildOrRetrofitYearly;
 
         // Initialise mortgage variables
         /** Assuming a constant interest rate, this figures stays the same until the mortgage term (`marketPurchase.houseMortgage.termYears`) is reached */


### PR DESCRIPTION
When working on social value, I found we needed to access the kwh demand figure from `Household`, so this PR refactors `Household` to store those values in a new `gasDemand` object property and makes its methods more concise too. 