### PR TITLE
feat: fix and style error messages

### DIFF
--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -101,7 +101,7 @@ const CalculatorInput = () => {
       case "INSUFFICIENT_PRICES_PAID_DATA":
         form.setError("housePostcode", {
           message:
-            "Insufficient data for this postcode. Please try again with a different postcode",
+            "Insufficient data for this postcode. Please try again with a different postcode.",
         });
         break;
       case "UNHANDLED_EXCEPTION":
@@ -195,7 +195,7 @@ const CalculatorInput = () => {
                       </div>
                     </RadioGroup>
                   </FormControl>
-                  <FormMessage />
+                  <FormMessage className="--error-text-rgb" />
                 </FormItem>
               )}
             />
@@ -215,7 +215,7 @@ const CalculatorInput = () => {
                         className="inputfield-style text-xs"
                       />
                     </FormControl>
-                    <FormMessage />
+                    <FormMessage  className="error-message-style" />
                   </FormItem>
                 )}
               />
@@ -236,7 +236,7 @@ const CalculatorInput = () => {
                         placeholder="Select house age"
                       />
                     </FormControl>
-                    <FormMessage />
+                    <FormMessage  className="error-message-style" />
                   </FormItem>
                 )}
               />
@@ -257,7 +257,7 @@ const CalculatorInput = () => {
                         className="inputfield-style text-xs"
                       />
                     </FormControl>
-                    <FormMessage />
+                    <FormMessage  className="error-message-style" />
                   </FormItem>
                 )}
               />
@@ -345,8 +345,8 @@ const CalculatorInput = () => {
                     </RadioGroup>
                   </FormControl>
                   <MaintenanceExplainerDrawer />
-                  <FormMessage />
-                </FormItem>
+                  <FormMessage  className="error-message-style" />
+                  </FormItem>
               )}
             />
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -27,6 +27,7 @@
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
   --social-rent-detail-color-rgb: 242 196 202;
+  --error-text-rgb: 181 31 20;
 }
 
 @layer utilities {
@@ -59,6 +60,10 @@ body {
   margin-top: 20px;
   margin-bottom: 10px;
   font-weight: 600;
+}
+
+.error-message-style {
+  color: rgb(var(--error-text-rgb));
 }
 
 .subheadstyle {

--- a/app/schemas/formSchema.ts
+++ b/app/schemas/formSchema.ts
@@ -8,25 +8,51 @@ const HouseTypeEnum = z.enum(HOUSE_TYPES);
 export const formSchema = z.object({
   housePostcode: z
     .string()
-    .min(1, "Postcode is required")
-    .refine(isValidPostcode, "Invalid postcode"),
+    .min(1, "Enter a postcode.")
+    .refine(isValidPostcode, "Enter a valid postcode."),
   houseSize: z.coerce
     .string()
     .transform((val) => (val === "" ? undefined : Number(val)))
     .optional()
     .refine((value) => value === undefined || value > 0, {
-      message: "House size must be a positive number",
+      message: "Enter a positive house size.",
     }),
-  houseAge: z.coerce
-    .number()
-    .nonnegative("House age must be a positive number or 0"),
-  houseBedrooms: z.coerce
-    .number()
-    .positive("House bedrooms must be a positive number"),
+  houseAge: z
+    .string({
+      required_error: "Enter an estimated build year.",
+      invalid_type_error: "Enter a valid estimated build year."
+    })
+    .transform((val) => {
+      if (!val) return undefined;
+      const parsed = Number(val);
+      return isNaN(parsed) ? undefined : parsed;
+    })
+    .pipe(
+      z.number({
+        invalid_type_error: "Enter a valid number for house age."
+      })
+      .nonnegative("Enter a positive number or 0.")
+    ),
+  houseBedrooms: z
+    .string({
+      required_error: "Enter the number of bedrooms.",
+      invalid_type_error: "Enter a valid number of bedrooms."
+    })
+    .transform((val) => {
+      if (!val) return undefined;
+      const parsed = Number(val);
+      return isNaN(parsed) ? undefined : parsed;
+    })
+    .pipe(
+      z.number({
+        invalid_type_error: "Enter a valid number of bedrooms."
+      })
+      .positive("Enter a positive number.")
+    ),
   houseType: HouseTypeEnum.refine(
     (value) => HouseTypeEnum.options.includes(value),
     {
-      message: `House type is required`,
+      message: `Enter a house type.`,
     }
   ),
   maintenanceLevel: maintenanceLevelSchema,


### PR DESCRIPTION
Ensures that meaningful error messages show (following content design principles (eg "Do this"), styled red to be more visible.

![image](https://github.com/user-attachments/assets/de4034d6-f43d-4bc8-abbf-24a318b9dc6b)

Closes #384 (where the 'before' screenshots can be found)
