### PR TITLE
fix: more info button colours

### DIFF
--- a/app/components/ui/BackgroundAssumptions.tsx
+++ b/app/components/ui/BackgroundAssumptions.tsx
@@ -1,7 +1,7 @@
 import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 
 export const BackgroundAssumptions: React.FC = () =>  (
-  <a href="https://github.com/theopensystemslab/fairhold-dashboard/wiki" className="flex text-sm items-center">
+  <a href="https://github.com/theopensystemslab/fairhold-dashboard/wiki" className="flex text-sm items-center text-[rgb(var(--text-inaccessible-rgb))] decoration-[rgb(var(--text-inaccessible-rgb))]">
     <QuestionMarkCircledIcon className="mr-2"/>
     Explore other background assumptions we have made in this calculator
   </a>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import plugin from "tailwindcss/plugin";
 
 const config: Config = {
   darkMode: ["class"],
@@ -85,6 +86,13 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    require("tailwindcss-animate"),
+    plugin(function({ addBase }) {
+      addBase({
+        'span, a': { color: 'rgb(var(--text-inaccessible-rgb))' },
+      });
+    })
+],
 };
 export default config;


### PR DESCRIPTION
A tiny PR to fix different colours, making `a` and `span` elements use `text-inaccessible-rgb` in the Tailwind config file (great shout Daf!). They still look kind of different to me 😅 but browser dev tools tells me that they are both ABA4A4. 

`BackgroundAssumptions` still needed the colour to be overwritten and I specified `decoration` there too.

Previous:
![image](https://github.com/user-attachments/assets/fce4d5fa-893a-4740-a2de-94d9a4028053)

Now:
![image](https://github.com/user-attachments/assets/4085efaa-ce0d-410b-9acf-572f7d1a822a)

Closes #416 