### PR TITLE
chore: tidy graphs

### DIFF
--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -1,5 +1,5 @@
 import GraphCard from "../../ui/GraphCard";
-import UpfrontComparisonWrapper from "../../graphs/UpfrontComparisonWrapper";
+import HowMuchFHCostWrapper from "../../graphs/HowMuchFHCostWrapper";
 import { Drawer } from "../../ui/Drawer";
 import { Household } from "@/app/models/Household";
 
@@ -14,7 +14,7 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
       subtitle="The up-front cost of a home, compared with conventional home ownership."
     >
       <div className="flex flex-col h-full w-3/4 justify-between">
-        <UpfrontComparisonWrapper household={data} />
+        <HowMuchFHCostWrapper household={data} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"
           title="How we estimated these figures"

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -1,5 +1,5 @@
 import GraphCard from "../../ui/GraphCard";
-import TenureComparisonWrapper from "../../graphs/TenureComparisonWrapper";
+import HowMuchPerMonthWrapper from "../../graphs/HowMuchPerMonthWrapper";
 import { Drawer } from "../../ui/Drawer";
 import { DashboardProps } from "../../ui/Dashboard";
 
@@ -14,7 +14,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
       subtitle="Monthly cost of housing, not including energy bills."
     >
       <div className="flex flex-col h-full w-3/4 justify-between">
