### PR TITLE
feat: calculate NHS / social save over lifetime (instead of annual)

### DIFF
--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -70,7 +70,7 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
     <Card title="Health savings">
     <p>
         If moving from substandard accommodation, Fairhold would save the NHS {" "}
-        <Highlight>£{savingsToNHSPerHouseLifetime}</Highlight> and society at large {" "}<Highlight>£{savingsToSocietyPerHouseLifetime}</Highlight> over a lifetime
+        <Highlight>£{savingsToNHSPerHouseLifetime}</Highlight> and society at large {" "}<Highlight>£{savingsToSocietyPerHouseLifetime}</Highlight> over {DEFAULT_FORECAST_PARAMETERS.yearsForecast} years
       </p>
     </Card>
     <Card title="Local economy">

--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -42,8 +42,6 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
   const communityWealthDecade = Math.round(household.socialValue.communityWealthDecade).toLocaleString();
   const embodiedCarbonSavings = household.socialValue.embodiedCarbonSavings.toFixed(1);
   const savingsEnergyPoundsYearly = Math.round(household.socialValue.savingsEnergyPoundsYearly).toLocaleString()
-  // const savingsToNHSPerHouseYearly = Math.round(household.socialValue.savingsToNHSPerHouseYearly).toLocaleString();
-  // const savingsToSocietyPerHouseYearly = Math.round(household.socialValue.savingsToSocietyPerHouseYearly).toLocaleString();
   const savingsToNHSPerHouseLifetime = Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.nhsCumulative).toLocaleString();
   const savingsToSocietyPerHouseLifetime = Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.socialCumulative).toLocaleString();
   const newBuildPrice = Math.round(household.property.newBuildPrice).toLocaleString();

--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -38,12 +38,14 @@ const Highlight: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 const Cards: React.FC<CardsProps> = ({ household }) => {
-  const moneySaved = Math.round(household.socialValue.moneySaved).toLocaleString();
+  const moneySaved = Math.round(household.socialValue.moneySaved).toLocaleString(); // Using .toLocaleString() to separate decimals and thousands correctly
   const communityWealthDecade = Math.round(household.socialValue.communityWealthDecade).toLocaleString();
   const embodiedCarbonSavings = household.socialValue.embodiedCarbonSavings.toFixed(1);
   const savingsEnergyPoundsYearly = Math.round(household.socialValue.savingsEnergyPoundsYearly).toLocaleString()
-  const savingsToNHSPerHouseYearly = Math.round(household.socialValue.savingsToNHSPerHouseYearly).toLocaleString();
-  const savingsToSocietyPerHouseYearly = Math.round(household.socialValue.savingsToSocietyPerHouseYearly).toLocaleString();
+  // const savingsToNHSPerHouseYearly = Math.round(household.socialValue.savingsToNHSPerHouseYearly).toLocaleString();
+  // const savingsToSocietyPerHouseYearly = Math.round(household.socialValue.savingsToSocietyPerHouseYearly).toLocaleString();
+  const savingsToNHSPerHouseLifetime = Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.nhsCumulative).toLocaleString();
+  const savingsToSocietyPerHouseLifetime = Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.socialCumulative).toLocaleString();
   const newBuildPrice = Math.round(household.property.newBuildPrice).toLocaleString();
   const operationalCarbonSavingsYearly = household.socialValue.operationalCarbonSavingsYearly.toFixed(1);
   const maintenanceCost = Math.round(household.lifetime.lifetimeData[0].maintenanceCost[household.property.maintenanceLevel]).toLocaleString();
@@ -68,7 +70,7 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
     <Card title="Health savings">
     <p>
         If moving from substandard accommodation, Fairhold would save the NHS {" "}
-        <Highlight>£{savingsToNHSPerHouseYearly}</Highlight> and society at large {" "}<Highlight>£{savingsToSocietyPerHouseYearly}</Highlight> yearly
+        <Highlight>£{savingsToNHSPerHouseLifetime}</Highlight> and society at large {" "}<Highlight>£{savingsToSocietyPerHouseLifetime}</Highlight> over a lifetime
       </p>
     </Card>
     <Card title="Local economy">

--- a/app/models/Lifetime.test.ts
+++ b/app/models/Lifetime.test.ts
@@ -86,3 +86,12 @@ it("correctly ages the house", () => {
     expect(lifetime.lifetimeData[20].houseAge).toBe(30);
     expect(lifetime.lifetimeData[39].houseAge).toBe(49);
 })
