### PR TITLE
feat: restyle up-front cost graph

### DIFF
--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -10,12 +10,23 @@ interface DashboardProps {
 }
 
 export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
+  const fairholdPercentage = Math.round((data.tenure.fairholdLandPurchase.discountedLandPrice + data.property.depreciatedBuildPrice) // shows FairholdLP
+    / data.property.averageMarketPrice * 100)
+
   return (
     <GraphCard
-      title="How much would a Fairhold home cost me?"
-      subtitle="The up-front cost of a home, compared with conventional home ownership"
-    >
-      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
+      title="How much would a home cost?"
+      subtitle={
+              <span>
+                A Fairhold home could cost 
+                <span style={{ color: "rgb(var(--fairhold-equity-color-rgb))" }} className="font-semibold">
+                  {` ${fairholdPercentage}% `}
+                </span>
+                of its freehold price.
+              </span>
+            }
+          >
+      <div className="flex flex-col h-full w-3/4 justify-between">
         <HowMuchFHCostWrapper household={data} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -26,7 +26,7 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
               </span>
             }
           >
-      <div className="flex flex-col h-full w-3/4 justify-between">
+      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
         <HowMuchFHCostWrapper household={data} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -27,7 +27,7 @@ const chartConfig = {
 } satisfies ChartConfig;
 
 import React from "react";
-import { formatValue } from "@/app/lib/format";
+// import { formatValue } from "@/app/lib/format";
 
 type DataInput = {
   category: string;
@@ -55,18 +55,6 @@ const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) =
   );
 };
 
-const formatValueWithLabel = (value: number, dataKey: string) => {
-  const formattedValue = formatValue(value);
-  
-  if (dataKey.includes('Land')) {
-    return `Land: ${formattedValue}`;
-  } else if (dataKey.includes('House')) {
-    return `House: ${formattedValue}`;
-  }
-  
-  return formattedValue;
-};
-
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
 }) => {
@@ -74,19 +62,24 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
     {
       tenure: "freehold",
       freeholdLand: data[0].marketPurchase,
+      freeholdLandLabel: "Land",
       freeholdHouse: data[1].marketPurchase,
-      total: data[0].marketPurchase + data[1].marketPurchase,
+      freeholdHouseLabel: "House",
+      freeholdTotal: data[0].marketPurchase + data[1].marketPurchase,
     },
     {
       tenure: "fairhold: land purchase",
       fairholdLand: data[0].fairholdLandPurchase,
+      fairholdLandLabel: "Land",
       fairholdHouse: data[2].fairholdLandPurchase,
-      total: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
+      fairholdHouseLabel: "House",
+      fairholdTotal: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
     },
     {
       tenure: "fairhold: land rent",
       fairholdHouse: data[2].fairholdLandRent,
-      total: data[2].fairholdLandRent,
+      fairholdHouseLabel: "House",
+      fairholdTotal: data[2].fairholdLandRent,
     },
   ];
 
@@ -144,9 +137,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-freeholdLand)"
             >
               <LabelList
-                dataKey="freeholdLand"
+                dataKey="freeholdLandLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "freeholdLand")}
                 fill="white"
                 fontSize={12}
               />
@@ -157,9 +149,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-freeholdHouse)"
             >
               <LabelList
-                dataKey="freeholdHouse"
+                dataKey="freeholdHouseLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "freeholdHouse")}
                 fill="white"
                 fontSize={12}
               />
@@ -170,9 +161,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-fairholdLand)"
             >
               <LabelList
-                dataKey="fairholdLand"
+                dataKey="fairholdLandLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "fairholdLand")}
                 fill="white"
                 fontSize={12}
               />
@@ -183,9 +173,8 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               fill="var(--color-fairholdHouse)"
             >
               <LabelList
-                dataKey="fairholdHouse"
+                dataKey="fairholdHouseLabel"
                 position="center"
-                formatter={(value: number) => formatValueWithLabel(value, "fairholdHouse")}
                 fill="white"
                 fontSize={12}
               />

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -102,11 +102,19 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                     case "freehold":
                       return "Freehold";
                     case "fairhold: land purchase":
-                      return "Fairhold –\nLand Purchase";
+                      return "Fairhold /\nLand Purchase";
                     case "fairhold: land rent":
-                      return "Fairhold –\nLand Rent";
+                      return "Fairhold /\nLand Rent";
                     default:
                       return payload.value;
+                  }
+                })();
+                const labelColor = (() => {
+                  switch (payload.value) {
+                    case "freehold":
+                      return "rgb(var(--freehold-equity-color-rgb))";
+                    default:
+                      return "rgb(var(--fairhold-equity-color-rgb))";
                   }
                 })();
 
@@ -119,8 +127,9 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                         y={i * 20}
                         dy={10}
                         textAnchor="middle"
-                        fill="#666"
+                        style={{ fill: labelColor }}
                         fontSize="12px"
+                        fontWeight={600}
                       >
                         {line}
                       </text>


### PR DESCRIPTION
- Adds totals on the top left of each bar (uses the parent element to position, thanks Daf for the suggestion!)
- Adds Fairhold as % of market in subtitle (with coloured highlight)
- Updates tooltip to show value breakdown based on what part of bar is being hovered over
    - Re-styles tooltip
    - Removes values from chart label
- Fixes mobile width
- Adds colours to bar labels (on x axis)

Mobile:
![image](https://github.com/user-attachments/assets/5fd060a8-2be6-4afc-b74f-5f4c425b64ae)

Desktop:
![image](https://github.com/user-attachments/assets/3077bf66-485d-4def-9048-8c32927dfa7b)

Tooltip:
![image](https://github.com/user-attachments/assets/825bfe79-ad8c-4b39-a8a5-b9f2504c68bf)

Closes #413 