### PR TITLE
feat: safe string replace when rendering markdown

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -61,7 +61,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
     };
     
     processMarkdown();
-  });
+  }, [replacements]);
 
   return (
     <GraphCard

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -40,7 +40,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
     constructionPriceGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear * 100).toString(),
     rentGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.rentGrowthPerYear * 100).toString(),
     propertyPriceGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear * 100).toString(),
-    incomeGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear * 100).toString(),
+    incomeGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear * 100).toString(),
     SOCIAL_RENT_ADJUSTMENT_FORECAST: (SOCIAL_RENT_ADJUSTMENT_FORECAST * 100).toString()
   }), []);
 
@@ -61,7 +61,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
     };
     
     processMarkdown();
-  }, [replacements]);
+  });
 
   return (
     <GraphCard

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -41,7 +41,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
     };
     
     processMarkdown();
-  }, [replacements]);
+  });
 
 
   return (

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useMemo } from "react";
 import GraphCard from "../../ui/GraphCard";
 import HowMuchPerMonthWrapper from "../../graphs/HowMuchPerMonthWrapper";
 import { Drawer } from "../../ui/Drawer";
@@ -5,23 +6,43 @@ import { DashboardProps } from "../../ui/Dashboard";
 import ReactMarkdown from 'react-markdown';
 import explanationContent from '../Help/HowMuchPerMonth.md';
 import { DEFAULT_INITIAL_DEPOSIT, DEFAULT_INTEREST_RATE, DEFAULT_MORTGAGE_TERM } from "@/app/models/constants";
+import { remark } from "remark";
+import { visit } from 'unist-util-visit';
+import type { TextNode } from "./types";
 
 type ProcessedDataOnly = Pick<DashboardProps, "processedData">;
 
 export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
   processedData,
 }) => {
+  const [processedContent, setProcessedContent] = useState('');
+
   // We don't want to hard code the variables in markdown because then we'd have to maintain them in multiple places
-  const processedContent = explanationContent.replace(
-    `{{DEFAULT_INTEREST_RATE}}`,
-    (DEFAULT_INTEREST_RATE * 100).toString()
-  ).replace(
-    `{{DEFAULT_MORTGAGE_TERM}}`,
-    DEFAULT_MORTGAGE_TERM.toString()
-  ).replace(
-    `{{DEFAULT_INITIAL_DEPOSIT}}`,
-    (DEFAULT_INITIAL_DEPOSIT * 100).toString()
-  );
+  const replacements = useMemo(() => ({
+    DEFAULT_INTEREST_RATE: (DEFAULT_INTEREST_RATE * 100).toString(),
+    DEFAULT_MORTGAGE_TERM: DEFAULT_MORTGAGE_TERM.toString(),
+    DEFAULT_INITIAL_DEPOSIT: (DEFAULT_INITIAL_DEPOSIT * 100).toString()
+  }), []);
+
+  useEffect(() => {
+    const processMarkdown = async () => {
+      const result = await remark()
+        .use(() => (tree) => {
+          visit(tree, 'text', (node: TextNode) => {
+            let value = node.value;
+            Object.entries(replacements).forEach(([key, replacement]) => {
+              value = value.replace(`{{${key}}}`, replacement);
+            });
+            node.value = value;
+          });
+        })
+        .process(explanationContent);
+      setProcessedContent(result.toString());
+    };
+    
+    processMarkdown();
+  }, [replacements]);
+
 
   return (
     <GraphCard

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -41,7 +41,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
     };
     
     processMarkdown();
-  });
+  }, [replacements]);
 
 
   return (

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -44,7 +44,7 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
     };
     
     processMarkdown();
