### PR TITLE
feat: add axes and split line 35% threshold label in monthly cost graph

### DIFF
--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -105,14 +105,32 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
               y={data[0].affordabilityMonthly} 
               stroke="rgb(var(--text-inaccessible-rgb))" 
               strokeDasharray="6 6" 
-              label={{ 
-                value: '35% median household income',
-                position: 'insideTopRight',
-                fill: 'rgb(var(--text-inaccessible-rgb))',
-                fontSize: 12, 
-                offset: 10
-              }} 
-            />        
+              label={(props) => { // formatting here is to ensure line break
+                const { viewBox } = props;
+                return (
+                  <g>
+                    <text
+                      x={viewBox.width + 30}  
+                      y={viewBox.y - 30}
+                      textAnchor="end"
+                      fill="rgb(var(--text-inaccessible-rgb))"
+                      fontSize={12}
+                    >
+                      Affordability threshold
+                    </text>
+                    <text
+                      x={viewBox.width + 30} 
+                      y={viewBox.y - 15} 
+                      textAnchor="end"
+                      fill="rgb(var(--text-inaccessible-rgb))"
+                      fontSize={12}
+                    >
+                      (35% median household income)
+                    </text>
+                  </g>
+                );
+              }}
+            />    
           </BarChart>
         </StyledChartContainer>
       </CardContent>

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -82,16 +82,14 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey="tenure"
-              tickLine={false}
               tickMargin={10}
-              axisLine={false}
+              tickSize={0}
               tickFormatter={(value) => value}
             />
             <YAxis 
               domain={[0, maxY]}
-              tick={false}
-              axisLine={false}
-              tickLine={false}
+              tickMargin={10}
+              tickFormatter={formatValue}
               ></YAxis>
             <ChartLegend content={<ChartLegendContent />} />    
               <Bar dataKey="monthly" strokeWidth={2} activeIndex={2}>


### PR DESCRIPTION
Old version:
![image](https://github.com/user-attachments/assets/37da60ec-e38e-4194-92f3-18009b425e7a)

New (with axes and splitting the 35% threshold label over two lines):
![image](https://github.com/user-attachments/assets/485a7ffa-4044-48d7-bb07-fcfeae75c3a2)

Recharts can't render JSX so we can't use `\n` or `<br>` to create a line break. I'm not sure if my solution is overly complex--couldn't figure anything else out but I have to say I don't like it very much! 