### PR TITLE
feat: scale y axis according to max value

### DIFF
--- a/app/components/graphs/CostOverTimeWrapper.tsx
+++ b/app/components/graphs/CostOverTimeWrapper.tsx
@@ -92,7 +92,9 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
     
     // We want a constant y value across the graphs so we can compare costs between them
     const firstYear = household.lifetime.lifetimeData[0]
-    const maxY = Math.ceil((1 * (firstYear.marketPurchaseYearly.yearlyEquityPaid + firstYear.marketPurchaseYearly.yearlyInterestPaid)) / 100000) * 100000 // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred thousand to make things tidy
+    const maxValue = firstYear.marketPurchaseYearly.yearlyEquityPaid + firstYear.marketPurchaseYearly.yearlyInterestPaid
+    const yScale = maxValue < 50000 ? 50000 : 100000
+    const maxY = Math.ceil((1 * (maxValue)) / yScale) * yScale // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred (or fifty) thousand to make things tidy
 
     return (
         <ErrorBoundary>


### PR DESCRIPTION
We were previously scaling the y axis here to the nearest 100k, which looked a bit funny if house prices / spend were very low:
![image](https://github.com/user-attachments/assets/b685a456-cb37-4bd0-a9c7-efd27677d3fb)

Have used an `if` ternary to scale the y axis to 50k if the max value is less than that:
![image](https://github.com/user-attachments/assets/78453258-0e5c-4659-9ba9-ad341ca35f65)
