### PR TITLE
feat: restructure and restyle social value

### DIFF
--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -1,7 +1,7 @@
 import { Household } from "@/app/models/Household";
 import { Drawer } from "../../ui/Drawer";
 import GraphCard from "../../ui/GraphCard"
-import { SOCIAL_VALUE_YEARS, DEFAULT_INTEREST_RATE, DEFAULT_MORTGAGE_TERM, DEFAULT_INITIAL_DEPOSIT } from "@/app/models/constants";
+import { DEFAULT_INTEREST_RATE, DEFAULT_MORTGAGE_TERM, DEFAULT_INITIAL_DEPOSIT } from "@/app/models/constants";
 import ReactMarkdown from 'react-markdown';
 import explanationContent from '../Help/WhatDifference.md';
 import { DEFAULT_FORECAST_PARAMETERS } from "@/app/models/ForecastParameters";
@@ -20,64 +20,54 @@ type WhatDifferenceProps = {
   data: Household;
 }
 
-const Card: React.FC<React.PropsWithChildren<CardProps>> = ({ title, figure, subfigure, children }) => (
-  <div className="flex flex-col w-1/5">
-    <p className="text-lg font-semibold mb-0">{title}</p>
+const Card: React.FC<React.PropsWithChildren<CardProps>> = ({ title, children }) => (
+  <div className="px-4 py-4 flex flex-col flex-1 max-w-[300px] bg-white drop-shadow-md">
+      <p className="text-2xl font-semibold mb-0 text-[rgb(var(--text-default-rgb))]">{title}</p>
     <div className="text-sm">{children}</div>
-    <div className="flex items-center gap-2">
-      {figure &&
-        <p className="text-4xl text-green-500 font-semibold">{figure}</p>
-      }
-      {figure && subfigure && 
-        <p className="text-sm text-green-500 font-semibold">{subfigure}</p>
-      }
-    </div>
+  </div>
+)
+
+const SubCard: React.FC<React.PropsWithChildren<CardProps>> = ({ figure, title, children})  => (
+  <div className="py-2">
+    <p className="text-2xl text-[rgb(var(--fairhold-equity-color-rgb))] font-semibold">{figure}</p>
+    <p className="text-xl text-[rgb(var(--fairhold-equity-color-rgb))] font-semibold">{title}</p>
+    <div className="text-sm">{children}</div>
   </div>
 )
 
 const Highlight: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <span className="text-green-500 font-semibold">{children}</span>
+  <span className="text-[rgb(var(--fairhold-equity-color-rgb))] font-semibold">{children}</span>
 )
 
 const Cards: React.FC<CardsProps> = ({ household }) => {
-  const moneySaved = Math.max(Math.round(household.socialValue.moneySaved),0).toLocaleString(); // Using .toLocaleString() to separate decimals and thousands correctly
-  const communityWealthDecade = Math.round(household.socialValue.communityWealthDecade).toLocaleString();
-  const embodiedCarbonSavings = household.socialValue.embodiedCarbonSavings.toFixed(1);
-  const savingsEnergyPoundsYearly = Math.round(household.socialValue.savingsEnergyPoundsYearly).toLocaleString()
-  const savingsToNHSPerHouseLifetime = Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.nhsCumulative).toLocaleString();
-  const savingsToSocietyPerHouseLifetime = Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.socialCumulative).toLocaleString();
-  const newBuildPrice = Math.round(household.property.newBuildPrice).toLocaleString();
-  const operationalCarbonSavingsYearly = household.socialValue.operationalCarbonSavingsYearly.toFixed(1);
-  const maintenanceCost = Math.round(household.lifetime.lifetimeData[0].maintenanceCost[household.property.maintenanceLevel]).toLocaleString();
+  const lifetime = household.lifetime.lifetimeData.length;
+  const moneySaved = `£${Math.max(Math.round(household.socialValue.moneySaved),0).toLocaleString()}`; // Using .toLocaleString() to separate decimals and thousands correctly
+  const communityWealthLifetime = `£${Math.round(household.socialValue.communityWealthLifetime).toLocaleString()}`;
+  const embodiedCarbonSavings = `${household.socialValue.embodiedCarbonSavings.toFixed(1)} TCO₂e`;
+  const savingsEnergyPoundsYearly = `£${Math.round(household.socialValue.savingsEnergyPoundsYearly).toLocaleString()}`
+  const savingsToNHSYear1 = `£${Math.round(household.lifetime.lifetimeData[0].healthSavings.nhs)}`;
+  const savingsToNHSPerHouseLifetime = `£${Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.nhsCumulative).toLocaleString()}`;
+  const savingsToSocietyPerHouseLifetime = `£${Math.round(household.lifetime.lifetimeData[household.lifetime.lifetimeData.length - 1].healthSavings.socialCumulative).toLocaleString()}`;
+  const newBuildPrice = `£${Math.round(household.property.newBuildPrice).toLocaleString()}`;
+  const operationalCarbonSavingsYearly = `${household.socialValue.operationalCarbonSavingsYearly.toFixed(1)} TCO₂e`;
+  const maintenanceCost = `£${Math.round(household.lifetime.lifetimeData[0].maintenanceCost[household.property.maintenanceLevel]).toLocaleString()}`;
   const localJobs = household.socialValue.localJobs.toFixed(1);
 
