### PR TITLE
feat: add deposit to y1 tooltip

### DIFF
--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -24,7 +24,7 @@ const CostOverTimeTooltip = ({ active, payload, label }: TooltipProps<ValueType,
   return (
     <div className="rounded-lg border bg-background p-2 shadow-sm">
       <div className="grid grid-cols-2 gap-2">
-        <div className="font-medium">Year {label}</div>
+        <div className="font-medium">Year {label}{parseInt(label as string) === 1 ? " (with deposit)" : ""}</div>
         {payload.map((entry, index) => (
           <div key={`${entry.name}-${index}`} className="grid grid-cols-2 gap-4">
             <div style={{ color: entry.color }}>{entry.name}:</div>


### PR DESCRIPTION
In cost over time graph:
![image](https://github.com/user-attachments/assets/4b7bd532-a817-4878-b698-0011de8e2f4f)

other years show as before:
![image](https://github.com/user-attachments/assets/5ad8d6e5-a9a7-4d5b-99c3-76b4d747a327)

Closes #386