### PR TITLE
feat: set max y axis for monthly costs

### DIFF
--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Bar, BarChart, CartesianGrid, XAxis, LabelList, ReferenceLine } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, LabelList, ReferenceLine } from "recharts";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ChartLegend,
@@ -25,9 +25,13 @@ type DataInput = {
 
 interface StackedBarChartProps {
   data: DataInput[];
+  maxY: number;
 }
 
-const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
+const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ 
+  data, 
+  maxY 
+}) => {
   const chartData = [
     {
       tenure: "Freehold",
@@ -83,6 +87,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ data }) => {
               axisLine={false}
               tickFormatter={(value) => value}
             />
+            <YAxis domain={[0, maxY]}></YAxis>
             <ChartLegend content={<ChartLegendContent />} />    
               <Bar dataKey="monthly" strokeWidth={2} activeIndex={2}>
               <LabelList

--- a/app/components/graphs/HowMuchPerMonthWrapper.tsx
+++ b/app/components/graphs/HowMuchPerMonthWrapper.tsx
@@ -17,6 +17,14 @@ const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
     return <div>No household data available</div>;
   }
 
+  const fairholdLandPurchaseMonthly = household.tenure.fairholdLandPurchase.depreciatedHouseMortgage.monthlyPayment + household.tenure.fairholdLandPurchase.discountedLandMortgage.monthlyPayment
+  const marketPurchaseMonthly = household.tenure.marketPurchase.landMortgage.monthlyPayment + household.tenure.marketPurchase.houseMortgage.monthlyPayment
+  const affordabilityMonthly = (household.incomeYearly / 12) *
+    household.forecastParameters
+      .affordabilityThresholdIncomePercentage || 0
+  const highestValue = Math.max(fairholdLandPurchaseMonthly, marketPurchaseMonthly, affordabilityMonthly)
+  const maxY = Math.ceil(highestValue / 500) * 500
+
   const formatData = (household: Household) => {
     return [
       {
@@ -31,9 +39,7 @@ const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
         fairholdLandRent:
           household.tenure.fairholdLandRent?.discountedLandRentMonthly || 0,
         affordabilityMonthly:
-          (household.incomeYearly / 12) *
-            household.forecastParameters
-              .affordabilityThresholdIncomePercentage || 0,
+          affordabilityMonthly,
       },
       {
         category: "Monthly Costs House",
@@ -47,10 +53,8 @@ const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
         fairholdLandRent:
           household.tenure.fairholdLandPurchase?.depreciatedHouseMortgage
             ?.monthlyPayment || 0,
-        affordabilityMonthly:
-          (household.incomeYearly / 12) *
-            household.forecastParameters
-              .affordabilityThresholdIncomePercentage || 0,
+        affordabilityMonthly: 
+          affordabilityMonthly,
       },
     ];
   };
@@ -60,7 +64,10 @@ const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
   return (
     <ErrorBoundary>
       <div>
-        <HowMuchPerMonthBarChart data={formattedData} />
+        <HowMuchPerMonthBarChart 
+          data={formattedData}
+          maxY={maxY} 
+          />
       </div>
     </ErrorBoundary>
   );


### PR DESCRIPTION
Turns out it wasn't a bug 😅 

# What does this PR do?
- Sets the y axis of the monthly costs graph to be the maximum of monthly market mortgage cost, monthly Fairhold cost, or 35% affordability threshold (rounded to nearest £500)

# Why?
Realised that the affordability line wasn't showing in areas where land values are negative. 
Before:
![image](https://github.com/user-attachments/assets/729245ee-b67f-452a-98a6-f481f8558f8d)

After:
![image](https://github.com/user-attachments/assets/8c1fc58d-53f8-4c0f-aa0d-1e37146de89d)
