### PR TITLE
feat: remove price paid dataset outliers

### DIFF
--- a/app/data/pricesPaidRepo.test.ts
+++ b/app/data/pricesPaidRepo.test.ts
@@ -2,7 +2,7 @@ import { pricesPaidRepo } from "./pricesPaidRepo";
 import prisma from "./db";
 
 jest.mock("./db", () => ({
-  pricesPaidSummary: {
+  pricesPaidSummaryFiltered: {
     findFirst: jest.fn(),
   },
 }));
@@ -19,7 +19,7 @@ describe("pricesPaidRepo", () => {
   });
 
   it("should return prices paid data", async () => {   
-    (prisma.pricesPaidSummary.findFirst as jest.Mock).mockResolvedValueOnce({
+    (prisma.pricesPaidSummaryFiltered.findFirst as jest.Mock).mockResolvedValueOnce({
       averagePrice: 500000,
       transactionCount: 35,
       postcode: postcodeSector,
@@ -40,7 +40,7 @@ describe("pricesPaidRepo", () => {
   });
 
   it("should throw an error if no transaction data is found", async () => {
-    (prisma.pricesPaidSummary.findFirst as jest.Mock).mockResolvedValueOnce(null);
+    (prisma.pricesPaidSummaryFiltered.findFirst as jest.Mock).mockResolvedValueOnce(null);
 
     await expect(
       pricesPaidRepo.getPricesPaidByPostcodeAndHouseType(
@@ -55,7 +55,7 @@ describe("pricesPaidRepo", () => {
   });
 
   it("should throw an error for any other error", async () => {
-    (prisma.pricesPaidSummary.findFirst as jest.Mock).mockRejectedValueOnce(
+    (prisma.pricesPaidSummaryFiltered.findFirst as jest.Mock).mockRejectedValueOnce(
       new Error("Database error")
     );
 

--- a/app/data/pricesPaidRepo.ts
+++ b/app/data/pricesPaidRepo.ts
@@ -16,7 +16,7 @@ const getPricesPaidByPostcodeAndHouseType = async (
   houseType: string
 ): Promise<PricesPaidParams> => {
   try {
-    const summary = await prisma.pricesPaidSummary.findFirst({
+    const summary = await prisma.pricesPaidSummaryFiltered.findFirst({
       where: {
         propertyType: houseType,
         postcode: {
@@ -27,7 +27,6 @@ const getPricesPaidByPostcodeAndHouseType = async (
         },
       },
       orderBy: {
-        // Coincidentally 'sector' comes before 'district' comes before 'area'
         granularityLevel: "asc",
       },
     });

--- a/app/data/rentRepo.ts
+++ b/app/data/rentRepo.ts
@@ -2,23 +2,21 @@ import prisma from "./db";
 
 const getRentByITL3AndBedrooms = async (itl3: string, bedrooms: number): Promise<number> => {
   try {
-    const result = await prisma.rent.aggregate({
+    const result = await prisma.rent.findMany({
       where: {
-        itl3: { equals: itl3 },
-        bedrooms: { equals: bedrooms }
-      },
-      _avg: {
-        monthlyMeanRent: true,
-      },
+        itl3: itl3,
+        bedrooms: bedrooms,
+      }
     });
 
-    const monthlyMeanRent = result._avg.monthlyMeanRent;
-
-    if (monthlyMeanRent === null) {
-      throw new Error(`No monthlyMeanRent found for itl3 ${itl3}`);
+    if (result.length === 0 || result[0].monthlyMeanRent === null) {
+      throw new Error(`No monthlyMeanRent found for itl3 ${itl3} and bedrooms ${bedrooms}`);
     }
 
-    return monthlyMeanRent;
+    const total = result.reduce((sum, item) => sum + item.monthlyMeanRent, 0);
+    const average = total / result.length;
+
+    return average;
   } catch (error) {
     throw new Error(
       `Data error: Unable to find monthlyMeanRent for itl3 ${itl3}`

--- a/prisma/migrations/20250214104412_create_filtered_price_paid_summary/migration.sql
+++ b/prisma/migrations/20250214104412_create_filtered_price_paid_summary/migration.sql
@@ -1,0 +1,97 @@
+-- CreateTable
+CREATE TABLE "prices_paid_summary_filtered" (
+    "id" SERIAL NOT NULL,
+    "postcode" TEXT NOT NULL,
+    "property_type" VARCHAR(250) NOT NULL,
+    "granularity_level" VARCHAR(250) NOT NULL,
+    "average_price" DOUBLE PRECISION NOT NULL,
+    "transaction_count" INTEGER NOT NULL,
+
+    CONSTRAINT "prices_paid_summary_filtered_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "prices_paid_summary_filtered_postcode_property_type_idx" ON "prices_paid_summary_filtered"("postcode", "property_type");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "prices_paid_summary_filtered_postcode_property_type_granula_key" ON "prices_paid_summary_filtered"("postcode", "property_type", "granularity_level");
+
+-- Insert filtered summary from raw prices_paid data; we are splitting by region and then filtering
+WITH area_price_quartiles AS (
+  SELECT 
+    CASE
+      WHEN SUBSTRING(postcode FROM '^[A-Z]{2}') IS NOT NULL THEN LEFT(postcode, 2)
+      ELSE LEFT(postcode, 1)
+    END as area,
+    property_type,
+    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY price) as q1,
+    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY price) as q3
+  FROM prices_paid
+  GROUP BY 
+    CASE
+      WHEN SUBSTRING(postcode FROM '^[A-Z]{2}') IS NOT NULL THEN LEFT(postcode, 2)
+      ELSE LEFT(postcode, 1)
+    END,
+    property_type
+),
+filtered_prices AS (
+  SELECT 
+    p.*
+  FROM prices_paid p
+  JOIN area_price_quartiles q 
+    ON (CASE
+          WHEN SUBSTRING(p.postcode FROM '^[A-Z]{2}') IS NOT NULL THEN LEFT(p.postcode, 2)
+          ELSE LEFT(p.postcode, 1)
+        END) = q.area
+    AND p.property_type = q.property_type
+  WHERE p.price BETWEEN q.q1 AND q.q3
+)
+INSERT INTO prices_paid_summary_filtered (
+  postcode,
+  property_type,
+  granularity_level,
+  average_price,
+  transaction_count
+)
+SELECT 
+  LEFT(postcode, POSITION(' ' IN postcode) + 1) as postcode,
+  property_type,
+  'sector' as granularity_level,
+  AVG(price) as average_price,
+  COUNT(*) as transaction_count
+FROM filtered_prices
+GROUP BY LEFT(postcode, POSITION(' ' IN postcode) + 1), property_type
+UNION ALL
+SELECT 
+  CASE
+    WHEN LENGTH(LEFT(postcode, POSITION(' ' IN postcode) - 1)) >= 4 THEN LEFT(postcode, 4)
+    ELSE LEFT(postcode, 3)
+  END as postcode,
+  property_type,
+  'district' as granularity_level,
+  AVG(price) as average_price,
+  COUNT(*) as transaction_count
+FROM filtered_prices
+GROUP BY 
+  CASE
+    WHEN LENGTH(LEFT(postcode, POSITION(' ' IN postcode) - 1)) >= 4 THEN LEFT(postcode, 4)
+    ELSE LEFT(postcode, 3)
+  END,
+  property_type
+UNION ALL
+SELECT 
+  CASE
+    WHEN SUBSTRING(postcode FROM '^[A-Z]{2}') IS NOT NULL THEN LEFT(postcode, 2)
+    ELSE LEFT(postcode, 1)
+  END as postcode,
+  property_type,
+  'area' as granularity_level,
+  AVG(price) as average_price,
+  COUNT(*) as transaction_count
+FROM filtered_prices
+GROUP BY 
+  CASE
+    WHEN SUBSTRING(postcode FROM '^[A-Z]{2}') IS NOT NULL THEN LEFT(postcode, 2)
+    ELSE LEFT(postcode, 1)
+  END,
+  property_type;

--- a/prisma/migrations/20250228120125_make_bedrooms_required/migration.sql
+++ b/prisma/migrations/20250228120125_make_bedrooms_required/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "rent" ALTER COLUMN "bedrooms" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,7 +77,7 @@ model Rent {
   ladCode         String @map("lad_code") @db.VarChar(250)
   region          String @db.VarChar(250)
   monthlyMeanRent Float  @map("monthly_mean_rent")
-  bedrooms        Float? 
+  bedrooms        Float 
 
   @@map("rent")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,3 +109,17 @@ model GasPrice {
 
   @@map("gas_price")
 }
+
+model PricesPaidSummaryFiltered {
+  id               Int    @id @default(autoincrement())
+  postcode         String
+  propertyType     String @map("property_type") @db.VarChar(250)
+  granularityLevel String @map("granularity_level") @db.VarChar(250)
+  averagePrice     Float  @map("average_price")
+  transactionCount Int    @map("transaction_count")
+
+  @@unique([postcode, propertyType, granularityLevel])
+  @@index([postcode, propertyType])
+
+  @@map("prices_paid_summary_filtered")
+}

--- a/scripts/export_price_paid.sql
+++ b/scripts/export_price_paid.sql
@@ -1,0 +1,31 @@
+\copy (
+  WITH combined_data AS (
+    SELECT 
+      'unfiltered' as source,
+      property_type,
+      granularity_level,
+      average_price
+    FROM prices_paid_summary
+    UNION ALL
+    SELECT 
+      'filtered' as source,
+      property_type,
+      granularity_level,
+      average_price
+    FROM prices_paid_summary_filtered
+  )
+  SELECT 
+    source,
+    property_type,
+    granularity_level,
+    COUNT(*) as count,
+    MIN(average_price) as min_price,
+    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY average_price) as q1,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY average_price) as median,
+    AVG(average_price) as mean,
+    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY average_price) as q3,
+    MAX(average_price) as max_price
+  FROM combined_data
+  GROUP BY source, property_type, granularity_level
+  ORDER BY property_type, granularity_level, source
+) TO '/backups/price_comparison.csv' CSV HEADER;

--- a/scripts/export_prices.sh
+++ b/scripts/export_prices.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+QUERY="SELECT 
+    source,
+    property_type,
+    granularity_level,
+    COUNT(*) as count,
+    MIN(average_price) as min_price,
+    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY average_price) as q1,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY average_price) as median,
+    AVG(average_price) as mean,
+    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY average_price) as q3,
+    MAX(average_price) as max_price
+FROM (
+    SELECT 'unfiltered' as source, property_type, granularity_level, average_price
+    FROM prices_paid_summary
+    UNION ALL
+    SELECT 'filtered' as source, property_type, granularity_level, average_price
+    FROM prices_paid_summary_filtered
+) combined_data
+GROUP BY source, property_type, granularity_level
+ORDER BY property_type, granularity_level, source"
+
+echo "$QUERY" | psql -h postgres -p 5432 -U "$POSTGRES_USER" -d "$POSTGRES_DATABASE" -A -F "," -o "/backups/price_comparison.csv" -q


### PR DESCRIPTION
This re-opens #329 since I had some unexpected test failures and had to revert the merge. 

Original PR description below!

___

What does this PR do?
- Filters prices paid data by area (eg SE) by first and last quartiles

Why?
Following [Gabry's suggestion](https://opensystemslab.slack.com/archives/C01RF806126/p1739524249696609?thread_ts=1739465942.321799&cid=C01RF806126), trying to create slightly more realistic data.

While sometimes the difference between freehold and private rent is even greater than in the other two methods, ultimately I think this method leads to the closest figures. 

This branch uses `oz/weight-purchase-price` as a base, so the property weightings and rental data by number of bedrooms are also inputs. 

![image](https://github.com/user-attachments/assets/76dd338c-faaf-495d-8675-b8584bcf3603)