-  });
+  }, [replacements]);
 
   return (
     <GraphCard

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import GraphCard from "../../ui/GraphCard";
 import ResaleValueWrapper from "../../graphs/ResaleValueWrapper";
 import { Drawer } from "../../ui/Drawer";
@@ -7,6 +7,9 @@ import TenureSelector from "../../ui/TenureSelector";
 import ReactMarkdown from 'react-markdown';
 import explanationContent from '../Help/ResaleValue.md';
 import { DEFAULT_FORECAST_PARAMETERS } from "@/app/models/ForecastParameters";
+import { remark } from "remark";
+import { visit } from 'unist-util-visit';
+import type { TextNode } from "./types";
 
 const TENURES = ['fairholdLandPurchase', 'fairholdLandRent'] as const;
 type Tenure = (typeof TENURES)[number];
@@ -16,13 +19,32 @@ interface DashboardProps {
 }
 
 export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
-    // We don't want to hard code the variables in markdown because then we'd have to maintain them in multiple places
-    const processedContent = explanationContent.replace(
-      `{{constructionPriceGrowthPerYear}}`,
-      (DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear * 100).toString()
-    )
-
   const [selectedTenure, setSelectedTenure] = useState<Tenure>('fairholdLandPurchase');
+  const [processedContent, setProcessedContent] = useState('');
+  
+  // We don't want to hard code the variables in markdown because then we'd have to maintain them in multiple places
+  const replacements = useMemo(() => ({
+    constructionPriceGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear * 100).toString()
+  }), []);
+
+  useEffect(() => {
+    const processMarkdown = async () => {
+      const result = await remark()
+        .use(() => (tree) => {
+          visit(tree, 'text', (node: TextNode) => {
+            let value = node.value;
+            Object.entries(replacements).forEach(([key, replacement]) => {
+              value = value.replace(`{{${key}}}`, replacement);
+            });
+            node.value = value;
+          });
+        })
+        .process(explanationContent);
+      setProcessedContent(result.toString());
+    };
+    
+    processMarkdown();
+  }, [replacements]);
 
   return (
     <GraphCard

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -44,7 +44,7 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
     };
     
     processMarkdown();