-  return <div className="flex flex-wrap gap-6">
-    <Card title="Money saved" figure={`£${moneySaved}`}>
-      <p>If Fairhold Land Purchase, on housing costs over {DEFAULT_FORECAST_PARAMETERS.yearsForecast} years compared to conventional ownership</p>
+  return <div className="flex flex-col sm:flex-row gap-6 w-3/4 justify-center py-4">
+    <Card title="Economy">
+      <SubCard figure={moneySaved} title="Savings on housing costs">Over {lifetime} years.</SubCard>
+      <SubCard figure={savingsToNHSPerHouseLifetime} title="Health savings">If moving from substandard accommodation, the home would save the NHS <Highlight>{savingsToNHSYear1}</Highlight> per year and the wider economy <Highlight>{savingsToSocietyPerHouseLifetime}</Highlight> over {lifetime} years.</SubCard>
+      <SubCard figure={savingsEnergyPoundsYearly} title="Energy savings">Every year, if new build or retrofitted.</SubCard>
     </Card>
-    <Card title="Community wealth">
-      <p>
-        If Fairhold Land Rent, every {SOCIAL_VALUE_YEARS} years the house would contribute{" "}
-        <Highlight>£{communityWealthDecade}</Highlight> to community infrastructure and services
-      </p>
+
+    <Card title="Community">
+      <SubCard figure={communityWealthLifetime} title="Community wealth">Contributions to community infrastructure and services over {lifetime} years, if using Fairhold Land Rent.</SubCard>
+      <SubCard figure={newBuildPrice} title="Local economy boost">If new build, the home would add <Highlight>{newBuildPrice}</Highlight> to the local economy, and <Highlight>{maintenanceCost}</Highlight> every year, supporting <Highlight>{localJobs}</Highlight> full-time equivalent jobs in total.</SubCard>
     </Card>
