### PR TITLE
wip: feat: dropdown menu for `houseAge` input

### DIFF
--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -30,6 +30,7 @@ import { Label } from "@/components/ui/label";
 import { APIError } from "@/app/lib/exceptions";
 import { BackgroundAssumptions } from "./BackgroundAssumptions";
 import { MaintenanceExplainerDrawer } from "./MaintenanceExplainerDrawer";
+import InputDropdown from "./InputDropdown"
 
 type View = "form" | "loading" | "dashboard";
 
@@ -44,6 +45,20 @@ const CalculatorInput = () => {
   const urlHouseBedrooms = searchParams.get("houseBedrooms");
   const urlHouseType = searchParams.get("houseType");
   const urlMaintenanceLevel = searchParams.get("maintenancePercentage");
+
+  const AGE_OPTIONS = [
+    { label: "New", value: 0},
+    { label: "2020s", value: 3},
+    { label: "2010s", value: 12},
+    { label: "2000s", value: 22},
+    { label: "1990s", value: 32},
+    { label: "1980s", value: 42},
+    { label: "1970s", value: 52},
+    { label: "1960s", value: 62},
+    { label: "1950s", value: 72},
+    { label: "Pre-war", value: 88},
+    { label: "Pre-1900", value: 130},
+] as const;
 
   const form = useForm<FormFrontend>({
     resolver: zodResolver(formSchema),
@@ -228,20 +243,20 @@ const CalculatorInput = () => {
                 control={form.control}
                 name="houseAge"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="h3-style">
-                      How old is the building?
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="e.g. 0 for a new house"
-                        {...field}
-                        value={field.value ?? ""}
-                        className="inputfield-style"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
+                    <FormItem>
+                        <FormLabel className="h3-style">
+                            How old is the building?
+                        </FormLabel>
+                        <FormControl>
+                            <InputDropdown
+                                value={field.value}
+                                onValueChange={field.onChange}
+                                options={AGE_OPTIONS}
+                                placeholder="Select house age"
+                            />
+                        </FormControl>
+                        <FormMessage />
+                    </FormItem>
                 )}
               />
 

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -30,7 +30,7 @@ import { Label } from "@/components/ui/label";
 import { APIError } from "@/app/lib/exceptions";
 import { BackgroundAssumptions } from "./BackgroundAssumptions";
 import { MaintenanceExplainerDrawer } from "./MaintenanceExplainerDrawer";
-import InputDropdown from "./InputDropdown"
+import InputDropdown from "./InputDropdown";
 
 type View = "form" | "loading" | "dashboard";
 
@@ -47,18 +47,18 @@ const CalculatorInput = () => {
   const urlMaintenanceLevel = searchParams.get("maintenancePercentage");
 
   const AGE_OPTIONS = [
-    { label: "New", value: 0},
-    { label: "2020s", value: 3},
-    { label: "2010s", value: 12},
-    { label: "2000s", value: 22},
-    { label: "1990s", value: 32},
-    { label: "1980s", value: 42},
-    { label: "1970s", value: 52},
-    { label: "1960s", value: 62},
-    { label: "1950s", value: 72},
-    { label: "Pre-war", value: 88},
-    { label: "Pre-1900", value: 130},
-] as const;
+    { label: "New", value: 0 },
+    { label: "2020s", value: 3 },
+    { label: "2010s", value: 12 },
+    { label: "2000s", value: 22 },
+    { label: "1990s", value: 32 },
+    { label: "1980s", value: 42 },
+    { label: "1970s", value: 52 },
+    { label: "1960s", value: 62 },
+    { label: "1950s", value: 72 },
+    { label: "Pre-war", value: 88 },
+    { label: "Pre-1900", value: 130 },
+  ] as const;
 
   const form = useForm<FormFrontend>({
     resolver: zodResolver(formSchema),
@@ -243,20 +243,20 @@ const CalculatorInput = () => {
                 control={form.control}
                 name="houseAge"
                 render={({ field }) => (
-                    <FormItem>
-                        <FormLabel className="h3-style">
-                            How old is the building?
-                        </FormLabel>
-                        <FormControl>
-                            <InputDropdown
-                                value={field.value}
-                                onValueChange={field.onChange}
-                                options={AGE_OPTIONS}
-                                placeholder="Select house age"
-                            />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
+                  <FormItem>
+                    <FormLabel className="h3-style">
+                      How old is the building?
+                    </FormLabel>
+                    <FormControl>
+                      <InputDropdown
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        options={AGE_OPTIONS}
+                        placeholder="Select house age"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
                 )}
               />
 

--- a/app/components/ui/InputDropdown.tsx
+++ b/app/components/ui/InputDropdown.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+  } from "@/components/ui/select"
+
+  interface DropdownOption {
+    readonly label: string;
+    readonly value: number;
+}
+
+interface InputDropdownProps {
+    value: number | undefined;
+    onValueChange: (value: number) => void;
+    options: readonly DropdownOption[];
+    placeholder: string;
+}
+
+const InputDropdown: React.FC<InputDropdownProps> = ({
+    value,
+    onValueChange,
+    options,
+    placeholder
+}) => {
+    return (
+        <Select 
+            value={value?.toString() || ""} 
+            onValueChange={(val) => onValueChange(Number(val))}
+        >
+            <SelectTrigger className="inputfield-style ">
+                <SelectValue placeholder={placeholder} className=".inputfield-style:focus::placeholder"/>
+            </SelectTrigger>
+            <SelectContent>
+                {options.map((option) => (
+                    <SelectItem 
+                        key={option.value} 
+                        value={option.value.toString()}
+                        className="text-xs"
+                    >
+                        {option.label}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>  
+    )
+};
+
+export default InputDropdown;

--- a/app/components/ui/InputDropdown.tsx
+++ b/app/components/ui/InputDropdown.tsx
@@ -1,51 +1,53 @@
 import React from "react";
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-  } from "@/components/ui/select"
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-  interface DropdownOption {
-    readonly label: string;
-    readonly value: number;
+interface DropdownOption {
+  readonly label: string;
+  readonly value: number;
 }
 
 interface InputDropdownProps {
-    value: number | undefined;
-    onValueChange: (value: number) => void;
-    options: readonly DropdownOption[];
-    placeholder: string;
+  value: number | undefined;
+  onValueChange: (value: number) => void;
+  options: readonly DropdownOption[];
+  placeholder: string;
 }
 
 const InputDropdown: React.FC<InputDropdownProps> = ({
-    value,
-    onValueChange,
-    options,
-    placeholder
+  value,
+  onValueChange,
+  options,
+  placeholder,
 }) => {
-    return (
-        <Select 
-            value={value?.toString() || ""} 
-            onValueChange={(val) => onValueChange(Number(val))}
-        >
-            <SelectTrigger className="inputfield-style ">
-                <SelectValue placeholder={placeholder} className=".inputfield-style:focus::placeholder"/>
-            </SelectTrigger>
-            <SelectContent>
-                {options.map((option) => (
-                    <SelectItem 
-                        key={option.value} 
-                        value={option.value.toString()}
-                        className="text-xs"
-                    >
-                        {option.label}
-                    </SelectItem>
-                ))}
-            </SelectContent>
-        </Select>  
-    )
+  return (
+    <Select
+      value={value?.toString() || ""}
+      onValueChange={(val) => onValueChange(Number(val))}
+    >
+      <SelectTrigger
+        className={`dropdown-style ${value !== undefined ? "selected" : ""}`}
+      >
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem
+            key={option.value}
+            value={option.value.toString()}
+            className="text-xs"
+          >
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
 };
 
 export default InputDropdown;

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,6 +81,23 @@ body {
   font-size: 12px;
 }
 
+.dropdown-style {
+  background: rgb(var(--background-input-field-rgb)) !important;
+  color: rgb(var(--text-inaccessible-rgb)) !important;
+  font-size: 12px !important;
+  border: 1px solid rgb(var(--text-inaccessible-rgb)) !important;
+}
+
+.dropdown-style:focus {
+  border: 1px solid rgb(var(--text-default-rgb)) !important;
+  color: rgb(var(--text-default-rgb)) !important;
+}
+
+.dropdown-style.selected {
+  border: 1px solid rgb(var(--text-default-rgb)) !important;
+  color: rgb(var(--text-default-rgb)) !important;
+}
+
 .inputfield-style:focus,
 .inputfield-style:not(:placeholder-shown) {
   color: rgb(var(--text-default-rgb));

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { cn } from "@/lib/utils"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDownIcon className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUpIcon className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDownIcon className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-[rgb(var(--background-input-field-rgb))] text-[rgb(var(--text-default-rgb))] shadow-md",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-radio-group": "^1.2.3",
+        "@radix-ui/react-select": "^2.1.5",
         "@radix-ui/react-slot": "^1.1.0",
         "chart.js": "^4.4.8",
         "class-variance-authority": "^0.7.0",
@@ -1234,6 +1235,44 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
+    },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "1.26.1",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.26.1.tgz",
@@ -2446,6 +2485,12 @@
         "@prisma/debug": "6.4.1"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
@@ -2466,6 +2511,29 @@
         "@radix-ui/react-id": "1.1.0",
         "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
+      "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2730,6 +2798,38 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
+      "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
@@ -2887,6 +2987,76 @@
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.5.tgz",
+      "integrity": "sha512-eVV7N8jBXAXnyrc+PsOF89O9AfVgGnbLxUtBb0clJ8y8ENMWLARGMI/1/SBRLz7u4HqxLgN71BJ17eono3wcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.1",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.4.tgz",
+      "integrity": "sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3064,6 +3234,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
@@ -3080,6 +3268,35 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.1.tgz",
+      "integrity": "sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-radio-group": "^1.2.3",
+    "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-slot": "^1.1.0",
     "chart.js": "^4.4.8",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
# What does this PR do?
- Installs the shadcn `select` component
- Creates a new `InputDropdown` component
    - Even though there's only one in the form I thought it was best to keep the component generic and place the dropdown options in `CalculatorInput`
- Uses the dropdown for a `houseAge` input in `CalculatorInput`
 
# Why?
As according to designs
![image](https://github.com/user-attachments/assets/a5feab9f-7281-457e-839c-1f9def1925c0)

# Issues
The placeholder text isn't the right colour and I can't for the life of me figure out how to add the border that other input fields have! 
![image](https://github.com/user-attachments/assets/561842cc-76e3-4ffe-b760-f933c2d1f1b5)
I have tried adding the `inputfield-style` className to `InputDropdown` in CalculatorInput; I have tried inspecting the element in browser and copying the styling from other input fields over into `SelectTrigger` to no avail. 
