### PR TITLE
(wip)feat: restyle up-front card

### DIFF
--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -10,11 +10,22 @@ interface DashboardProps {
 }
 
 export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
+  const fairholdPercentage = Math.round((data.tenure.fairholdLandPurchase.discountedLandPrice + data.property.depreciatedBuildPrice) // shows FairholdLP
+    / data.property.averageMarketPrice * 100)
+
   return (
     <GraphCard
-      title="How much would a Fairhold home cost me?"
-      subtitle="The up-front cost of a home, compared with conventional home ownership"
-    >
+      title="How much would a home cost?"
+      subtitle={
+              <span>
+                A Fairhold home could cost 
+                <span style={{ color: "rgb(var(--fairhold-equity-color-rgb))" }} className="font-semibold">
+                  {` ${fairholdPercentage}% `}
+                </span>
+                of its freehold price.
+              </span>
+            }
+          >
       <div className="flex flex-col h-full w-3/4 justify-between">
         <HowMuchFHCostWrapper household={data} />
         <Drawer

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList, Tooltip, TooltipProps } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList } from "recharts";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ChartConfig,
@@ -8,8 +8,6 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { ValueType } from "tailwindcss/types/config";
-import { NameType } from "recharts/types/component/DefaultTooltipContent";
 
 const chartConfig = {
   freeholdLand: {
@@ -24,6 +22,9 @@ const chartConfig = {
   fairholdHouse: {
     color: "rgb(var(--fairhold-interest-color-rgb))",
   },
+  total: {
+    color: "transparent",
+  }
 } satisfies ChartConfig;
 
 import React from "react";
@@ -41,20 +42,6 @@ interface StackedBarChartProps {
   data: DataInput[];
 }
 
-const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
-  if (!active || !payload) return null;
-
-  const total = payload[0].payload.total;
-  return (
-    <div className="rounded-lg border bg-background p-2 shadow-sm">
-      <div className="grid grid-cols-2 gap-2">
-        <div className="font-medium">Total:</div>
-        <div>£{total.toLocaleString()}</div>
-      </div>
-    </div>
-  );
-};
-
 const formatValueWithLabel = (value: number, dataKey: string) => {
   const formattedValue = formatValue(value);
   
@@ -62,6 +49,8 @@ const formatValueWithLabel = (value: number, dataKey: string) => {
     return `Land: ${formattedValue}`;
   } else if (dataKey.includes('House')) {
     return `House: ${formattedValue}`;
+  } else if (dataKey === 'total') {
+    return formattedValue;
   }
   
   return formattedValue;
@@ -75,18 +64,18 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       tenure: "freehold",
       freeholdLand: data[0].marketPurchase,
       freeholdHouse: data[1].marketPurchase,
-      total: data[0].marketPurchase + data[1].marketPurchase,
+      freeholdTotal: data[0].marketPurchase + data[1].marketPurchase,
     },
     {
       tenure: "fairhold: land purchase",
       fairholdLand: data[0].fairholdLandPurchase,
       fairholdHouse: data[2].fairholdLandPurchase,
-      total: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
+      fairholdTotal: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
     },
     {
       tenure: "fairhold: land rent",
       fairholdHouse: data[2].fairholdLandRent,
-      total: data[2].fairholdLandRent,
+      fairholdTotal: data[2].fairholdLandRent,
     },
   ];
 
@@ -96,7 +85,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       <CardContent>
         <StyledChartContainer config={chartConfig}
         className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent">
-          <BarChart accessibilityLayer data={chartData}>
+          <BarChart accessibilityLayer data={chartData} margin={{ top: 30 }}>
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey="tenure"
@@ -122,7 +111,6 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               />
             </XAxis>
 
-            <Tooltip content={<CustomTooltip />} />
             <Bar
               dataKey="freeholdLand"
               stackId="stack"
@@ -148,6 +136,15 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 fill="white"
                 fontSize={12}
               />
+              <LabelList
+                dataKey="freeholdTotal"
+                position="top"
+                offset={10}
+                formatter={(value: number) => formatValueWithLabel(value, "freeholdTotal")}
+                fill="rgb(var(--freehold-equity-color-rgb))" 
+                fontSize={18}
+                fontWeight={600}
+                />
               </Bar>
             <Bar
               dataKey="fairholdLand"
@@ -174,6 +171,15 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 fill="white"
                 fontSize={12}
               />
