### PR TITLE
feat: split mortgage payments into principal repayment (equity) and interest

### DIFF
--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -8,9 +8,10 @@ import {
 } from "@/components/ui/chart";
 
 export interface LifetimeBarData {
-  year: number;
-  land: number;
-  house: number;
+  landRent?: number;
+  equity?: number;
+  interest?: number;
+  rent?: number;
   maintenance?: number;
 }
 
@@ -19,13 +20,14 @@ export interface LifetimeBarData {
     maxY: number;
     config: {
       colors: {
-        land: string;
-        house: string;
+        landRent?: string;
+        equity?: string;
+        interest?: string;
+        rent?: string;
         maintenance?: string;
       };
-      showMaintenance: boolean;
+      // showMaintenance: boolean;
     };
-
   }
 
 const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = ({
@@ -33,23 +35,43 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
   maxY,
   config
 }) => {
-    const chartConfig: Record<string, { label: string; color: string }> = { // LINE CHANGED
-        land: {
-          label: "Land",
-          color: config.colors.land,
-        },
-        house: {
-          label: "House",
-          color: config.colors.house,
-        },
-      };
+  const chartConfig: Record<string, { label: string; color: string }> = {}; 
     
-      if (config.colors.maintenance) { // LINE CHANGED
-        chartConfig.maintenance = { // LINE CHANGED
-          label: "Maintenance", // LINE CHANGED
-          color: config.colors.maintenance, // LINE CHANGED
-        }; // LINE CHANGED
-      }
+  if (config.colors.landRent) { 
+    chartConfig.landRent = { 
+      label: "Land Rent", 
+      color: config.colors.landRent, 
+    }; 
+  }
+
+  if (config.colors.equity) { 
+    chartConfig.equity = { 
+      label: "Equity", 
+      color: config.colors.equity, 
+    }; 
+  }
+
+  if (config.colors.interest) { 
+    chartConfig.interest = { 
+      label: "Interest", 
+      color: config.colors.interest, 
+    }; 
+  }
+
+  if (config.colors.rent) { 
+    chartConfig.rent = { 
+      label: "Rent", 
+      color: config.colors.rent, 
+    }; 
+  }
+
+  if (config.colors.maintenance) { 
+    chartConfig.maintenance = { 
+      label: "Maintenance", 
+      color: config.colors.maintenance, 
+    }; 
+  }
+
   return (
     <Card>
       <CardContent>
@@ -62,15 +84,20 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
             <Tooltip content={<ChartTooltipContent />} />
             <Legend />
             
-            <Bar dataKey="land" stackId="a" fill={config.colors.land} name="Land" />
-            <Bar dataKey="house" stackId="a" fill={config.colors.house} name="House" />
-            {config.showMaintenance && config.colors.maintenance && (
-              <Bar 
-                dataKey="maintenance" 
-                stackId="a" 
-                fill={config.colors.maintenance} 
-                name="Maintenance" 
-              />
+            {config.colors.landRent && ( 
+              <Bar dataKey="landRent" stackId="a" fill={config.colors.landRent} name="Land Rent" /> 
+            )}
+            {config.colors.equity && ( 
+              <Bar dataKey="equity" stackId="a" fill={config.colors.equity} name="Equity" /> 
+            )}
+            {config.colors.interest && ( 
+              <Bar dataKey="interest" stackId="a" fill={config.colors.interest} name="Interest" /> 
+            )}
+            {config.colors.rent && ( 
+              <Bar dataKey="rent" stackId="a" fill={config.colors.rent} name="Rent" /> 
+            )}
+            {config.colors.maintenance && (
+              <Bar dataKey="maintenance" stackId="a" fill={config.colors.maintenance} name="Maintenance" />
             )}
           </BarChart>
         </ChartContainer>

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -4,8 +4,10 @@ import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend, Tooltip } from "rec
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartContainer,
-  ChartTooltipContent,
 } from "@/components/ui/chart";
+import { TooltipProps } from "recharts";
+import { ValueType } from "tailwindcss/types/config";
+import { NameType } from "recharts/types/component/DefaultTooltipContent";
 
 export interface LifetimeBarData {
   landRent?: number;
@@ -14,6 +16,24 @@ export interface LifetimeBarData {
   rent?: number;
   maintenance?: number;
 }
+
+const CostOverTimeTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+  if (!active || !payload) return null;
+
+  return (
+    <div className="rounded-lg border bg-background p-2 shadow-sm">
+      <div className="grid grid-cols-2 gap-2">
+        <div className="font-medium">Year {label}</div>
+        {payload.map((entry, index) => (
+          <div key={`${entry.name}-${index}`} className="grid grid-cols-2 gap-4">
+            <div style={{ color: entry.color }}>{entry.name}:</div>
+            <div>£{entry.value ? entry.value.toLocaleString() : '0'}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
   interface CostOverTimeStackedBarChartProps {
     data: LifetimeBarData[];
@@ -26,7 +46,6 @@ export interface LifetimeBarData {
         rent?: string;
         maintenance?: string;
       };
-      // showMaintenance: boolean;
     };
   }
 
@@ -81,7 +100,7 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
             <XAxis dataKey="year" />
             <YAxis 
               domain={[0, maxY]}/>
-            <Tooltip content={<ChartTooltipContent />} />
+            <Tooltip content={<CostOverTimeTooltip />} />
             <Legend />
             
             {config.colors.landRent && ( 
@@ -107,3 +126,4 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
 };
 
 export default CostOverTimeStackedBarChart
+

--- a/app/components/graphs/CostOverTimeWrapper.tsx
+++ b/app/components/graphs/CostOverTimeWrapper.tsx
@@ -9,27 +9,26 @@ export type TenureType = 'marketPurchase' | 'fairholdLandPurchase' | 'fairholdLa
 
 const TENURE_COLORS = {
     marketPurchase: {
-      land: "rgb(var(--freehold-land-color-rgb))",
-      house: "rgb(var(--freehold-house-color-rgb))",
+      equity: "rgb(var(--freehold-equity-color-rgb))",
+      interest: "rgb(var(--freehold-interest-color-rgb))",
       maintenance: "rgb(var(--freehold-detail-color-rgb))",
     },
     fairholdLandPurchase: {
-      land: "rgb(var(--fairhold-land-color-rgb))",
-      house: "rgb(var(--fairhold-house-color-rgb))",
+      equity: "rgb(var(--fairhold-equity-color-rgb))",
+      interest: "rgb(var(--fairhold-interest-color-rgb))",
       maintenance: "rgb(var(--fairhold-detail-color-rgb))",
     },
     fairholdLandRent: {
-      land: "rgb(var(--fairhold-land-color-rgb))",
-      house: "rgb(var(--fairhold-house-color-rgb))",
+      landRent: "rgb(var(--fairhold-land-rent-color-rgb))",
+      equity: "rgb(var(--fairhold-equity-color-rgb))",
+      interest: "rgb(var(--fairhold-interest-color-rgb))",
       maintenance: "rgb(var(--fairhold-detail-color-rgb))",
     },
     marketRent: {
-      land: "rgb(var(--private-rent-land-color-rgb))",
-      house: "rgb(var(--private-rent-house-color-rgb))",
+      rent: "rgb(var(--private-rent-land-color-rgb))"
     },
     socialRent: {
-      land: "rgb(var(--social-rent-land-color-rgb))",
-      house: "rgb(var(--social-rent-house-color-rgb))",
+      rent: "rgb(var(--social-rent-land-color-rgb))",
     }
   } as const;
 interface CostOverTimeWrapperProps {
@@ -49,35 +48,34 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
                 case 'marketPurchase': 
                     return {
                         year: index,
-                        land: yearData.marketLandMortgageYearly,
-                        house: yearData.newbuildHouseMortgageYearly,
+                        equity: yearData.marketPurchaseYearly.yearlyEquityPaid,
+                        interest: yearData.marketPurchaseYearly.yearlyInterestPaid,
                         maintenance: yearData.maintenanceCost[maintenanceLevel]
                     }
                 case 'marketRent':
                     return {
                         year: index,
-                        land: yearData.marketLandRentYearly,
-                        house: yearData.marketHouseRentYearly,
+                        rent: yearData.marketRentYearly
                     };                
                 case 'fairholdLandPurchase':
                     return {
                         year: index,
-                        land: yearData.fairholdLandMortgageYearly,
-                        house: yearData.depreciatedHouseMortgageYearly,
+                        equity: yearData.fairholdLandPurchaseYearly.yearlyEquityPaid,
+                        interest: yearData.fairholdLandPurchaseYearly.yearlyInterestPaid,
                         maintenance: yearData.maintenanceCost[maintenanceLevel]
                     }
                 case 'fairholdLandRent':
                     return {
                         year: index,
-                        land: yearData.fairholdLandRentYearly,
-                        house: yearData.depreciatedHouseMortgageYearly,
+                        landRent: yearData.fairholdLandRentCGRYearly,
+                        equity: yearData.fairholdLandRentYearly.yearlyEquityPaid,
+                        interest: yearData.fairholdLandRentYearly.yearlyInterestPaid,
                         maintenance: yearData.maintenanceCost[maintenanceLevel]
                     }
                 case 'socialRent':
                     return {
                         year: index,
-                        land: yearData.socialRentLandYearly,
-                        house: yearData.socialRentHouseYearly
+                        rent: yearData.socialRentYearly
                     }
             }
         })
@@ -94,7 +92,7 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
     
     // We want a constant y value across the graphs so we can compare costs between them
     const firstYear = household.lifetime.lifetimeData[0]
-    const maxY = Math.ceil((1 * (firstYear.marketLandMortgageYearly + firstYear.newbuildHouseMortgageYearly)) / 100000) * 100000 // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred thousand to make things tidy
+    const maxY = Math.ceil((1 * (firstYear.marketPurchaseYearly.yearlyEquityPaid + firstYear.marketPurchaseYearly.yearlyInterestPaid)) / 100000) * 100000 // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred thousand to make things tidy
 
     return (
         <ErrorBoundary>

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -20,19 +20,19 @@ type CustomTooltipProps = TooltipProps<number, string> & {
 const chartConfig = {
   none: {
     label: "No maintenance",
-    color: "rgb(var(--fairhold-land-color-rgb))", 
+    color: "rgb(var(--fairhold-equity-color-rgb))", 
   },
   low: {
     label: "Low maintenance",
-    color: "rgb(var(--fairhold-land-color-rgb))",
+    color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   medium: {
     label: "Medium maintenance",
-    color: "rgb(var(--fairhold-land-color-rgb))",
+    color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   high: {
     label: "High maintenance",
-    color: "rgb(var(--fairhold-land-color-rgb))",
+    color: "rgb(var(--fairhold-equity-color-rgb))",
   },
 } satisfies ChartConfig;
 

--- a/app/components/graphs/TenureComparisonBarChart.tsx
+++ b/app/components/graphs/TenureComparisonBarChart.tsx
@@ -34,7 +34,7 @@ const TenureComparisonBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
       land: data[0].marketPurchase,
       house: data[1].marketPurchase,
       monthly: data[0].marketPurchase + data[1].marketPurchase,
-      fill: "rgb(var(--freehold-land-color-rgb))",
+      fill: "rgb(var(--freehold-equity-color-rgb))",
     },
     {
       tenure: "Private Rent",
@@ -49,14 +49,14 @@ const TenureComparisonBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
       land: data[0].fairholdLandPurchase,
       house: data[1].fairholdLandPurchase,
       monthly: data[0].fairholdLandPurchase + data[1].fairholdLandPurchase,
-      fill: "rgb(var(--fairhold-land-color-rgb))",
+      fill: "rgb(var(--fairhold-equity-color-rgb))",
     },
     {
       tenure: "Fairhold - Land Rent",
       land: data[0].fairholdLandRent,
       house: data[1].fairholdLandRent,
       monthly: data[0].fairholdLandRent + data[1].fairholdLandRent,
-      fill: "rgb(var(--fairhold-house-color-rgb))",
+      fill: "rgb(var(--fairhold-interest-color-rgb))",
     },
 
     {

--- a/app/components/graphs/UpfrontComparisonBarChart.tsx
+++ b/app/components/graphs/UpfrontComparisonBarChart.tsx
@@ -12,19 +12,19 @@ import {
 const chartConfig = {
   freeholdLand: {
     label: "Land",
-    color: "rgb(var(--freehold-land-color-rgb))",
+    color: "rgb(var(--freehold-equity-color-rgb))",
   },
   freeholdHouse: {
     label: "House",
-    color: "rgb(var(--freehold-house-color-rgb))",
+    color: "rgb(var(--freehold-interest-color-rgb))",
   },
   fairholdLand: {
     label: "Land",
-    color: "rgb(var(--fairhold-land-color-rgb))",
+    color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   fairholdHouse: {
     label: "House",
-    color: "rgb(var(--fairhold-house-color-rgb))",
+    color: "rgb(var(--fairhold-interest-color-rgb))",
   },
 } satisfies ChartConfig;
 

--- a/app/components/ui/TenureSelector.tsx
+++ b/app/components/ui/TenureSelector.tsx
@@ -21,13 +21,13 @@ const TenureSelector: React.FC<TenureSelectorProps> = ({
     
     switch (tenureType) {
       case 'marketPurchase':
-        return "bg-[rgb(var(--freehold-detail-color-rgb))] text-[rgb(var(--freehold-land-color-rgb))]";
+        return "bg-[rgb(var(--freehold-detail-color-rgb))] text-[rgb(var(--freehold-equity-color-rgb))]";
       case 'marketRent':
           return "bg-[rgb(var(--private-rent-detail-color-rgb))] text-[rgb(var(--private-rent-land-color-rgb))]";
       case 'fairholdLandPurchase':
-        return "bg-[rgb(var(--fairhold-detail-color-rgb))] text-[rgb(var(--fairhold-land-color-rgb))]";
+        return "bg-[rgb(var(--fairhold-detail-color-rgb))] text-[rgb(var(--fairhold-equity-color-rgb))]";
       case 'fairholdLandRent':
-          return "bg-[rgb(var(--fairhold-detail-color-rgb))] text-[rgb(var(--fairhold-land-color-rgb))]";
+          return "bg-[rgb(var(--fairhold-detail-color-rgb))] text-[rgb(var(--fairhold-equity-color-rgb))]";
       case 'socialRent':
         return "bg-[rgb(var(--social-rent-detail-color-rgb))] text-[rgb(var(--social-rent-land-color-rgb))]";
       default:

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,11 +14,12 @@
   --text-inaccessible-rgb: 171 164 164;
   --button-background-rgb: 227 227 225;
 
-  --freehold-land-color-rgb: 66 75 179;
-  --freehold-house-color-rgb: 131 164 255;
+  --freehold-equity-color-rgb: 66 75 179;
+  --freehold-interest-color-rgb: 131 164 255;
   --freehold-detail-color-rgb: 190 201 232;
-  --fairhold-land-color-rgb: 74 179 91;
-  --fairhold-house-color-rgb: 159 211 166;
+  --fairhold-land-rent-color-rgb: 28 117 43;
+  --fairhold-equity-color-rgb: 74 179 91;
+  --fairhold-interest-color-rgb: 159 211 166;
   --fairhold-detail-color-rgb: 207 227 209;
   --private-rent-land-color-rgb: 45 155 240;
   --private-rent-house-color-rgb: 119 188 242;

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -142,7 +142,6 @@ export class Household {
         yearsForecast: params.forecastParameters.yearsForecast,
         maintenanceLevel: params.forecastParameters.maintenanceLevel,
         incomeGrowthPerYear: params.forecastParameters.incomeGrowthPerYear,
-        affordabilityThresholdIncomePercentage: params.forecastParameters.affordabilityThresholdIncomePercentage,
         incomeYearly: this.incomeYearly,
       };
       return new Lifetime(lifetimeParams);

--- a/app/models/Lifetime.test.ts
+++ b/app/models/Lifetime.test.ts
@@ -16,10 +16,9 @@ it("creates an array with the correct number of years", () => {
 })
 
 it("reduces mortgage payments to 0 after the mortgage term is reached", () => {
-    expect(lifetime.lifetimeData[35].newbuildHouseMortgageYearly).toBe(0);
-    expect(lifetime.lifetimeData[34].marketLandMortgageYearly).toBe(0);
-    expect(lifetime.lifetimeData[33].fairholdLandMortgageYearly).toBe(0);
-    expect(lifetime.lifetimeData[32].marketLandMortgageYearly).toBe(0);
+    expect(lifetime.lifetimeData[35].marketPurchaseYearly.yearlyEquityPaid).toBe(0);
+    expect(lifetime.lifetimeData[34].fairholdLandPurchaseYearly.yearlyInterestPaid).toBe(0);
+    expect(lifetime.lifetimeData[33].fairholdLandRentYearly.yearlyEquityPaid).toBe(0);
 })
 
 describe("resale values", () => {

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -129,7 +129,7 @@ export class Lifetime {
             landPriceOrRent: marketRentLandYearlyIterative,
         }).discountedLandPriceOrRent;
 
-        // Initialise LifetimeMortgageBreakdown Y0 TODO: deal with deposits too!
+        // Initialise LifetimeMortgageBreakdown
         let marketPurchaseYearlyIterative = this.getMortgageBreakdown("marketPurchase", params.household, 0)
         let fairholdLandPurchaseYearlyIterative = this.getMortgageBreakdown("fairholdLandPurchase", params.household, 0)
         let fairholdLandRentYearlyIterative = this.getMortgageBreakdown("fairholdLandRent", params.household, 0)

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -20,7 +20,6 @@ export interface LifetimeParams {
     yearsForecast: number;
     maintenanceLevel: MaintenanceLevel;
     incomeGrowthPerYear: number;
-    affordabilityThresholdIncomePercentage: number;
     incomeYearly: number;
 }
 
@@ -39,7 +38,6 @@ export interface DepreciatedHouseByMaintenanceLevel {
 }
 export interface LifetimeData {
     incomeYearly: number;
-    affordabilityThresholdIncome: number;
     newbuildHouseMortgageYearly: number;
     depreciatedHouseMortgageYearly: number;
     fairholdLandMortgageYearly: number;
@@ -80,9 +78,6 @@ export class Lifetime {
         const lifetime: LifetimeData[] = [];
         /** Increases yearly by `ForecastParameters.incomeGrowthPerYear`*/
         let incomeYearlyIterative = params.incomeYearly;
-        /** 35% (or the value of `affordabilityThresholdIncomePercentage`) multiplied by `incomeYearly`*/
-        let affordabilityThresholdIncomeIterative =
-            incomeYearlyIterative * params.affordabilityThresholdIncomePercentage;
         /** Increases yearly by `ForecastParameters.propertyPriceGrowthPerYear`*/
         let averageMarketPriceIterative = params.property.averageMarketPrice;
         /** Increases yearly by `ForecastParameters.constructionPriceGrowthPerYear`*/
@@ -147,7 +142,6 @@ export class Lifetime {
         // Push the Y0 values before they start being iterated-upon
         lifetime.push({
             incomeYearly: incomeYearlyIterative,
-            affordabilityThresholdIncome: affordabilityThresholdIncomeIterative,
             newbuildHouseMortgageYearly: newbuildHouseMortgageYearlyIterative,
             depreciatedHouseMortgageYearly: depreciatedHouseMortgageYearlyIterative,
             fairholdLandMortgageYearly: fairholdLandMortgageYearlyIterative,
@@ -179,8 +173,6 @@ export class Lifetime {
         for (let i = 1; i <= params.yearsForecast - 1; i++) {
             incomeYearlyIterative = 
                 incomeYearlyIterative * (1 + params.incomeGrowthPerYear);
-            affordabilityThresholdIncomeIterative =
-                incomeYearlyIterative * params.affordabilityThresholdIncomePercentage;
             averageMarketPriceIterative =
                 averageMarketPriceIterative * (1 + params.propertyPriceGrowthPerYear);
             newBuildPriceIterative =
@@ -270,7 +262,6 @@ export class Lifetime {
             
             lifetime.push({
                 incomeYearly: incomeYearlyIterative,
-                affordabilityThresholdIncome: affordabilityThresholdIncomeIterative,
                 newbuildHouseMortgageYearly: newbuildHouseMortgageYearlyIterative,
                 depreciatedHouseMortgageYearly: depreciatedHouseMortgageYearlyIterative,
                 fairholdLandMortgageYearly: fairholdLandMortgageYearlyIterative,

--- a/app/models/Mortgage.ts
+++ b/app/models/Mortgage.ts
@@ -100,7 +100,7 @@ export class Mortgage {
     // Calculate first year's interest and principal
     let balance = parseFloat(this.principal.toFixed(10));  // This method uses this throughout to ensure consistent precision, was hitting errors
     let yearlyInterestPaid = 0;
-    let yearlyEquityPaid = 0;
+    let yearlyEquityPaid = this.initialDeposit * this.propertyValue;
     
     // Calculate first year's monthly payments
     for (let month = 0; month < MONTHS_PER_YEAR; month++) {

--- a/app/models/SocialValue.ts
+++ b/app/models/SocialValue.ts
@@ -30,8 +30,8 @@ export class SocialValue {
         let fairholdLandPurchaseTotal = 0;
         const lifetime = params.household.lifetime.lifetimeData
         for (let i = 0; i < 10; i++) { // TODO: should this include bills? TODO: do we want to show 10 years only? using 10 here because designs showed savings over 10 year period, not lifetime
-            marketPurchaseTotal += (lifetime[i].marketLandMortgageYearly + lifetime[i].newbuildHouseMortgageYearly)
-            fairholdLandPurchaseTotal += (lifetime[i].fairholdLandMortgageYearly + lifetime[i].depreciatedHouseMortgageYearly)
+            marketPurchaseTotal += (lifetime[i].marketPurchaseYearly.yearlyEquityPaid + lifetime[i].marketPurchaseYearly.yearlyInterestPaid)
+            fairholdLandPurchaseTotal += (lifetime[i].fairholdLandPurchaseYearly.yearlyEquityPaid + lifetime[i].fairholdLandPurchaseYearly.yearlyInterestPaid)
         }
         const moneySaved = marketPurchaseTotal - fairholdLandPurchaseTotal
         return moneySaved;
@@ -40,7 +40,7 @@ export class SocialValue {
         const lifetime = params.household.lifetime.lifetimeData
         let communityWealth = 0
         for (let i = 0; i < SOCIAL_VALUE_YEARS; i++) { // TODO: decide on time period
-            communityWealth += lifetime[i].fairholdLandRentYearly
+            communityWealth += lifetime[i].fairholdLandRentCGRYearly
         }
         return communityWealth;
     }

--- a/app/models/testHelpers.ts
+++ b/app/models/testHelpers.ts
@@ -453,7 +453,6 @@ export const createTestLifetime = (overrides = {}) => {
     yearsForecast: DEFAULT_FORECAST_PARAMETERS.yearsForecast,
     maintenanceLevel: 'low',
     incomeGrowthPerYear: DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear,
-    affordabilityThresholdIncomePercentage: DEFAULT_FORECAST_PARAMETERS.affordabilityThresholdIncomePercentage,
     incomeYearly: 30000,
     ...overrides
   })


### PR DESCRIPTION
# What does this PR do?
- Reorganises the `Lifetime` class to include `LifetimeMortgageBreakdown` type, which breaks yearly mortgage payments down into equity accumulated and interest paid
    - new `getMortgageBreakdown()` method pulls in mortgage payment data from `Mortgage` class
- Updates the bar chart and wrapper to access the new data structure
- Fixed mortgage related colours (from `land` and `house` to `equity` and `interest`(other tenure colour fixes will come in another PR)
    - We needed a new colour for Fairhold Land Rent land rent

# Why?
We want to be able to show the split of mortgage payments by equity and interest, not land and house. 