### PR TITLE
feat: use median GDHI data instead of average

### DIFF
--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -98,7 +98,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
               stroke="rgb(var(--text-inaccessible-rgb))" 
               strokeDasharray="6 6" 
               label={{ 
-                value: '35% average household income',
+                value: '35% median household income',
                 position: 'insideTopRight',
                 fill: 'rgb(var(--text-inaccessible-rgb))',
                 fontSize: 12, 

--- a/app/data/gdhiRepo.test.ts
+++ b/app/data/gdhiRepo.test.ts
@@ -1,6 +1,5 @@
-// __tests__/gdhiRepo.test.ts
-import { gdhiRepo } from "./gdhiRepo"; // Adjust the import according to your file structure
-import prisma from "./db"; // Your Prisma setup file
+import { gdhiRepo } from "./gdhiRepo";
+import prisma from "./db";
 
 jest.mock("./db", () => ({
   gDHI: {
@@ -13,9 +12,9 @@ describe("gdhiRepo", () => {
     jest.clearAllMocks();
   });
 
-  it("should return the GDHI value for a valid ITL3", async () => {
-    const itl3 = "XYZ123456"; // Example ITL3
-    const mockGDHI = 1000; // Example GDHI value
+  it("should return the GDHI value for a valid ITL1", async () => {
+    const itl1 = "TLH";
+    const mockGDHI = 28000;
 
     // Mock the Prisma client response
     (prisma.gDHI.findFirstOrThrow as jest.Mock).mockResolvedValueOnce({
@@ -23,22 +22,22 @@ describe("gdhiRepo", () => {
     });
 
     // Call the function
-    const result = await gdhiRepo.getGDHIByITL3(itl3);
+    const result = await gdhiRepo.getGDHIByITL1(itl1);
 
     // Assertions
     expect(result).toBe(mockGDHI);
     expect(prisma.gDHI.findFirstOrThrow).toHaveBeenCalledWith({
       where: {
         AND: {
-          itl3: { equals: itl3 },
+          itl1: { equals: itl1 },
         },
       },
       select: { gdhi: true },
     });
   });
 
-  it("should throw an error when no GDHI value is found for the ITL3", async () => {
-    const itl3 = "non-existent-ITL3";
+  it("should throw an error when no GDHI value is found for the ITL1", async () => {
+    const itl1 = "non-existent-ITL1";
 
     // Mock rejection of the Prisma client
     (prisma.gDHI.findFirstOrThrow as jest.Mock).mockRejectedValueOnce(
@@ -46,13 +45,13 @@ describe("gdhiRepo", () => {
     );
 
     // Call the function and expect an error
-    await expect(gdhiRepo.getGDHIByITL3(itl3)).rejects.toThrow(
-      `Data error: Unable to find gdhi for itl3 ${itl3}`
+    await expect(gdhiRepo.getGDHIByITL1(itl1)).rejects.toThrow(
+      `Data error: Unable to find gdhi for itl1 ${itl1}`
     );
   });
 
   it("should throw an error when there is a database error", async () => {
-    const itl3 = "XYZ123456";
+    const itl1 = "TLH";
 
     // Mock rejection of the Prisma client
     (prisma.gDHI.findFirstOrThrow as jest.Mock).mockRejectedValueOnce(
@@ -60,8 +59,8 @@ describe("gdhiRepo", () => {
     );
 
     // Call the function and expect an error
-    await expect(gdhiRepo.getGDHIByITL3(itl3)).rejects.toThrow(
-      `Data error: Unable to find gdhi for itl3 ${itl3}`
+    await expect(gdhiRepo.getGDHIByITL1(itl1)).rejects.toThrow(
+      `Data error: Unable to find gdhi for itl1 ${itl1}`
     );
   });
 });

--- a/app/data/gdhiRepo.ts
+++ b/app/data/gdhiRepo.ts
@@ -1,22 +1,22 @@
 import prisma from "./db";
 
-const getGDHIByITL3 = async (itl3: string): Promise<number> => {
+const getGDHIByITL1 = async (itl1: string): Promise<number> => {
   try {
     const { gdhi } = await prisma.gDHI.findFirstOrThrow({
       where: {
         AND: {
-          itl3: { equals: itl3 },
+          itl1: { equals: itl1 },
         },
       },
       select: { gdhi: true },
     });
     return gdhi;
   } catch (error) {
-    throw Error(`Data error: Unable to find gdhi for itl3 ${itl3}`);
+    throw Error(`Data error: Unable to find gdhi for itl1 ${itl1}`);
   }
 };
 
 export const gdhiRepo = {
-  getGDHIByITL3,
+  getGDHIByITL1,
 };
 

--- a/app/models/Household.ts
+++ b/app/models/Household.ts
@@ -8,12 +8,12 @@ import { SocialRent } from "./tenure/SocialRent";
 import { ForecastParameters } from "./ForecastParameters";
 import { socialRentAdjustmentTypes } from "../data/socialRentAdjustmentsRepo";
 import { Lifetime, LifetimeParams } from "./Lifetime"; 
-import { KWH_M2_YR_EXISTING_BUILDS, KWH_M2_YR_NEWBUILDS_RETROFIT, HEADS_PER_HOUSEHOLD } from "./constants" ;
+import { KWH_M2_YR_EXISTING_BUILDS, KWH_M2_YR_NEWBUILDS_RETROFIT } from "./constants" ;
 import { SocialValue } from "./SocialValue";
 
 type ConstructorParams = Pick<
   Household,
-  "incomePerPersonYearly" | "kwhCostPence" | "property" | "forecastParameters"
+  "incomeYearly" | "kwhCostPence" | "property" | "forecastParameters"
 > & {
   averageRentYearly: number;
   socialRentAverageEarning: number;
@@ -24,11 +24,11 @@ type ConstructorParams = Pick<
 
 /** The 'parent' class; when instantiated, it instantiates all other relevant classes, including `Property` */
 export class Household {
-  public incomePerPersonYearly: number;
+  /** Median household */
+  public incomeYearly: number;
   public kwhCostPence: number;
   public property: Property;
   public forecastParameters: ForecastParameters;
-  public incomeYearly: number;
   public tenure: {
     marketPurchase: MarketPurchase;
     marketRent: MarketRent;
@@ -46,11 +46,10 @@ export class Household {
   public socialValue: SocialValue;
 
   constructor(params: ConstructorParams) {
-    this.incomePerPersonYearly = params.incomePerPersonYearly;
+    this.incomeYearly = params.incomeYearly;
     this.kwhCostPence = params.kwhCostPence;
     this.property = params.property;
     this.forecastParameters = params.forecastParameters;
-    this.incomeYearly = HEADS_PER_HOUSEHOLD * params.incomePerPersonYearly;
     this.gasDemand = this.calculateGasDemand(params)
     this.tenure = this.calculateTenures(params);
     this.lifetime = this.calculateLifetime(params);

--- a/app/models/SocialValue.test.ts
+++ b/app/models/SocialValue.test.ts
@@ -10,10 +10,10 @@ describe('Social Value', () => {
     })
 
     it("calculates money saved", () => {
-        expect(socialValue.moneySaved).toBeCloseTo(412362.556)
+        expect(socialValue.moneySaved).toBeCloseTo(481215.981)
     })
     it("calculates money to community", () => {
-        expect(socialValue.communityWealthDecade).toBeCloseTo(5574.685)
+        expect(socialValue.communityWealthDecade).toBeCloseTo(5425.91)
     })
     it("calculates energy bill savings", () => {
         expect(socialValue.savingsEnergyPoundsYearly).toBeCloseTo(554.4)

--- a/app/models/calculateFairhold.ts
+++ b/app/models/calculateFairhold.ts
@@ -50,7 +50,7 @@ function calculateFairhold(responseData: ResponseData) {
 
   // define the household object
   const household = new Household({
-    incomePerPersonYearly: responseData.gdhi,
+    incomeYearly: responseData.gdhi,
     averageRentYearly: responseData.averageRentMonthly * MONTHS_PER_YEAR,
     socialRentAverageEarning: responseData.socialRentAverageEarning,
     socialRentAdjustments: responseData.socialRentAdjustments,

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -61,9 +61,6 @@ export type componentBreakdownType = {
   percentOfMaintenanceYearly: number
 }
 
-/** from ONS https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/families/bulletins/familiesandhouseholds/2022 */
-export const HEADS_PER_HOUSEHOLD = 2.36; 
-
 export type houseBreakdownType = {
   foundations: componentBreakdownType,
   structureEnvelope: componentBreakdownType,

--- a/app/models/testHelpers.ts
+++ b/app/models/testHelpers.ts
@@ -160,7 +160,7 @@ const socialRentAdjustments: socialRentAdjustmentTypes = [
  * socialRentAverageEarning: 354.1,
  * socialRentAdjustments: socialRentAdjustments,
  * housePriceIndex: 100000,
- * incomePerPersonYearly: 30000,
+ * incomeYearly: 30000,
  * kwhCostPence: 8,
  * property: createTestProperty(),
  * forecastParameters: DEFAULT_FORECAST_PARAMETERS,`
@@ -172,7 +172,7 @@ export const createTestHousehold = (overrides = {}) => {
     socialRentAverageEarning: 354.1,
     socialRentAdjustments: socialRentAdjustments,
     housePriceIndex: 100000,
-    incomePerPersonYearly: 30000,
+    incomeYearly: 35000,
     kwhCostPence: 7,
     property: createTestProperty(),
     forecastParameters: DEFAULT_FORECAST_PARAMETERS,

--- a/app/services/calculationService.test.ts
+++ b/app/services/calculationService.test.ts
@@ -87,7 +87,7 @@ describe("getHouseholdData", () => {
     (itlService.getByPostcodeDistrict as jest.Mock).mockResolvedValueOnce(
       mockITL3
     );
-    (gdhiService.getByITL3 as jest.Mock).mockResolvedValueOnce(mockGDHI);
+    (gdhiService.getByITL1 as jest.Mock).mockResolvedValueOnce(mockGDHI);
     (gasPriceService.getByITL3 as jest.Mock).mockResolvedValueOnce(
       mockGasPriceYearly
     );

--- a/app/services/calculationService.ts
+++ b/app/services/calculationService.ts
@@ -26,7 +26,9 @@ export const getHouseholdData = async (input: Calculation) => {
     const bedrooms = input.houseBedrooms <= 4 ? input.houseBedrooms : 4; // rental data only goes up to 4br TODO: do we want to increase the weight? 
 
     const itl3 = await itlService.getByPostcodeDistrict(postcodeDistrict);
-    const gdhi = await gdhiService.getByITL3(itl3);
+    const itl1 = itl3.substring(0,3)
+    
+    const gdhi = await gdhiService.getByITL1(itl1);
     const kwhCostPence = await gasPriceService.getByITL3(itl3);
     const hpi = await hpiService.getByITL3(itl3);
     const buildPrice = await buildPriceService.getBuildPriceByHouseType(input.houseType);

--- a/app/services/gdhiService.test.ts
+++ b/app/services/gdhiService.test.ts
@@ -4,35 +4,35 @@ import { gdhiRepo } from "../data/gdhiRepo"; // Adjust the path according to you
 
 jest.mock("../data/gdhiRepo");
 
-describe("gdhiService.getByITL3", () => {
+describe("gdhiService.getByITL1", () => {
   const mockGDHI = 35000;
 
   beforeEach(() => {
     jest.clearAllMocks(); // Clear mocks before each test
   });
 
-  it("should return GDHI for a valid ITL3", async () => {
+  it("should return GDHI for a valid ITL1", async () => {
     // Arrange
-    const itl3 = "ITL3-123";
-    (gdhiRepo.getGDHIByITL3 as jest.Mock).mockResolvedValueOnce(mockGDHI);
+    const itl1 = "TLH";
+    (gdhiRepo.getGDHIByITL1 as jest.Mock).mockResolvedValueOnce(mockGDHI);
 
     // Act
-    const result = await gdhiService.getByITL3(itl3);
+    const result = await gdhiService.getByITL1(itl1);
 
     // Assert
-    expect(gdhiRepo.getGDHIByITL3).toHaveBeenCalledWith(itl3);
+    expect(gdhiRepo.getGDHIByITL1).toHaveBeenCalledWith(itl1);
     expect(result).toBe(mockGDHI);
   });
 
   it("should throw an error when the repo fails", async () => {
     // Arrange
     const errorMessage = "Failed to fetch GDHI";
-    (gdhiRepo.getGDHIByITL3 as jest.Mock).mockRejectedValueOnce(
+    (gdhiRepo.getGDHIByITL1 as jest.Mock).mockRejectedValueOnce(
       new Error(errorMessage)
     );
 
     // Act & Assert
-    await expect(gdhiService.getByITL3("ITL3-123")).rejects.toThrow(
+    await expect(gdhiService.getByITL1("TLG")).rejects.toThrow(
       errorMessage
     );
   });

--- a/app/services/gdhiService.ts
+++ b/app/services/gdhiService.ts
@@ -1,9 +1,9 @@
 import { gdhiRepo } from "../data/gdhiRepo";
 
-const getByITL3 = async (itl3: string) => {
-  return await gdhiRepo.getGDHIByITL3(itl3);
+const getByITL1 = async (itl1: string) => {
+  return await gdhiRepo.getGDHIByITL1(itl1);
 };
 
 export const gdhiService = {
-  getByITL3,
+  getByITL1,
 };

--- a/prisma/migrations/20250305100045_use_median_gdhi_data/migration.sql
+++ b/prisma/migrations/20250305100045_use_median_gdhi_data/migration.sql
@@ -1,0 +1,19 @@
+-- delete all data
+DELETE FROM "gdhi";
+
+-- change ITL3 to ITL1
+ALTER TABLE "gdhi" DROP COLUMN "itl3",
+ADD COLUMN     "itl1" VARCHAR(250) NOT NULL;
+
+-- insert median data
+-- itl1, region, gdhi
+INSERT INTO "gdhi" (itl1, region, gdhi)
+VALUES ('TLC', 'North East', 30366),
+('TLD', 'North West', 28802),
+('TLE', 'Yorkshire and The Humber', 30084),
+('TLF', 'East Midlands', 31414),
+('TLG', 'West Midlands', 28780),
+('TLH', 'East of England', 35013),
+('TLI', 'London', 37616),
+('TLJ', 'South East', 36991),
+('TLK', 'South West', 32697);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,7 @@ model BuildPrices {
 
 model GDHI {
   id       Int     @id @default(autoincrement())
-  itl3     String  @db.VarChar(250)
+  itl1     String  @db.VarChar(250)
   region   String  @db.VarChar(250)
   gdhi Float 
 


### PR DESCRIPTION
# What does this PR do
- Migration to drop all previous GDHI data, replace `itl3` column with `itl1` and insert new median GDHI data
- Update GDHI repo and service accordingly 
- Update `Household` class (eg we no longer need per-head income, `HEADS_PER_HOUSEHOLD` constant and a household income property; we just retrieve the one household income figure and save to `Household.incomeYearly` 

# Why
Our previous GDHI data was using average income per-head and multiplying this by the average household size. This led to higher and less accurate household income figures. 

# To-dos after merging
- Update the help text on how this was calculated (see PR #323)
- Update sources (`gdhi` script in [fairhold-data](https://github.com/theopensystemslab/fairhold-data) becomes redundant; source should also be updated to [IFS](https://ifs.org.uk/data-items/median-household-incomes-region))
- (Maybe) adjust discount formula accordingly as affordability figures  / inputs will be different now