### PR TITLE
feat: render housing quality savings NHS and society

### DIFF
--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -36,19 +36,18 @@ const Highlight: React.FC<React.PropsWithChildren> = ({ children }) => (
   <span className="text-green-500 font-semibold">{children}</span>
 )
 
-
-
 const Cards: React.FC<CardsProps> = ({ household }) => {
   const moneySaved = Math.round(household.socialValue.moneySaved).toLocaleString();
   const communityWealthDecade = Math.round(household.socialValue.communityWealthDecade).toLocaleString();
   const embodiedCarbonSavings = household.socialValue.embodiedCarbonSavings.toFixed(1);
   const savingsEnergyPoundsYearly = Math.round(household.socialValue.savingsEnergyPoundsYearly).toLocaleString()
-  const savingsToNHSPerHeadYearly = Math.round(household.socialValue.savingsToNHSPerHeadYearly).toLocaleString();
+  const savingsToNHSPerHouseYearly = Math.round(household.socialValue.savingsToNHSPerHouseYearly).toLocaleString();
+  const savingsToSocietyPerHouseYearly = Math.round(household.socialValue.savingsToSocietyPerHouseYearly).toLocaleString();
   const newBuildPrice = Math.round(household.property.newBuildPrice).toLocaleString();
   const operationalCarbonSavingsYearly = household.socialValue.operationalCarbonSavingsYearly.toFixed(1);
   const maintenanceCost = Math.round(household.lifetime.lifetimeData[0].maintenanceCost[household.property.maintenanceLevel]).toLocaleString();
   const localJobs = household.socialValue.localJobs.toFixed(1);
-  
+
   return <div className="flex flex-wrap gap-6">
     <Card title="Money saved" figure={`£${moneySaved}`}>
       <p>If Fairhold Land Purchase, on housing costs over 10 years compared to conventional ownership</p>
@@ -65,8 +64,11 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
     <Card title="Energy savings" figure={`£${savingsEnergyPoundsYearly}`} subfigure="per year">
       <p>Every year, if new build or retrofitted</p>
     </Card>
-    <Card title="Savings to NHS" figure={`£${savingsToNHSPerHeadYearly}`}>
-      <p>per person, per year of a healthy, well-maintained home</p>
+    <Card title="Health savings">
+    <p>
+        If moving from substandard accommodation, Fairhold would save the NHS {" "}
+        <Highlight>£{savingsToNHSPerHouseYearly}</Highlight> and society at large {" "}<Highlight>£{savingsToSocietyPerHouseYearly}</Highlight> yearly
+      </p>
     </Card>
     <Card title="Local economy">
       <p>If new build, the home would add <Highlight>£{newBuildPrice}</Highlight> to the local economy, and <Highlight>£{maintenanceCost}</Highlight> every year, supporting <Highlight>{localJobs}</Highlight> full-time-equivalent jobs in total</p>

--- a/app/models/SocialValue.ts
+++ b/app/models/SocialValue.ts
@@ -1,5 +1,5 @@
 import { Household } from "./Household"
-import { KG_CO2_PER_KWH, NHS_SAVINGS_PER_HEAD_PER_YEAR, FTE_SPEND, SOCIAL_VALUE_YEARS } from "./constants";
+import { KG_CO2_PER_KWH, NHS_SAVINGS_PER_HOUSE_PER_YEAR, SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR, FTE_SPEND, SOCIAL_VALUE_YEARS } from "./constants";
 
 type ConstructorParams = {
     household: Household
@@ -11,7 +11,8 @@ export class SocialValue {
     public communityWealthDecade: number;
     public embodiedCarbonSavings: number;
     public savingsEnergyPoundsYearly: number;
-    public savingsToNHSPerHeadYearly: number;
+    public savingsToNHSPerHouseYearly: number;
+    public savingsToSocietyPerHouseYearly: number;
     public localJobs: number;
     public operationalCarbonSavingsYearly: number;
 
@@ -20,7 +21,8 @@ export class SocialValue {
         this.communityWealthDecade = this.calculateCommunityWealth(params);
         this.embodiedCarbonSavings = 31.89; // TODO: update figures, not placing in constants.ts because it's placeholder; static number comparing average brick & block emissions vs. timber on slab
         this.savingsEnergyPoundsYearly = this.calculateSavingsEnergyPoundsYearly(params);
-        this.savingsToNHSPerHeadYearly = NHS_SAVINGS_PER_HEAD_PER_YEAR
+        this.savingsToNHSPerHouseYearly = NHS_SAVINGS_PER_HOUSE_PER_YEAR;
+        this.savingsToSocietyPerHouseYearly = SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR;
         this.localJobs = this.calculateLocalJobsSupported(params);
         this.operationalCarbonSavingsYearly = this.calculateCarbonSavingsYearly(params);
     }

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -182,8 +182,9 @@ export const KWH_M2_YR_NEWBUILDS_RETROFIT = {
 /** from Carbon Independent https://www.carbonindependent.org/15.html#:~:text=Natural%20gas&text=Older%20gas%20meters%20measure%20gas,kg%20%2F%20kWh%20%5B9%5D%20 */
 export const KG_CO2_PER_KWH = 0.185
 
-/** from BRE report in 2021, NHS first-year care costs due to poor housing in England individualised */
-export const NHS_SAVINGS_PER_HEAD_PER_YEAR = 24.78 // TODO: math
+/** from BRE report in 2021, NHS first-year care costs due to poor housing in England individualised according to English Housing Survey 2021–2022 3.5m households in substandard accom figure */
+export const NHS_SAVINGS_PER_HOUSE_PER_YEAR = 400
+export const SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR = 5286
 
 export const FTE_SPEND = 60000
 


### PR DESCRIPTION
- Update / fixes the way we individualise the cost of poor housing (from BRE report)
- Adds broader cost to society (in addition to existing cost to NHS)
    - Makes the figures per-household, not per-head (I figured we could just make this static, we also have the option of doing this by # of bedrooms instead of assuming an average household size of 2.4)

Draft until getting Alastair's feedback on the change; closes #303 