### PR TITLE
feat: calculate and render cumulative cost by tenure

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -4,6 +4,7 @@ import CostOverTimeWrapper, { TenureType } from "../../graphs/CostOverTimeWrappe
 import { Drawer } from "../../ui/Drawer";
 import TenureSelector from "../../ui/TenureSelector";
 import { DashboardProps } from "../../ui/Dashboard";
+import { DEFAULT_FORECAST_PARAMETERS } from "@/app/models/ForecastParameters";
 
 const TENURES = ['marketPurchase', 'marketRent', 'fairholdLandPurchase', 'fairholdLandRent', 'socialRent'] as const
 const TENURE_LABELS = {
@@ -20,7 +21,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   return (
     <GraphCard
       title="How would the cost change over my life?"
-      subtitle="Over x years, the home would cost £y" // TODO: interpolate
+      subtitle={`Over ${DEFAULT_FORECAST_PARAMETERS.yearsForecast} years, the home would cost £y`}
     >
       <div className="flex flex-col h-full w-3/4 justify-between">
         <div className="flex gap-2 mb-4">

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -5,6 +5,7 @@ import { Drawer } from "../../ui/Drawer";
 import TenureSelector from "../../ui/TenureSelector";
 import { DashboardProps } from "../../ui/Dashboard";
 import { DEFAULT_FORECAST_PARAMETERS } from "@/app/models/ForecastParameters";
+import { formatValue } from "@/app/lib/format";
 
 const TENURES = ['marketPurchase', 'marketRent', 'fairholdLandPurchase', 'fairholdLandRent', 'socialRent'] as const
 const TENURE_LABELS = {
@@ -15,14 +16,30 @@ const TENURE_LABELS = {
   socialRent: 'Social rent'
 }
 
+const TENURE_COLORS = {
+  marketPurchase: 'rgb(var(--freehold-equity-color-rgb))',
+  marketRent: 'rgb(var(--private-rent-land-color-rgb))',
+  fairholdLandPurchase: 'rgb(var(--fairhold-equity-color-rgb))',
+  fairholdLandRent: 'rgb(var(--fairhold-equity-color-rgb))',
+  socialRent: 'rgb(var(--social-rent-land-color-rgb))'
+} as const;
+
 export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const [selectedTenure, setSelectedTenure] = useState<TenureType>('marketPurchase');
+  const lifetimeTotal = processedData.lifetime.lifetimeData[processedData.lifetime.lifetimeData.length - 1].cumulativeCosts[selectedTenure];
 
   return (
     <GraphCard
       title="How would the cost change over my life?"
-      subtitle={`Over ${DEFAULT_FORECAST_PARAMETERS.yearsForecast} years, the home would cost £y`}
-    >
+      subtitle={
+        <span>
+          Over {DEFAULT_FORECAST_PARAMETERS.yearsForecast} years, the home would cost{' '}
+          <span style={{ color: TENURE_COLORS[selectedTenure] }}>
+            {formatValue(lifetimeTotal)}
+          </span>
+        </span>
+      }
+      >
       <div className="flex flex-col h-full w-3/4 justify-between">
         <div className="flex gap-2 mb-4">
         {TENURES.map(tenure => (

--- a/app/components/ui/GraphCard.tsx
+++ b/app/components/ui/GraphCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 type Props = React.PropsWithChildren<{
   title: string;
-  subtitle?: string;
+  subtitle?: string | React.ReactNode;
 }>;
 
 const GraphCard: React.FC<Props> = ({ title, subtitle, children }) => {

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -3,10 +3,10 @@
  */
 export const formatValue = (value: number) => {
   if (value >= 1000000) {
-    return `£${(value / 1000000).toFixed(1)}M`;
+    return `£${(value / 1000000).toFixed(1)}m`;
   }
   if (value >= 10000) {
-    return `£${(value / 1000).toFixed(0)}K`;
+    return `£${(value / 1000).toFixed(0)}k`;
   }
   return `£${value.toFixed(0)}`;
 };


### PR DESCRIPTION
# What does this PR do?
- Adds an object to `Lifetime` to iterate through and store cumulative spend by tenure
- Accesses the figures from `CostOverTime` card
    - Updates the colour according to tenure selected
    - Changes the `GraphCard` component to accept a component _or_ just a string (I wasn't so sure about this move, but thought it ultimately makes sense since other subtitles are straightforward strings?)

Now the subtitle updates the figure and colour according to selected tenure
![image](https://github.com/user-attachments/assets/db9df09b-8d45-4b16-9259-243c39b4a862)

![image](https://github.com/user-attachments/assets/686a3f24-c803-4483-8429-96e43ecb2188)


# Why?
As shown in the designs:
![image](https://github.com/user-attachments/assets/98474f36-aea1-4e54-8ed9-55476cb36f7e)

Alastair also explained the colour / figure changing functionality [in Slack](https://opensystemslab.slack.com/archives/C01RF806126/p1738103335315569?thread_ts=1738067412.188359&cid=C01RF806126)