### PR TITLE
chore: rename testClasse file

### DIFF
--- a/app/api/route.test.ts
+++ b/app/api/route.test.ts
@@ -1,6 +1,6 @@
 import { POST } from "../api/route";
 import * as calculationService from "../services/calculationService";
-import calculateFairhold from "../models/testClasses";
+import calculateFairhold from "../models/calculateFairhold";
 import { NextResponse } from "next/server";
 
 // Mock dependencies

--- a/app/api/route.test.ts
+++ b/app/api/route.test.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 
 // Mock dependencies
 jest.mock("../services/calculationService");
-jest.mock("../models/testClasses", () => jest.fn()); // Mock calculateFairhold
+jest.mock("../models/calculateFairhold", () => jest.fn()); // Mock calculateFairhold
 jest.mock("next/server", () => ({
   NextResponse: {
     json: jest.fn((data) => ({ data })),

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { calculationSchema } from "../schemas/calculationSchema";
 import * as calculationService from "../services/calculationService";
-import calculateFairhold from "../models/testClasses";
+import calculateFairhold from "../models/calculateFairhold";
 import { APIError } from "../lib/exceptions";
 
 export async function POST(req: Request) {
@@ -16,16 +16,13 @@ export async function POST(req: Request) {
     console.log("ERROR: API - ", (error as Error).message);
 
     if (error instanceof APIError) {
-      return NextResponse.json(
-        { error },
-        { status: error.status },
-      );
+      return NextResponse.json({ error }, { status: error.status });
     }
 
     const response = {
-      error: { 
-        message: (error as Error).message, 
-        code: "UNHANDLED_EXCEPTION" 
+      error: {
+        message: (error as Error).message,
+        code: "UNHANDLED_EXCEPTION",
       },
     };
     return NextResponse.json(response, { status: 500 });

--- a/app/models/calculateFairhold.ts
+++ b/app/models/calculateFairhold.ts
@@ -1,4 +1,4 @@
-import { ValidPostcode } from './../schemas/calculationSchema';
+import { ValidPostcode } from "../schemas/calculationSchema";
 import { createForecastParameters } from "./ForecastParameters";
 import { Household } from "./Household";
 import { HouseType, Property } from "./Property";
@@ -59,7 +59,7 @@ function calculateFairhold(responseData: ResponseData) {
     property: property,
     forecastParameters: createForecastParameters(responseData.maintenanceLevel),
   });
-  
+
   return household;
 }
 


### PR DESCRIPTION
# What does this PR do?
It renames the `testClasses.ts` file into `calculateFairhold.ts`.

# Why?
I think the name `testClasses.ts` is misleading because no test is involved. The file contains the function calculateFairhold, so maybe we should change its name?

I was thinking actually a follow up PR should be developing the unit testing for it, i.e. `calculateFairhold.test.ts` because it is currently missing. OThinking of a file named `testClasses.test.ts` will become even more confusing to me