+              <LabelList
+                dataKey="fairholdTotal"
+                position="top"
+                offset={10}
+                formatter={(value: number) => formatValueWithLabel(value, "fairholdTotal")}
+                fill="rgb(var(--fairhold-equity-color-rgb))"
+                fontSize={18}
+                fontWeight={600}
+                />
             </Bar>
           </BarChart>
         </StyledChartContainer>

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -46,11 +46,9 @@ const formatValueWithLabel = (value: number, dataKey: string) => {
   const formattedValue = formatValue(value);
   
   if (dataKey.includes('Land')) {
-    return `Land: ${formattedValue}`;
+    return `Land`;
   } else if (dataKey.includes('House')) {
-    return `House: ${formattedValue}`;
-  } else if (dataKey === 'total') {
-    return formattedValue;
+    return `House`;
   }
   
   return formattedValue;
@@ -63,18 +61,23 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
     {
       tenure: "freehold",
       freeholdLand: data[0].marketPurchase,
+      freeholdLandLabel: "Land",
       freeholdHouse: data[1].marketPurchase,
+      freeholdHouseLabel: "House",
       freeholdTotal: data[0].marketPurchase + data[1].marketPurchase,
     },
     {
       tenure: "fairhold: land purchase",
       fairholdLand: data[0].fairholdLandPurchase,
+      fairholdLandLabel: "Land",
       fairholdHouse: data[2].fairholdLandPurchase,
+      fairholdHouseLabel: "House",
       fairholdTotal: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
     },
     {
       tenure: "fairhold: land rent",
       fairholdHouse: data[2].fairholdLandRent,
+      fairholdHouseLabel: "House",
       fairholdTotal: data[2].fairholdLandRent,
     },
   ];
@@ -117,9 +120,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-freeholdLand)"
             >
               <LabelList
-                dataKey="freeholdLand"
+                dataKey="freeholdLandLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "freeholdLand")}
                 fill="white"
                 fontSize={12}
               />
@@ -130,9 +132,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-freeholdHouse)"
             >
               <LabelList
-                dataKey="freeholdHouse"
+                dataKey="freeholdHouseLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "freeholdHouse")}
                 fill="white"
                 fontSize={12}
               />
@@ -152,9 +153,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-fairholdLand)"
             >
               <LabelList
-                dataKey="fairholdLand"
+                dataKey="fairholdLandLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "fairholdLand")}
                 fill="white"
                 fontSize={12}
               />
@@ -165,9 +165,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-fairholdHouse)"
             >
               <LabelList
-                dataKey="fairholdHouse"
+                dataKey="fairholdHouseLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "fairholdHouse")}
                 fill="white"
                 fontSize={12}
               />

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, Label, LabelList, Tooltip } from "recharts";
+import type { ValueType, NameType } from "recharts/types/component/DefaultTooltipContent";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ChartConfig,
 } from "@/components/ui/chart";
+import { TooltipProps } from "recharts";
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
+
+import React from "react";
+import { formatValue } from "@/app/lib/format";
 
 const chartConfig = {
   freeholdLand: {
@@ -27,8 +32,43 @@ const chartConfig = {
   }
 } satisfies ChartConfig;
 
-import React from "react";
-import { formatValue } from "@/app/lib/format";
+const UpFrontCostTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
+  if (!active || !payload) return null;
+
+    // Sort payload so House comes before Land
+    const sortedPayload = [...payload].sort((a, b) => {
+      const aIsLand = (a.dataKey as string).includes("Land");
+      const bIsLand = (b.dataKey as string).includes("Land");
+      return aIsLand ? 1 : bIsLand ? -1 : 0;
+    });
+
+  return (
+    <div className="rounded-lg bg-[rgb(var(--text-default-rgb))] p-2 shadow-sm">
+      <div className="flex flex-col gap-2">
+        {sortedPayload.map((segment, index) => {
+          const dataKey = segment.dataKey as string;
+          const value = segment.value as number;
+
+          let segmentLabel = "";
+          if (dataKey.includes("House")) {
+            segmentLabel = "House";
+          }
+          else if (dataKey.includes("Land")) {
+            segmentLabel = "Land";
+          }
+          return (
+            <div key={index} className="grid grid-cols-2 gap-2">
+              <div className="font-normal text-white">
+                {`${segmentLabel}`}
+              </div>
+              <div className="text-right text-white">{formatValue(value)}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
 
 type DataInput = {
   category: string;
@@ -180,6 +220,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 fontWeight={600}
                 />
             </Bar>
+            <Tooltip content={<UpFrontCostTooltip />} />
           </BarChart>
         </StyledChartContainer>
       </CardContent>


### PR DESCRIPTION
Following the new designs, this PR
- Adds a tooltip to the `HowMuchFHCost` graph
- Adds the total labels on top of each bar
- Inserts a highlight variable into the subtitle (to show Fairhold % of market)
- Updates the copy for title and subtitle

Issues
- I couldn't overwrite the square corners on the tooltip somehow
- I couldn't figure out how to access the correct object in the payload to segment the house bars from the land bars (to show different tooltips while hovering over each), so both Land and House labels are in one tooltip right now
![image](https://github.com/user-attachments/assets/80920f93-27d7-41dd-8e51-678684d19b59)

Closes #413 