-    <Card title="Embodied carbon savings" figure={`${embodiedCarbonSavings} TCO₂e`}>
-      <p>If new build, compared to typical development</p>
-    </Card>
-    <Card title="Energy savings" figure={`£${savingsEnergyPoundsYearly}`} subfigure="per year">
-      <p>Every year, if new build or retrofitted</p>
-    </Card>
-    <Card title="Health savings">
-    <p>
-        If moving from substandard accommodation, Fairhold would save the NHS {" "}
-        <Highlight>£{savingsToNHSPerHouseLifetime}</Highlight> and society at large {" "}<Highlight>£{savingsToSocietyPerHouseLifetime}</Highlight> over {DEFAULT_FORECAST_PARAMETERS.yearsForecast} years
-      </p>
-    </Card>
-    <Card title="Local economy">
-      <p>If new build, the home would add <Highlight>£{newBuildPrice}</Highlight> to the local economy, and <Highlight>£{maintenanceCost}</Highlight> every year, supporting <Highlight>{localJobs}</Highlight> full-time-equivalent jobs in total</p>
-    </Card>
-    <Card title="Annual carbon savings" figure={`${operationalCarbonSavingsYearly} TCO₂e`}>
-      <p>If new build or retrofit, compared to average home</p>
+
+    <Card title="Environment">
+      <SubCard figure={embodiedCarbonSavings} title={"Embodied carbon savings"}>If new build, compared to typical development.</SubCard>
+      <SubCard figure={operationalCarbonSavingsYearly} title={"Annual carbon savings"}>If new build or retrofit, compared to the average home.</SubCard>
     </Card>
   </div>
 }