+
+it("correctly calculates health savings", () => {
+    const exampleYear10 = lifetime.lifetimeData[9].healthSavings
+    const exampleYear9 = lifetime.lifetimeData[8].healthSavings
+    expect(exampleYear10.nhsCumulative).toBeGreaterThan(exampleYear10.nhs)
+    expect(exampleYear10.socialCumulative).toBeGreaterThan(exampleYear10.social)
+    expect(exampleYear10.nhsCumulative).toBeGreaterThan(exampleYear9.nhsCumulative)
+    expect(exampleYear10.social).toBeGreaterThan(exampleYear9.social)
+})

--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -5,8 +5,9 @@ import { FairholdLandPurchase } from "./tenure/FairholdLandPurchase";
 import { FairholdLandRent } from "./tenure/FairholdLandRent";
 import { Fairhold } from "./Fairhold";
 import { Property } from "./Property";
-import { MONTHS_PER_YEAR, MAINTENANCE_LEVELS, MaintenanceLevel, SOCIAL_RENT_ADJUSTMENT_FORECAST } from "./constants";
+import { MONTHS_PER_YEAR, MAINTENANCE_LEVELS, MaintenanceLevel, SOCIAL_RENT_ADJUSTMENT_FORECAST, NHS_SAVINGS_PER_HOUSE_PER_YEAR, SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR } from "./constants";
 import type { MortgageBreakdownElement } from "./Mortgage"
+import { DEFAULT_FORECAST_PARAMETERS } from "./ForecastParameters";
 
 export interface LifetimeParams {
     household: Household;
@@ -61,6 +62,12 @@ export interface LifetimeData {
         fairholdLandPurchase: number;
         fairholdLandRent: number;
         socialRent: number;
+    }
+    healthSavings: {
+        nhs: number;
+        social: number;
+        nhsCumulative: number;
+        socialCumulative: number;
     }
     [key: number]: number;
 }
@@ -147,6 +154,12 @@ export class Lifetime {
         let fairholdLandPurchaseCumulative = fairholdLandPurchaseYearlyIterative.yearlyEquityPaid + fairholdLandPurchaseYearlyIterative.yearlyInterestPaid
         let fairholdLandRentCumulative = fairholdLandRentYearlyIterative.yearlyEquityPaid + fairholdLandRentYearlyIterative.yearlyInterestPaid
         let socialRentCumulative = socialRentYearlyIterative
+
+        // Initialise the health savings figures
+        let nhsSaveYearlyIterative = NHS_SAVINGS_PER_HOUSE_PER_YEAR
+        let socialSaveYearlyIterative = SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR
+        let nhsSaveCumulative = nhsSaveYearlyIterative
+        let socialSaveCumulative = socialSaveYearlyIterative
         
         // Push the Y0 values before they start being iterated-upon
         lifetime.push({
@@ -180,6 +193,12 @@ export class Lifetime {
                 fairholdLandPurchase: fairholdLandPurchaseCumulative,
                 fairholdLandRent: fairholdLandRentCumulative,
                 socialRent: socialRentCumulative
+            },
+            healthSavings: {
+                nhs: nhsSaveYearlyIterative,
+                social: socialSaveYearlyIterative,
+                nhsCumulative: nhsSaveCumulative,
+                socialCumulative: socialSaveCumulative
             }
         });
 
@@ -221,6 +240,10 @@ export class Lifetime {
                 (fairholdLandRentYearlyIterative.yearlyEquityPaid + fairholdLandRentYearlyIterative.yearlyInterestPaid + fairholdLandRentCGRYearlyIterative)
             socialRentCumulative += 
                 socialRentYearlyIterative
+            nhsSaveYearlyIterative *= (1 + DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear)
+            socialSaveYearlyIterative *= (1 + DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear)
+            nhsSaveCumulative += nhsSaveYearlyIterative
+            socialSaveCumulative += socialSaveYearlyIterative
 
             /** A new instance of the `Property` class is needed each loop in order to re-calculate the depreciated house value as the house gets older */
             const iterativePropertyNoMaintenance = new Property({ 
@@ -312,6 +335,12 @@ export class Lifetime {
                     fairholdLandPurchase: fairholdLandPurchaseCumulative,
                     fairholdLandRent: fairholdLandRentCumulative,
                     socialRent: socialRentCumulative
+                },
+                healthSavings: {
+                    nhs: nhsSaveYearlyIterative,
+                    social: socialSaveYearlyIterative,
+                    nhsCumulative: nhsSaveCumulative,
+                    socialCumulative: socialSaveCumulative
                 }
             });
         }


### PR DESCRIPTION
# What does this PR do?
- Adds another object to `Lifetime` to store inflating savings to NHS and society
    - Both iterative and cumulative versions, so we get total lifetime save
- Shows the cumulative values in the WhatDifference` card

# Why?
Following convo with Alastair, decided to show health savings over a lifetime rather than just yearly