### PR TITLE
feat: bottom out money saved at 0

### DIFF
--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -40,7 +40,7 @@ const Highlight: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 const Cards: React.FC<CardsProps> = ({ household }) => {
-  const moneySaved = Math.round(household.socialValue.moneySaved).toLocaleString(); // Using .toLocaleString() to separate decimals and thousands correctly
+  const moneySaved = Math.max(Math.round(household.socialValue.moneySaved),0).toLocaleString(); // Using .toLocaleString() to separate decimals and thousands correctly
   const communityWealthDecade = Math.round(household.socialValue.communityWealthDecade).toLocaleString();
   const embodiedCarbonSavings = household.socialValue.embodiedCarbonSavings.toFixed(1);
   const savingsEnergyPoundsYearly = Math.round(household.socialValue.savingsEnergyPoundsYearly).toLocaleString()


### PR DESCRIPTION
In cases where a Fairhold home would be more expensive than market (eg newbuild in an area with negative land values / where the market price of a home is less than construction cost)

Previous:
![image](https://github.com/user-attachments/assets/f6a4e498-6827-46c1-aab4-52eee47c1024)
