### PR TITLE
feat: allow user to enter half (outward) postcode only

### DIFF
--- a/app/api/route.test.ts
+++ b/app/api/route.test.ts
@@ -58,15 +58,12 @@ describe("POST API Route", () => {
       ...validApiInput,
       // Parsed postcode object
       housePostcode: {
+        outcode: "SE17",
+        incode: "1PE",
         area: "SE",
         district: "SE17",
-        incode: "1PE",
-        outcode: "SE17",
-        postcode: "SE17 1PE",
         sector: "SE17 1",
-        subDistrict: null,
-        unit: "PE",
-        valid: true,
+        postcode: "SE17 1PE"
       },
     });
     expect(calculateFairhold).toHaveBeenCalledWith(householdData);
@@ -116,15 +113,12 @@ describe("POST API Route", () => {
       ...validApiInput,
       // Parsed postcode object
       housePostcode: {
+        outcode: "SE17",
+        incode: "1PE",
         area: "SE",
         district: "SE17",
-        incode: "1PE",
-        outcode: "SE17",
-        postcode: "SE17 1PE",
         sector: "SE17 1",
-        subDistrict: null,
-        unit: "PE",
-        valid: true,
+        postcode: "SE17 1PE"
       },
     });
     expect(NextResponse.json).toHaveBeenCalledWith(

--- a/app/models/calculateFairhold.ts
+++ b/app/models/calculateFairhold.ts
@@ -1,4 +1,4 @@
-import { ValidPostcode } from "../schemas/calculationSchema";
+import { PostcodeScales } from "../schemas/calculationSchema";
 import { createForecastParameters } from "./ForecastParameters";
 import { Household } from "./Household";
 import { HouseType, Property } from "./Property";
@@ -7,7 +7,7 @@ import { socialRentAdjustmentTypes } from "../data/socialRentAdjustmentsRepo";
 
 // TODO: Share type with backend
 export interface ResponseData {
-  postcode: ValidPostcode;
+  postcode: PostcodeScales;
   houseType: HouseType;
   houseBedrooms: number;
   buildPrice: number;
@@ -37,7 +37,7 @@ function calculateFairhold(responseData: ResponseData) {
 
   // define the property object
   const property = new Property({
-    postcode: responseData.postcode.postcode,
+    postcode: responseData.postcode.postcode ?? responseData.postcode.outcode,
     houseType: responseData.houseType,
     numberOfBedrooms: responseData.houseBedrooms,
     age: responseData.houseAge,

--- a/app/schemas/calculationSchema.test.ts
+++ b/app/schemas/calculationSchema.test.ts
@@ -2,7 +2,7 @@ import { calculationSchema, maintenanceLevelSchema } from "../schemas/calculatio
 import { MAINTENANCE_LEVELS } from "../models/constants";
 
 describe("calculationSchema", () => {
-  it("should validate valid input", () => {
+  it("should validate valid input (whole postcode)", () => {
     const validInput = {
       housePostcode: "SE17 1PE",
       houseBedrooms: 2,
@@ -12,19 +12,40 @@ describe("calculationSchema", () => {
     };
 
     const result = calculationSchema.parse(validInput);
-    
     expect(result).toEqual({
       ...validInput,
       housePostcode: {
+        outcode: "SE17",
+        incode: "1PE",
         area: "SE",
         district: "SE17",
-        incode: "1PE",
-        outcode: "SE17",
-        postcode: "SE17 1PE",
         sector: "SE17 1",
-        subDistrict: null,
-        unit: "PE",
-        valid: true,
+        postcode: "SE17 1PE"
+      },
+      houseSize: 70, // auto-assigned for 2 bedrooms
+    });
+  });
+
+  it("should validate valid input (outward postcode only)", () => {
+    const validInput = {
+      housePostcode: "SE17",
+      houseBedrooms: 2,
+      houseAge: 3,
+      houseType: "D",
+      maintenanceLevel: "medium",
+    };
+
+    const result = calculationSchema.parse(validInput);
+    console.log({result})
+    expect(result).toEqual({
+      ...validInput,
+      housePostcode: {
+        outcode: "SE17",
+        incode: null,
+        area: "SE",
+        district: "SE17",
+        sector: null,
+        postcode: null
       },
       houseSize: 70, // auto-assigned for 2 bedrooms
     });

--- a/app/schemas/formSchema.ts
+++ b/app/schemas/formSchema.ts
@@ -10,13 +10,6 @@ export const formSchema = z.object({
     .string()
     .min(1, "Postcode is required")
     .refine(isValidPostcode, "Invalid postcode"),
-  houseSize: z.coerce
-    .string()
-    .transform((val) => (val === "" ? undefined : Number(val)))
-    .optional()
-    .refine((value) => value === undefined || value > 0, {
-      message: "House size must be a positive number",
-    }),
   houseAge: z.coerce
     .number()
     .nonnegative("House age must be a positive number or 0"),

--- a/app/schemas/formSchema.ts
+++ b/app/schemas/formSchema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { isValid as isValidPostcode } from "postcode";
+import { isValid as isValidPostcode, validOutcode as isValidOutcode } from "postcode";
 import { HOUSE_TYPES } from "../models/Property";
 import { maintenanceLevelSchema } from "../schemas/calculationSchema";
 
@@ -8,8 +8,11 @@ const HouseTypeEnum = z.enum(HOUSE_TYPES);
 export const formSchema = z.object({
   housePostcode: z
     .string()
-    .min(1, "Postcode is required")
-    .refine(isValidPostcode, "Invalid postcode"),
+    .min(1, "Enter a postcode")
+    .refine(
+      (postcode) => isValidPostcode(postcode) || isValidOutcode(postcode), 
+      "Enter a valid postcode (e.g. SW1 1AA) or outcode (e.g. SW1)"
+    ),
   houseAge: z.coerce
     .number()
     .nonnegative("House age must be a positive number or 0"),

--- a/app/services/calculationService.test.ts
+++ b/app/services/calculationService.test.ts
@@ -9,9 +9,8 @@ import { socialRentAdjustmentsService } from "./socialRentAdjustmentsService";
 import { socialRentEarningsService } from "./socialRentEarningsService";
 import { rentService } from "./rentService";
 import { parse } from "postcode";
-import { ValidPostcode } from "../schemas/calculationSchema";
 import { z } from "zod";
-import { maintenanceLevelSchema } from "../schemas/calculationSchema";
+import { maintenanceLevelSchema, PostcodeScales } from "../schemas/calculationSchema";
 import { APIError } from "../lib/exceptions";
 
 jest.mock("./itlService");
@@ -46,7 +45,7 @@ describe("getHouseholdData", () => {
   }
 
   interface MockInputType {
-    housePostcode: ValidPostcode;
+    housePostcode: PostcodeScales;
     houseType: "D" | "S" | "T" | "F";
     houseAge: number;
     houseBedrooms: number;

--- a/app/services/calculationService.ts
+++ b/app/services/calculationService.ts
@@ -22,7 +22,10 @@ export const getHouseholdData = async (input: Calculation) => {
     const postcode = input.housePostcode;
     const postcodeArea = postcode.area; // extract only the characters for the area, e.g SE
     const postcodeDistrict = postcode.district; // extract only characters for the district, SE17
-    const postcodeSector = postcode.sector; // extract only the characters for the sector, SE17 1
+    
+    // may not be available (if user only enters outward postcode, aka district)
+    const postcodeSector = postcode.sector ?? postcodeDistrict; // extract only the characters for the sector, SE17 1
+    
     const bedrooms = input.houseBedrooms <= 4 ? input.houseBedrooms : 4; // rental data only goes up to 4br TODO: do we want to increase the weight? 
 
     const itl3 = await itlService.getByPostcodeDistrict(postcodeDistrict);


### PR DESCRIPTION
# What
- New type called `PostcodeScales` that allows `null`s for certain values, should work if user enters outward postcode instead of full 
    - Uses type in schema
- Updates tests

# Why
Alastair raised this in roadmap: what happens if someone wants to test a dream home location but doesn't know a full postcode? 

# Questions
I'm not sure if this was the most elegant way of doing this--suggestions very much appreciated. 

Closes #385 