### PR TITLE
feat: responsive graphs dashboard

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -75,7 +75,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
         </span>
       }
       >
-      <div className="flex flex-col h-full w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
         <div className="flex gap-2 mb-4">
         {TENURES.map(tenure => (
           <TenureSelector

--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -15,7 +15,7 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
       title="How much would a Fairhold home cost me?"
       subtitle="The up-front cost of a home, compared with conventional home ownership"
     >
-      <div className="flex flex-col h-full w-3/4 justify-between">
+      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
         <HowMuchFHCostWrapper household={data} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -49,7 +49,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
       title="How much would Fairhold cost me every month?"
       subtitle="Monthly cost of housing, excluding bills and maintenance"
     >
-      <div className="flex flex-col h-full w-3/4 justify-between">
+      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
         <HowMuchPerMonthWrapper household={processedData} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -51,7 +51,7 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
       title="How much could I sell it for?"
       subtitle="Estimated sale price at any time"
     >
-      <div className="flex flex-col h-full w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
       <div className="flex gap-2 mb-4">
           {TENURES.map(tenure => ( 
             <TenureSelector 

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend, Tooltip, Label } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Tooltip } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   StyledChartContainer,
@@ -93,39 +93,26 @@ const CostOverTimeStackedBarChart: React.FC<CostOverTimeStackedBarChartProps> = 
   }
 
   return (
-    <Card>
-      <CardContent>
-        <StyledChartContainer config={chartConfig}>
+    <Card className="h-full w-full">
+      <CardContent className="h-full w-full p-0 md:p-4">
+        <StyledChartContainer config={chartConfig}
+        className="h-full w-full">
           <BarChart 
             data={data}
             margin={{ top: 20, right: 30, left: 20, bottom: 50 }}
             >
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="year">
-              <Label
-                  value="Year"
-                  position="bottom"
-                  offset={10}
-                  className="label-class"
-                  />
-            </XAxis> 
+            <XAxis 
+              dataKey="year"
+              tickLine={false}
+              ></XAxis>
             <YAxis 
               domain={[0, maxY]}
               tickFormatter={formatValue}
+              tickLine={false}
               >
-                
-                <Label
-                  value="Cost"
-                  angle={-90}
-                  position="left"
-                  offset={10}
-                  className="label-class"
-                  />
               </YAxis>
             <Tooltip content={<CostOverTimeTooltip />} />
-            <Legend 
-                verticalAlign="top"
-            />
             
             {config.colors.landRent && ( 
               <Bar dataKey="landRent" stackId="a" fill={config.colors.landRent} name="Land Rent" /> 

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -26,7 +26,7 @@ const CostOverTimeTooltip = ({ active, payload, label }: TooltipProps<ValueType,
       <div className="grid grid-cols-2 gap-2">
         <div className="font-medium">Year {label}{parseInt(label as string) === 1 ? " (with deposit)" : ""}</div>
         {payload.map((entry, index) => (
-          <div key={`${entry.name}-${index}`} className="grid grid-cols-2 gap-4">
+          <div key={`tooltip-${entry.name}-${index}`} className="grid grid-cols-2 gap-4">
             <div style={{ color: entry.color }}>{entry.name}:</div>
             <div>£{entry.value ? entry.value.toLocaleString() : '0'}</div>
           </div>

--- a/app/components/graphs/CostOverTimeStackedBarChartMobile.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChartMobile.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Tooltip } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import { StyledChartContainer } from "../ui/StyledChartContainer";
+import { formatValue } from "@/app/lib/format";
+import { LifetimeBarData } from "./CostOverTimeStackedBarChart";
+
+interface CostOverTimeHorizontalChartProps {
+  data: LifetimeBarData[];
+  maxY: number;
+  config: {
+    colors: {
+      landRent?: string;
+      equity?: string;
+      interest?: string;
+      rent?: string;
+      maintenance?: string;
+    };
+  };
+}
+
+const CostOverTimeHorizontalChart: React.FC<CostOverTimeHorizontalChartProps> = ({
+  data,
+  maxY,
+  config
+}) => {
+  const chartConfig: Record<string, { label: string; color: string }> = {};
+  
+  // Same config setup as StackedBarChart
+  Object.entries(config.colors).forEach(([key, color]) => {
+    if (color) {
+      chartConfig[key] = {
+        label: key.charAt(0).toUpperCase() + key.slice(1),
+        color
+      };
+    }
+  });
+
+  return (
+    <Card className="h-full">
+      <CardContent className="h-[600px] w-full">
+        <StyledChartContainer config={chartConfig} className="h-full w-full">
+          <BarChart
+            layout="vertical"
+            data={data}
+            margin={{ top: 20, right: 5, left: 5, bottom: 20 }}
+            className="h-full w-full"
+          >
+            <CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={true} />
+            <XAxis
+              type="number"
+              domain={[0, maxY]}
+              tickFormatter={formatValue}
+              orientation="top"
+              tickLine={false}
+            >
+            </XAxis>
+            <YAxis
+              type="category"
+              dataKey="year"
+              ticks={Array.from(
+                { length: Math.floor(data.length / 5) + 1 },
+                (_, i) => i * 5
+              ).filter(tick => tick <= data.length)}
+              width={20}
+              axisLine={false}
+              tickLine={false}
+            >
+            </YAxis>
+            <Tooltip 
+              formatter={(value) => formatValue(value as number)}
+              labelFormatter={(label) => `Year ${label}`}
+            />
+            
+            {Object.entries(config.colors).map(([key, color]) => (
+              color && (
+                <Bar
+                  key={key}
+                  dataKey={key}
+                  stackId="a"
+                  fill={color}
+                  name={chartConfig[key].label}
+                />
+              )
+            ))}
+          </BarChart>
+        </StyledChartContainer>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CostOverTimeHorizontalChart;

--- a/app/components/graphs/CostOverTimeWrapper.tsx
+++ b/app/components/graphs/CostOverTimeWrapper.tsx
@@ -3,7 +3,9 @@ import React from "react";
 import ErrorBoundary from "../ErrorBoundary";
 import { Household } from "@/app/models/Household";
 import CostOverTimeStackedBarChart, { LifetimeBarData } from "./CostOverTimeStackedBarChart";
+import CostOverTimeStackedBarChartMobile from "./CostOverTimeStackedBarChartMobile";
 import { MaintenanceLevel } from "@/app/models/constants";
+import { useScreenSize } from "@/app/hooks/UseScreenSize";
 
 export type TenureType = 'marketPurchase' | 'fairholdLandPurchase' | 'fairholdLandRent' | 'marketRent' | 'socialRent';
 
@@ -40,6 +42,8 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
     tenure,
     household
 }) => {
+    const isMobile = useScreenSize();
+
     const formatData = (tenure: TenureType, household: Household, maintenanceLevel: MaintenanceLevel): LifetimeBarData[] => {
         const lifetimeData = household.lifetime.lifetimeData;
 
@@ -97,12 +101,22 @@ const CostOverTimeWrapper: React.FC<CostOverTimeWrapperProps> = ({
     const maxY = Math.ceil((1 * (maxValue)) / yScale) * yScale // Scale y axis by 1.1 (for a bit of visual headroom) and round to nearest hundred (or fifty) thousand to make things tidy
 
     return (
-        <ErrorBoundary>
-      <CostOverTimeStackedBarChart 
-        data={formattedData}
-        config={chartConfig}
-        maxY={maxY}
-      />
+    <ErrorBoundary>
+        <div className="h-full">
+        {isMobile ? (
+                <CostOverTimeStackedBarChartMobile 
+                    data={formattedData}
+                    config={chartConfig}
+                    maxY={maxY}
+                />
+            ) : (
+                <CostOverTimeStackedBarChart 
+                    data={formattedData}
+                    config={chartConfig}
+                    maxY={maxY}
+                />
+            )}
+        </div>
     </ErrorBoundary>
     )
 };

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList, Tooltip, TooltipProps } from "recharts";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Bar, BarChart, CartesianGrid, XAxis, LabelList, Tooltip, TooltipProps } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
 } from "@/components/ui/chart";
@@ -91,35 +91,50 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   ];
 
   return (
-    <Card>
-      <CardHeader></CardHeader>
-      <CardContent>
+    <Card className="h-full w-full">
+      <CardContent className="h-full w-full p-0 md:p-4">
         <StyledChartContainer config={chartConfig}
-        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
-          <BarChart accessibilityLayer data={chartData}>
+        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent h-full w-full">
+          <BarChart className="full" accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey="tenure"
               tickLine={false}
-              tickFormatter={(value) => {
-                switch (value) {
-                  case "freehold":
-                    return "Freehold";
-                  case "fairhold: land purchase":
-                    return "Fairhold – Land Purchase";
-                  case "fairhold: land rent":
-                    return "Fairhold – Land Rent";
-                  default:
-                    return value;
-                }
+              interval={0} 
+              height={60}  
+              tick={({ x, y, payload }) => {
+                const label = (() => {
+                  switch (payload.value) {
+                    case "freehold":
+                      return "Freehold";
+                    case "fairhold: land purchase":
+                      return "Fairhold –\nLand Purchase";
+                    case "fairhold: land rent":
+                      return "Fairhold –\nLand Rent";
+                    default:
+                      return payload.value;
+                  }
+                })();
+
+                return (
+                  <g transform={`translate(${x},${y})`}>
+                    {label.split('\n').map((line: string, i: number) => (
+                      <text
+                        key={i}
+                        x={0}
+                        y={i * 20}
+                        dy={10}
+                        textAnchor="middle"
+                        fill="#666"
+                        fontSize="12px"
+                      >
+                        {line}
+                      </text>
+                    ))}
+                  </g>
+                );
               }}
             >
-              <Label
-                value="Tenure Types"
-                position="bottom"
-                offset={20}
-                className="label-class"
-              />
             </XAxis>
 
             <Tooltip content={<CustomTooltip />} />

--- a/app/components/graphs/HowMuchFHCostWrapper.tsx
+++ b/app/components/graphs/HowMuchFHCostWrapper.tsx
@@ -54,7 +54,7 @@ const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
 
   return (
     <ErrorBoundary>
-      <div>
+      <div className="h-full w-full">
         <HowMuchFHCostBarChart data={formattedData} />
       </div>
     </ErrorBoundary>

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis, LabelList, ReferenceLine } from "recharts";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartLegend,
   ChartLegendContent,
@@ -73,23 +73,60 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
   ];
 
   return (
-    <Card>
-      <CardHeader></CardHeader>
-      <CardContent>
+    <Card className="h-full w-full">
+      <CardContent className="h-full w-full p-0 md:p-4">
         <StyledChartContainer config={{}}
-        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
+        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent h-full w-full">
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey="tenure"
-              tickMargin={10}
-              tickSize={0}
-              tickFormatter={(value) => value}
-            />
+              tickLine={false}
+              interval={0} 
+              height={60} 
+              tick={({ x, y, payload }) => {
+                const label = (() => {
+                  switch (payload.value) {
+                    case "Freehold":
+                      return "Freehold";
+                    case "Private Rent":
+                      return "Private\nrent";
+                    case "Fairhold - Land Purchase":
+                      return "Fairhold \n/LP";
+                    case "Fairhold - Land Rent":
+                      return "Fairhold \n/LR";
+                    case "Social Rent":
+                      return "Social\nRent";
+                    default:
+                      return payload.value;
+                  }
+                })();
+                              return (
+                                <g transform={`translate(${x},${y})`}>
+                                  {label.split('\n').map((line: string, i: number) => (
+                                    <text
+                                      key={i}
+                                      x={0}
+                                      y={i * 20}
+                                      dy={10}
+                                      textAnchor="middle"
+                                      fill="#666"
+                                      fontSize="12px"
+                                    >
+                                      {line}
+                                    </text>
+                                  ))}
+                                </g>
+                              );
+                            }}
+                          >
+                          </XAxis>
             <YAxis 
               domain={[0, maxY]}
-              tickMargin={10}
-              tickFormatter={formatValue}
+              tick={false}
+              axisLine={false}
+              tickLine={false}
+              hide={true}
               ></YAxis>
             <ChartLegend content={<ChartLegendContent />} />    
               <Bar dataKey="monthly" strokeWidth={2} activeIndex={2}>

--- a/app/components/graphs/HowMuchPerMonthWrapper.tsx
+++ b/app/components/graphs/HowMuchPerMonthWrapper.tsx
@@ -63,7 +63,7 @@ const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
 
   return (
     <ErrorBoundary>
-      <div>
+      <div  className="h-full">
         <HowMuchPerMonthBarChart 
           data={formattedData}
           maxY={maxY} 

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { LineChart, Line, CartesianGrid, XAxis, YAxis, Label, TooltipProps } from "recharts";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, TooltipProps } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
   ChartTooltip,
@@ -95,38 +95,28 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
   };
 
   return (
-    <Card>
-      <CardHeader></CardHeader>
-      <CardContent>
-        <StyledChartContainer config={chartConfig}>
+    <Card className="h-full w-full">
+      <CardContent className="h-full w-full p-0 md:p-4">
+        <StyledChartContainer config={chartConfig}  className="h-full w-full">
           <LineChart
             data={data}
-            margin={{ top: 20, right: 30, left: 20, bottom: 50 }}
           >
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis 
               dataKey="year"
               tickLine={false}
+              ticks={Array.from(
+                { length: Math.floor(data.length / 5) + 1 },
+                (_, i) => i * 5
+              ).filter(tick => tick <= data.length)}
             >
-              <Label
-                value="Year"
-                position="bottom"
-                offset={20}
-                className="label-class"
-              />
             </XAxis>
             <YAxis
               tickFormatter={formatValue}
               tickLine={false}
               domain={[0, maxY]}
+              width={40}
             >
-              <Label
-                value="Resale Value"
-                angle={-90}
-                position="left"
-                offset={0}
-                className="label-class"
-              />
             </YAxis>
             <ChartTooltip content={<CustomTooltip />} />
             {renderLine("high")}

--- a/app/components/graphs/ResaleValueWrapper.tsx
+++ b/app/components/graphs/ResaleValueWrapper.tsx
@@ -48,7 +48,7 @@ const ResaleValueWrapper: React.FC<ResaleValueWrapperProps> = ({
 
     return (
         <ErrorBoundary>
-        <div>
+        <div  className="h-full">
           <ResaleValueLineChart 
             data={formattedData} 
             selectedMaintenance={household.property.maintenanceLevel}

--- a/app/components/ui/GraphCard.tsx
+++ b/app/components/ui/GraphCard.tsx
@@ -8,9 +8,9 @@ type Props = React.PropsWithChildren<{
 const GraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
     <div className="h-screen snap-start p-10 flex flex-col">
-      <div className="w-3/4">
-        <h1 className="text-black">{title}</h1>
-        {subtitle && <h2>{subtitle}</h2>}
+      <div className="w-full md:w-3/4">
+        <h1 className={`text-2xl md:text-3xl lg:text-4xl  sm:text-xl font-bold text-black`}>{title}</h1>
+        {subtitle && <h2 className={`text-lg md:text-xl lg:text-2xl text-gray-600 mt-2`}>{subtitle}</h2>}
       </div>
       {children && <div className="mt-4 flex-1">{children}</div>}
     </div>

--- a/app/hooks/UseScreenSize.tsx
+++ b/app/hooks/UseScreenSize.tsx
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export const useScreenSize = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkScreenSize = () => {
+      setIsMobile(window.innerWidth < 768); // matches Tailwind's md breakpoint
+    };
+
+    checkScreenSize();
+    window.addEventListener('resize', checkScreenSize);
+    return () => window.removeEventListener('resize', checkScreenSize);
+  }, []);
+
+  return isMobile;
+};


### PR DESCRIPTION
# What does this PR do?
- Responsive styling in the graphs: just looking at layout for the moment, not addressing all of Alastair's new changes in [Figma](https://www.figma.com/design/SThTPsRJbUzhgPJIgjIXdo/Fairhold-Calculator?node-id=0-1&t=Ow50PrRJhYO13L7A-1)
- New CostOverTimeStackedBarChartMobile component (this is the only one that needs to rotate on mobile), conditional logic / new `UseScreenSize` hook will select which one to render
-  `GraphCard` component now has responsive titles / subtitles

Closes #360 