-        <TenureComparisonWrapper household={processedData} />
+        <HowMuchPerMonthWrapper household={processedData} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"
           title="How we estimated these figures"

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend, Tooltip } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend, Tooltip, Label } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartContainer,
@@ -8,6 +8,7 @@ import {
 import { TooltipProps } from "recharts";
 import { ValueType } from "tailwindcss/types/config";
 import { NameType } from "recharts/types/component/DefaultTooltipContent";
+import { formatValue } from "@/app/lib/format";
 
 export interface LifetimeBarData {
   landRent?: number;
@@ -95,13 +96,36 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
     <Card>
       <CardContent>
         <ChartContainer config={chartConfig}>
-          <BarChart data={data}>
+          <BarChart 
+            data={data}
+            margin={{ top: 20, right: 30, left: 20, bottom: 50 }}
+            >
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="year" />
+            <XAxis dataKey="year">
+              <Label
+                  value="Year"
+                  position="bottom"
+                  offset={10}
+                  className="label-class"
+                  />
+            </XAxis> 
             <YAxis 
-              domain={[0, maxY]}/>
+              domain={[0, maxY]}
+              tickFormatter={formatValue}
+              >
+                
+                <Label
+                  value="Cost"
+                  angle={-90}
+                  position="left"
+                  offset={10}
+                  className="label-class"
+                  />
+              </YAxis>
             <Tooltip content={<CostOverTimeTooltip />} />
-            <Legend />
+            <Legend 
+                verticalAlign="top"
+            />
             
             {config.colors.landRent && ( 
               <Bar dataKey="landRent" stackId="a" fill={config.colors.landRent} name="Land Rent" /> 

--- a/app/components/graphs/CostOverTimeWrapper.tsx
+++ b/app/components/graphs/CostOverTimeWrapper.tsx
@@ -47,26 +47,26 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
             switch (tenure) {
                 case 'marketPurchase': 
                     return {
-                        year: index,
+                        year: index + 1,
                         equity: yearData.marketPurchaseYearly.yearlyEquityPaid,
                         interest: yearData.marketPurchaseYearly.yearlyInterestPaid,
                         maintenance: yearData.maintenanceCost[maintenanceLevel]
                     }
                 case 'marketRent':
                     return {
-                        year: index,
+                        year: index + 1,
                         rent: yearData.marketRentYearly
                     };                
                 case 'fairholdLandPurchase':
                     return {
-                        year: index,
+                        year: index + 1,
                         equity: yearData.fairholdLandPurchaseYearly.yearlyEquityPaid,
                         interest: yearData.fairholdLandPurchaseYearly.yearlyInterestPaid,
                         maintenance: yearData.maintenanceCost[maintenanceLevel]
                     }
                 case 'fairholdLandRent':
                     return {
-                        year: index,
+                        year: index + 1,
                         landRent: yearData.fairholdLandRentCGRYearly,
                         equity: yearData.fairholdLandRentYearly.yearlyEquityPaid,
                         interest: yearData.fairholdLandRentYearly.yearlyInterestPaid,
@@ -74,7 +74,7 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
                     }
                 case 'socialRent':
                     return {
-                        year: index,
+                        year: index + 1,
                         rent: yearData.socialRentYearly
                     }
             }

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -11,19 +11,15 @@ import { NameType } from "recharts/types/component/DefaultTooltipContent";
 
 const chartConfig = {
   freeholdLand: {
-    label: "Land ",
     color: "rgb(var(--freehold-equity-color-rgb))",
   },
   freeholdHouse: {
-    label: "House ",
     color: "rgb(var(--freehold-interest-color-rgb))",
   },
   fairholdLand: {
-    label: "Land ",
     color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   fairholdHouse: {
-    label: "House ",
     color: "rgb(var(--fairhold-interest-color-rgb))",
   },
 } satisfies ChartConfig;
@@ -43,14 +39,14 @@ interface StackedBarChartProps {
   data: DataInput[];
 }
 
-const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => { // LINE CHANGED
+const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
   if (!active || !payload) return null;
 
   const total = payload[0].payload.total;
   return (
     <div className="rounded-lg border bg-background p-2 shadow-sm">
       <div className="grid grid-cols-2 gap-2">
-        <div className="font-medium">Total</div>
+        <div className="font-medium">Total:</div>
         <div>£{total.toLocaleString()}</div>
       </div>
     </div>

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList, Tooltip, TooltipProps } from "recharts";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ChartConfig,
   ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
 } from "@/components/ui/chart";
+import { ValueType } from "tailwindcss/types/config";
+import { NameType } from "recharts/types/component/DefaultTooltipContent";
 
 const chartConfig = {
   freeholdLand: {
@@ -43,6 +43,20 @@ interface StackedBarChartProps {
   data: DataInput[];
 }
 
+const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => { // LINE CHANGED
+  if (!active || !payload) return null;
+
+  const total = payload[0].payload.total;
+  return (
+    <div className="rounded-lg border bg-background p-2 shadow-sm">
+      <div className="grid grid-cols-2 gap-2">
+        <div className="font-medium">Total</div>
+        <div>£{total.toLocaleString()}</div>
+      </div>
+    </div>
+  );
+};
+
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
 }) => {
@@ -51,15 +65,18 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       tenure: "freehold",
       freeholdLand: data[0].marketPurchase,
       freeholdHouse: data[1].marketPurchase,
+      total: data[0].marketPurchase + data[1].marketPurchase,
     },
     {
       tenure: "fairhold: land purchase",
       fairholdLand: data[0].fairholdLandPurchase,
       fairholdHouse: data[2].fairholdLandPurchase,
+      total: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
     },
     {
       tenure: "fairhold: land rent",
       fairholdHouse: data[2].fairholdLandRent,
+      total: data[2].fairholdLandRent,
     },
   ];
 
@@ -94,7 +111,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               />
             </XAxis>
 
-            <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+            <Tooltip content={<CustomTooltip />} />
             <Bar
               dataKey="freeholdLand"
               stackId="stack"

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -11,19 +11,19 @@ import {
 
 const chartConfig = {
   freeholdLand: {
-    label: "Land",
+    label: "Land ",
     color: "rgb(var(--freehold-equity-color-rgb))",
   },
   freeholdHouse: {
-    label: "House",
+    label: "House ",
     color: "rgb(var(--freehold-interest-color-rgb))",
   },
   fairholdLand: {
-    label: "Land",
+    label: "Land ",
     color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   fairholdHouse: {
-    label: "House",
+    label: "House ",
     color: "rgb(var(--fairhold-interest-color-rgb))",
   },
 } satisfies ChartConfig;
@@ -43,7 +43,7 @@ interface StackedBarChartProps {
   data: DataInput[];
 }
 
-const UpfrontComparisonBarChart: React.FC<StackedBarChartProps> = ({
+const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
 }) => {
   const chartData = [
@@ -78,9 +78,9 @@ const UpfrontComparisonBarChart: React.FC<StackedBarChartProps> = ({
                   case "freehold":
                     return "Freehold";
                   case "fairhold: land purchase":
-                    return "Fairhold - Land Purchase";
+                    return "Fairhold – Land Purchase";
                   case "fairhold: land rent":
-                    return "Fairhold - Land Rent";
+                    return "Fairhold – Land Rent";
                   default:
                     return value;
                 }
@@ -154,4 +154,4 @@ const UpfrontComparisonBarChart: React.FC<StackedBarChartProps> = ({
   );
 };
 
-export default UpfrontComparisonBarChart;
+export default HowMuchFHCostBarChart;

--- a/app/components/graphs/HowMuchFHCostWrapper.tsx
+++ b/app/components/graphs/HowMuchFHCostWrapper.tsx
@@ -2,9 +2,9 @@
 import React from "react";
 import ErrorBoundary from "../ErrorBoundary";
 import { Household } from "@/app/models/Household";
-import UpfrontComparisonBarChart from "./UpfrontComparisonBarChart";
+import HowMuchFHCostBarChart from "./HowMuchFHCostBarChart";
 
-interface UpfrontComparisonWrapperProps {
+interface HowMuchFHCostWrapperProps {
   household: Household;
   mortgageLand?: number;
   averageRentLand?: number;
@@ -17,7 +17,7 @@ interface UpfrontComparisonWrapperProps {
   socialRentMonthlyHouse?: number;
 }
 
-const UpfrontComparisonWrapper: React.FC<UpfrontComparisonWrapperProps> = ({
+const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
   household,
 }) => {
   if (!household) {
@@ -55,10 +55,10 @@ const UpfrontComparisonWrapper: React.FC<UpfrontComparisonWrapperProps> = ({
   return (
     <ErrorBoundary>
       <div>
-        <UpfrontComparisonBarChart data={formattedData} />
+        <HowMuchFHCostBarChart data={formattedData} />
       </div>
     </ErrorBoundary>
   );
 };
 
-export default UpfrontComparisonWrapper;
+export default HowMuchFHCostWrapper;

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -27,7 +27,7 @@ interface StackedBarChartProps {
   data: DataInput[];
 }
 
-const TenureComparisonBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
+const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
   const chartData = [
     {
       tenure: "Freehold",
@@ -100,4 +100,4 @@ const TenureComparisonBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
   );
 };
 
-export default TenureComparisonBarChart;
+export default HowMuchPerMonthBarChart;

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -7,8 +7,6 @@ import {
   ChartContainer,
   ChartLegend,
   ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
 } from "@/components/ui/chart";
 import { formatValue } from "@/app/lib/format";
 
@@ -82,7 +80,6 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
               axisLine={false}
               tickFormatter={(value) => value}
             />
-            <ChartTooltip content={<ChartTooltipContent hideLabel />} />
             <ChartLegend content={<ChartLegendContent />} />
             <Bar dataKey="monthly" strokeWidth={2} activeIndex={2}>
               <LabelList

--- a/app/components/graphs/HowMuchPerMonthWrapper.tsx
+++ b/app/components/graphs/HowMuchPerMonthWrapper.tsx
@@ -2,16 +2,16 @@
 import React from "react";
 import ErrorBoundary from "../ErrorBoundary";
 import { Household } from "@/app/models/Household";
-import TenureComparisonBarChart from "./TenureComparisonBarChart";
+import HowMuchPerMonthBarChart from "./HowMuchPerMonthBarChart";
 
-interface TenureComparisonWrapperProps {
+interface HowMuchPerMonthWrapperProps {
   household: Household;
 }
 
-const TenureComparisonWrapper: React.FC<TenureComparisonWrapperProps> = ({
+const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
   household,
 }) => {
-  console.log("TenureComparisonWrapper household:", household);
+  console.log("HowMuchPerMonthWrapper household:", household);
 
   if (!household) {
     return <div>No household data available</div>;
@@ -60,10 +60,10 @@ const TenureComparisonWrapper: React.FC<TenureComparisonWrapperProps> = ({
   return (
     <ErrorBoundary>
       <div>
-        <TenureComparisonBarChart data={formattedData} />
+        <HowMuchPerMonthBarChart data={formattedData} />
       </div>
     </ErrorBoundary>
   );
 };
 
-export default TenureComparisonWrapper;
+export default HowMuchPerMonthWrapper;

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -107,7 +107,7 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
               tickLine={false}
             >
               <Label
-                value="Years"
+                value="Year"
                 position="bottom"
                 offset={20}
                 className="label-class"


### PR DESCRIPTION
# What does this PR do?
- Renames graphs and their wrappers so that they match their content card names in `Dashboard/`
- Removes tooltip from graph 2 because I thought it was redundant (❓ unsure about this one, what do people think?? The old tooltip label just showed what was already in the bar)
![image](https://github.com/user-attachments/assets/3df1942f-91b7-4b18-a9ff-6f8ec87b7468)
- Changes tooltip in graph 1 to match styling in 3 and 4 (and to show 'Total' instead of redundant information)
Before: 
![Screenshot 2025-02-14 143700](https://github.com/user-attachments/assets/dc3017b0-0aa6-4e0d-9606-0b3317ea4247)
After: 
![Screenshot 2025-02-14 143706](https://github.com/user-attachments/assets/21e09af0-1d04-4a7b-aae7-c71d684c688f)
- Makes axes naming and styling consistent in graphs 3 and 4

Closes #330 