### PR TITLE
feat: calculate total money saved over lifetime

### DIFF
--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -2,6 +2,7 @@ import { Household } from "@/app/models/Household";
 import { Drawer } from "../../ui/Drawer";
 import GraphCard from "../../ui/GraphCard"
 import { SOCIAL_VALUE_YEARS } from "@/app/models/constants";
+import { DEFAULT_FORECAST_PARAMETERS } from "@/app/models/ForecastParameters";
 
 type CardsProps = {
   household: Household;
@@ -50,7 +51,7 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
 
   return <div className="flex flex-wrap gap-6">
     <Card title="Money saved" figure={`£${moneySaved}`}>
-      <p>If Fairhold Land Purchase, on housing costs over 10 years compared to conventional ownership</p>
+      <p>If Fairhold Land Purchase, on housing costs over {DEFAULT_FORECAST_PARAMETERS.yearsForecast} years compared to conventional ownership</p>
     </Card>
     <Card title="Community wealth">
       <p>

--- a/app/models/SocialValue.ts
+++ b/app/models/SocialValue.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FORECAST_PARAMETERS } from "./ForecastParameters";
 import { Household } from "./Household"
 import { KG_CO2_PER_KWH, NHS_SAVINGS_PER_HOUSE_PER_YEAR, SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR, FTE_SPEND, SOCIAL_VALUE_YEARS } from "./constants";
 
@@ -28,14 +29,12 @@ export class SocialValue {
     }
 
     private calculateMoneySavedFHLP(params: ConstructorParams) {
-        let marketPurchaseTotal = 0;
-        let fairholdLandPurchaseTotal = 0;
+        const finalYear = DEFAULT_FORECAST_PARAMETERS.yearsForecast - 1
         const lifetime = params.household.lifetime.lifetimeData
-        for (let i = 0; i < 10; i++) { // TODO: should this include bills? TODO: do we want to show 10 years only? using 10 here because designs showed savings over 10 year period, not lifetime
-            marketPurchaseTotal += (lifetime[i].marketPurchaseYearly.yearlyEquityPaid + lifetime[i].marketPurchaseYearly.yearlyInterestPaid)
-            fairholdLandPurchaseTotal += (lifetime[i].fairholdLandPurchaseYearly.yearlyEquityPaid + lifetime[i].fairholdLandPurchaseYearly.yearlyInterestPaid)
-        }
+        const marketPurchaseTotal = lifetime[finalYear].cumulativeCosts.marketPurchase
+        const fairholdLandPurchaseTotal = lifetime[finalYear].cumulativeCosts.fairholdLandPurchase
         const moneySaved = marketPurchaseTotal - fairholdLandPurchaseTotal
+
         return moneySaved;
     }
     private calculateCommunityWealth(params: ConstructorParams) {


### PR DESCRIPTION
# What does this PR do?
- Calculate money saved over a lifetime (as discussed with Alastair, and not the previous 10-year period)
- Update the value and time period showing in the `WhatDifference` card