@@ -103,12 +93,12 @@ export const WhatDifference: React.FC<WhatDifferenceProps> = ({ data }) => {
   
   return (
     <GraphCard 
-      title="What difference would Fairhold make to me, my community, and the world?"
-      subtitle="Social, environmental and economic impacts"  
+      title="What impact would Fairhold have?"
+      subtitle="The wider benefits for people and planet."  
     >
-      <div className="flex flex-col h-full w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full">
         <Cards household={data}/>
-        <Drawer
+        <Drawer 
           buttonTitle="Find out more about how we estimated these"
           title="How we estimated these figures"
           description={<ReactMarkdown className="space-y-4">{processedContent}</ReactMarkdown>}

--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -53,7 +53,7 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
   const maintenanceCost = `£${Math.round(household.lifetime.lifetimeData[0].maintenanceCost[household.property.maintenanceLevel]).toLocaleString()}`;
   const localJobs = household.socialValue.localJobs.toFixed(1);
 
-  return <div className="flex flex-col sm:flex-row gap-6 w-3/4 justify-center py-4">
+  return <div className="flex md:flex-row flex-col gap-6 w-3/4 justify-center py-4">
     <Card title="Economy">
       <SubCard figure={moneySaved} title="Savings on housing costs">Over {lifetime} years.</SubCard>
       <SubCard figure={savingsToNHSPerHouseLifetime} title="Health savings">If moving from substandard accommodation, the home would save the NHS <Highlight>{savingsToNHSYear1}</Highlight> per year and the wider economy <Highlight>{savingsToSocietyPerHouseLifetime}</Highlight> over {lifetime} years.</SubCard>

--- a/app/models/SocialValue.test.ts
+++ b/app/models/SocialValue.test.ts
@@ -13,7 +13,7 @@ describe('Social Value', () => {
         expect(socialValue.moneySaved).toBeCloseTo(481215.981)
     })
     it("calculates money to community", () => {
-        expect(socialValue.communityWealthDecade).toBeCloseTo(5425.91)
+        expect(socialValue.communityWealthLifetime).toBeCloseTo(5425.91)
     })
     it("calculates energy bill savings", () => {
         expect(socialValue.savingsEnergyPoundsYearly).toBeCloseTo(554.4)

--- a/app/models/SocialValue.test.ts
+++ b/app/models/SocialValue.test.ts
@@ -13,7 +13,7 @@ describe('Social Value', () => {
         expect(socialValue.moneySaved).toBeCloseTo(481215.981)
     })
     it("calculates money to community", () => {
-        expect(socialValue.communityWealthLifetime).toBeCloseTo(5425.91)
+        expect(socialValue.communityWealthLifetime).toBeCloseTo(43270.08)
     })
     it("calculates energy bill savings", () => {
         expect(socialValue.savingsEnergyPoundsYearly).toBeCloseTo(554.4)

--- a/app/models/SocialValue.ts
+++ b/app/models/SocialValue.ts
@@ -4,7 +4,6 @@ import { KG_CO2_PER_KWH,
     NHS_SAVINGS_PER_HOUSE_PER_YEAR, 
     SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR, 
     FTE_SPEND, 
-    SOCIAL_VALUE_YEARS,
     EMBODIED_CARBON_BRICK_BLOCK_KG_M2,
     EMBODIED_CARBON_TIMBER_SLAB_KG_M2
 } from "./constants";
@@ -15,7 +14,7 @@ type ConstructorParams = {
 
 export class SocialValue {
     public moneySaved: number;
-    public communityWealthDecade: number;
+    public communityWealthLifetime: number;
     public embodiedCarbonSavings: number;
     public savingsEnergyPoundsYearly: number;
     public savingsToNHSPerHouseYearly: number;
@@ -25,7 +24,7 @@ export class SocialValue {
 
     constructor(params: ConstructorParams) {
         this.moneySaved = this.calculateMoneySavedFHLP(params);
-        this.communityWealthDecade = this.calculateCommunityWealth(params);
+        this.communityWealthLifetime = this.calculateCommunityWealth(params);
         this.embodiedCarbonSavings = this.calculateEmbodiedCarbonSaved(params)
         this.savingsEnergyPoundsYearly = this.calculateSavingsEnergyPoundsYearly(params);
         this.savingsToNHSPerHouseYearly = NHS_SAVINGS_PER_HOUSE_PER_YEAR;
@@ -45,8 +44,9 @@ export class SocialValue {
     }
     private calculateCommunityWealth(params: ConstructorParams) {
         const lifetime = params.household.lifetime.lifetimeData
+        const lifetimeLength = params.household.lifetime.lifetimeData.length
         let communityWealth = 0
-        for (let i = 0; i < SOCIAL_VALUE_YEARS; i++) { // TODO: decide on time period
+        for (let i = 0; i < lifetimeLength; i++) {
             communityWealth += lifetime[i].fairholdLandRentCGRYearly
         }
         return communityWealth;

--- a/app/models/constants.ts
+++ b/app/models/constants.ts
@@ -191,8 +191,6 @@ export const SOCIAL_SAVINGS_PER_HOUSE_PER_YEAR = 5286
 
 export const FTE_SPEND = 60000
 
-export const SOCIAL_VALUE_YEARS = 10;
-
 /** 
  * from Leeds Beckett Wikihouse LCA comparison report: 30.66 tco2e for a 92m2 brick and block home in A1-A5 
  * https://cdn.prod.website-files.com/612569c3243035968aaf61f1/63bd27536d1e152e28e96403_77084_Wikihouse%20Thermal%20Perfromance%20and%20LCA%20report_July%202021.pdf


### PR DESCRIPTION
# What does this PR do? 
Restyles the social value card (`WhatDifference`) and makes some minor updates to the `SocialValue` class since we decided to show benefits over `lifetime` length and not the somewhat arbitrary 10 year perios. 

# Questions
In line 56, the effects of `flex-col` and `flex-row` seem to be reversed. Am I being stupid? I removed styling from parent and grandparent etc. elements to try to isolate the issue and wasn't able to, so just kept the classes as is to achieve desired look. 
___

I'd say the bulk of the restyling is done, this is what desktop looks like:
![image](https://github.com/user-attachments/assets/8ee4a00b-c5b3-478e-a900-773e39e1bf79)

And responsive sizes etc are working on mobile (scrolling / snap is a separate issue so I would like to keep that in a separate PR):
![image](https://github.com/user-attachments/assets/8941b34e-dc90-48f8-b835-7ea24c6b2cba)

Design for reference:
![image](https://github.com/user-attachments/assets/995225d8-6e1f-45b2-9a75-52ff9186a8c9)