-  }, [replacements]);
+  });
 
   return (
     <GraphCard

--- a/app/components/Dashboard/Cards/types.ts
+++ b/app/components/Dashboard/Cards/types.ts
@@ -1,0 +1,6 @@
+import type { Node } from 'unist';
+
+export interface TextNode extends Node { 
+  type: 'text';
+  value: string;
+}

--- a/app/components/Dashboard/Help/CostOverTime.md
+++ b/app/components/Dashboard/Help/CostOverTime.md
@@ -2,7 +2,7 @@
 Maintenance levels increase with the consumer price index, assumed at a steady {{constructionPriceGrowthPerYear}}% each year. 
 
 ### Private Rent
-This assumes that private rent increases {{rentGrowthPerYear}}% each year.
+This assumes that private rent increases by {{rentGrowthPerYear}}% each year.
 
 ### Fairhold Land Purchase
 Maintenance levels are identical to freehold.

--- a/app/components/Dashboard/Help/CostOverTime.md
+++ b/app/components/Dashboard/Help/CostOverTime.md
@@ -14,3 +14,7 @@ Rising community ground rents are calculated according to rising property prices
 
 ### Social Rent
 Formula rent is inflated by {{SOCIAL_RENT_ADJUSTMENT_FORECAST}}% each year, the average of historical social rent adjustments. 
+
+___
+
+_For more detailed documentation, please see the [Fairhold calculator wiki](https://github.com/theopensystemslab/fairhold-dashboard/wiki)._

--- a/app/components/Dashboard/Help/HowMuchFHCost.md
+++ b/app/components/Dashboard/Help/HowMuchFHCost.md
@@ -10,3 +10,7 @@ For more on the depreciation method or the Fairhold formula used here, see [sour
 
 ### Fairhold - Land Rent
 The up-front purchase price of a Fairhold Land Rent property only accounts for the consumer durable home. Land is paid for via community ground rent, and so is not an up-front cost. 
+
+___
+
+_For more detailed documentation, please see the [Fairhold calculator wiki](https://github.com/theopensystemslab/fairhold-dashboard/wiki)._

--- a/app/components/Dashboard/Help/HowMuchPerMonth.md
+++ b/app/components/Dashboard/Help/HowMuchPerMonth.md
@@ -14,3 +14,7 @@ Mortgage payments for the house (treated as a consumer durable) and the communit
 
 ### Social Rent
 This value comes from the [national social rent formula](https://www.gov.uk/government/publications/direction-on-the-rent-standard-from-1-april-2020/policy-statement-on-rents-for-social-housing#chapter-2-social-rent). 
+
+___
+
+_For more detailed documentation, please see the [Fairhold calculator wiki](https://github.com/theopensystemslab/fairhold-dashboard/wiki)._

--- a/app/components/Dashboard/Help/ResaleValue.md
+++ b/app/components/Dashboard/Help/ResaleValue.md
@@ -5,3 +5,7 @@ As the house is treated as a consumer durable, its price depreciates over time a
 
 ### Fairhold Land Rent
 No land resale value is included since community ground rent is paid monthly. Resale value only represents the house. 
+
+___
+
+_For more detailed documentation, please see the [Fairhold calculator wiki](https://github.com/theopensystemslab/fairhold-dashboard/wiki)._

--- a/app/components/Dashboard/Help/WhatDifference.md
+++ b/app/components/Dashboard/Help/WhatDifference.md
@@ -14,7 +14,11 @@ A retrofitted home is compared to the typical existing home, calculating heating
 Costs to the NHS and to society more broadly are taken from a [BRE report](https://files.bregroup.com/research/BRE_Report_the_cost_of_poor_housing_2021.pdf). They have been individualised according to the [English Housing Survey 2021-2022](https://www.gov.uk/government/statistics/english-housing-survey-2021-to-2022-housing-quality-and-condition/english-housing-survey-2021-to-2022-housing-quality-and-condition#:~:text=There%20are%203.5%20million%20households,a%20home%20with%20damp%20problems.).
 
 ### Local economy
-Base build cost and added yearly maintenance spend is divided by £60k, the assumed cost of one full-time equivalet role. 
+Base build cost and added yearly maintenance spend is divided by £60k, the assumed cost of one full-time equivalent role. 
 
 ### Annual carbon savings
 Carbon demand calculated using kwh/m2 by house type figures above and [Carbon Independent](https://www.carbonindependent.org/15.html#:~:text=Natural%20gas&text=Older%20gas%20meters%20measure%20gas,kg%20%2F%20kWh%20%5B9%5D%20)'s kg of CO2 per kwh figure.
+
+___
+
+_For more detailed documentation, please see the [Fairhold calculator wiki](https://github.com/theopensystemslab/fairhold-dashboard/wiki)._

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-markdown": "^9.0.3",
         "react-spinners": "^0.15.0",
         "recharts": "^2.15.1",
+        "remark": "^15.0.1",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "ts-node": "^10.9.2",
@@ -12174,6 +12175,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
+      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -12201,6 +12218,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "ts-node": "^10.9.2",
+        "unist-util-visit": "^5.0.0",
         "vaul": "^1.1.2",
         "zod": "^3.24.1"
       },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-markdown": "^9.0.3",
     "react-spinners": "^0.15.0",
     "recharts": "^2.15.1",
+    "remark": "^15.0.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.9.2",
+    "unist-util-visit": "^5.0.0",
     "vaul": "^1.1.2",
     "zod": "^3.24.1"
   },


### PR DESCRIPTION
# What does this PR do?
- Installs relevant dependencies (`remark` for string processing and `unis-util-visit` which is used to iterate through the 'nodes' of markdown content and replace values where needed)
- In the relevant cards, Use `remark` to replace previous usage of `.replace` method
- New file `Dashboard/Cards/types.ts` with the `TextNode` type (to resolve type issue)

# Why?
- Doing string processing directly on the markdown files was vulnerable to injection attacks 