### PR TITLE
feat: remove bar graph hover background

### DIFF
--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -95,7 +95,8 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
   return (
     <Card>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer config={chartConfig}
+        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
           <BarChart 
             data={data}
             margin={{ top: 20, right: 30, left: 20, bottom: 50 }}

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -3,8 +3,8 @@
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend, Tooltip, Label } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
-  ChartContainer,
-} from "@/components/ui/chart";
+  StyledChartContainer,
+} from "../ui/StyledChartContainer";
 import { TooltipProps } from "recharts";
 import { ValueType } from "tailwindcss/types/config";
 import { NameType } from "recharts/types/component/DefaultTooltipContent";
@@ -95,8 +95,7 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
   return (
     <Card>
       <CardContent>
-        <ChartContainer config={chartConfig}
-        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
+        <StyledChartContainer config={chartConfig}>
           <BarChart 
             data={data}
             margin={{ top: 20, right: 30, left: 20, bottom: 50 }}
@@ -144,7 +143,7 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
               <Bar dataKey="maintenance" stackId="a" fill={config.colors.maintenance} name="Maintenance" />
             )}
           </BarChart>
-        </ChartContainer>
+        </StyledChartContainer>
       </CardContent>
     </Card>
   );

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -4,8 +4,10 @@ import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList, Tooltip, Tooltip
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ChartConfig,
-  ChartContainer,
 } from "@/components/ui/chart";
+import {
+  StyledChartContainer,
+} from "../ui/StyledChartContainer";
 import { ValueType } from "tailwindcss/types/config";
 import { NameType } from "recharts/types/component/DefaultTooltipContent";
 
@@ -80,7 +82,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
     <Card>
       <CardHeader></CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}
+        <StyledChartContainer config={chartConfig}
         className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
@@ -162,7 +164,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               />
             </Bar>
           </BarChart>
-        </ChartContainer>
+        </StyledChartContainer>
       </CardContent>
     </Card>
   );

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -80,7 +80,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
     <Card>
       <CardHeader></CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer config={chartConfig}
+        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -70,7 +70,8 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
     <Card>
       <CardHeader></CardHeader>
       <CardContent>
-        <ChartContainer config={{}}>
+        <ChartContainer config={{}}
+        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -4,10 +4,12 @@ import React from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, LabelList } from "recharts";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
-  ChartContainer,
   ChartLegend,
   ChartLegendContent,
 } from "@/components/ui/chart";
+import {
+  StyledChartContainer,
+} from "../ui/StyledChartContainer";
 import { formatValue } from "@/app/lib/format";
 
 type DataInput = {
@@ -70,7 +72,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
     <Card>
       <CardHeader></CardHeader>
       <CardContent>
-        <ChartContainer config={{}}
+        <StyledChartContainer config={{}}
         className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
@@ -92,7 +94,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
               />
             </Bar>
           </BarChart>
-        </ChartContainer>
+        </StyledChartContainer>
       </CardContent>
     </Card>
   );

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -3,9 +3,11 @@ import { LineChart, Line, CartesianGrid, XAxis, YAxis, Label, TooltipProps } fro
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ChartConfig,
-  ChartContainer,
   ChartTooltip,
 } from "@/components/ui/chart";
+import {
+  StyledChartContainer,
+} from "../ui/StyledChartContainer";
 import { formatValue } from "@/app/lib/format";
 import { MaintenanceLevel } from "@/app/models/constants";
 
@@ -96,7 +98,7 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
     <Card>
       <CardHeader></CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <StyledChartContainer config={chartConfig}>
           <LineChart
             data={data}
             margin={{ top: 20, right: 30, left: 20, bottom: 50 }}
@@ -132,7 +134,7 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
             {renderLine("low")}
             {renderLine("none")}
           </LineChart>
-        </ChartContainer>
+        </StyledChartContainer>
       </CardContent>
     </Card>
   );

--- a/app/components/ui/StyledChartContainer.tsx
+++ b/app/components/ui/StyledChartContainer.tsx
@@ -1,0 +1,13 @@
+import { ChartContainer } from "@/components/ui/chart";
+import { ComponentProps } from "react";
+
+type ChartContainerProps = ComponentProps<typeof ChartContainer>
+
+export const StyledChartContainer = ({ className, ...props }: ChartContainerProps) => {
+    return (
+      <ChartContainer
+        {...props}
+        className={`[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent ${className || ''}`}
+      />
+    );
+  };


### PR DESCRIPTION
Adds `className` to instances of `ChartContainer` to remove the previous background colour.

Follow up question: should we change the tooltip to only show when the visible bar is hovered over?
![image](https://github.com/user-attachments/assets/c11c5fab-694a-4a04-b793-0d03f145cb3c)

Closes #326