### PR TITLE
feat: add affordability threshold to monthly cost graph

### DIFF
--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Bar, BarChart, CartesianGrid, XAxis, LabelList } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, LabelList, ReferenceLine } from "recharts";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ChartLegend,
@@ -83,8 +83,8 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
               axisLine={false}
               tickFormatter={(value) => value}
             />
-            <ChartLegend content={<ChartLegendContent />} />
-            <Bar dataKey="monthly" strokeWidth={2} activeIndex={2}>
+            <ChartLegend content={<ChartLegendContent />} />    
+              <Bar dataKey="monthly" strokeWidth={2} activeIndex={2}>
               <LabelList
                 dataKey="monthly"
                 position="center"
@@ -93,6 +93,18 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
                 fontSize={12}
               />
             </Bar>
+            <ReferenceLine 
+              y={data[0].affordabilityMonthly} 
+              stroke="rgb(var(--text-inaccessible-rgb))" 
+              strokeDasharray="6 6" 
+              label={{ 
+                value: '35% average household income',
+                position: 'insideTopRight',
+                fill: 'rgb(var(--text-inaccessible-rgb))',
+                fontSize: 12, 
+                offset: 10
+              }} 
+            />        
           </BarChart>
         </StyledChartContainer>
       </CardContent>

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -8,10 +8,8 @@ import { SocialRent } from "./tenure/SocialRent";
 import { ForecastParameters } from "./ForecastParameters";
 import { socialRentAdjustmentTypes } from "../data/socialRentAdjustmentsRepo";
 import { Lifetime, LifetimeParams } from "./Lifetime"; 
-import { KWH_M2_YR_EXISTING_BUILDS, KWH_M2_YR_NEWBUILDS_RETROFIT } from "./constants" ;
+import { KWH_M2_YR_EXISTING_BUILDS, KWH_M2_YR_NEWBUILDS_RETROFIT, HEADS_PER_HOUSEHOLD } from "./constants" ;
 import { SocialValue } from "./SocialValue";
-
-const HEADS_PER_HOUSEHOLD = 2.4;
 
 type ConstructorParams = Pick<
   Household,

--- a/app/models/SocialValue.test.ts
+++ b/app/models/SocialValue.test.ts
@@ -10,10 +10,10 @@ describe('Social Value', () => {
     })
 
     it("calculates money saved", () => {
-        expect(socialValue.moneySaved).toBeCloseTo(408354.174)
+        expect(socialValue.moneySaved).toBeCloseTo(412362.556)
     })
     it("calculates money to community", () => {
-        expect(socialValue.communityWealthDecade).toBeCloseTo(5577.11)
+        expect(socialValue.communityWealthDecade).toBeCloseTo(5574.685)
     })
     it("calculates energy bill savings", () => {
         expect(socialValue.savingsEnergyPoundsYearly).toBeCloseTo(554.4)

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -61,6 +61,9 @@ export type componentBreakdownType = {
   percentOfMaintenanceYearly: number
 }
 
+/** from ONS https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/families/bulletins/familiesandhouseholds/2022 */
+export const HEADS_PER_HOUSEHOLD = 2.36; 
+
 export type houseBreakdownType = {
   foundations: componentBreakdownType,
   structureEnvelope: componentBreakdownType,


### PR DESCRIPTION
Adds the 35% of household income line
![image](https://github.com/user-attachments/assets/09b43811-89f9-41f8-839c-6124421c046e)

following designs
![image](https://github.com/user-attachments/assets/1a0638e7-87f0-4c1b-8ef8-c5a2c70a0649)
