### PR TITLE
feat: restyle monthly costs graph

### DIFF
--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -46,8 +46,8 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
 
   return (
     <GraphCard
-      title="How much would Fairhold cost me every month?"
-      subtitle="Monthly cost of housing, excluding bills and maintenance"
+      title="How much would it cost every month?"
+      subtitle="Not including bills"
     >
       <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
         <HowMuchPerMonthWrapper household={processedData} />

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -52,7 +52,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
       <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
         <HowMuchPerMonthWrapper household={processedData} />
         <Drawer
-          buttonTitle="Find out more about how we estimated these"
+          buttonTitle="35% of the local median household income is a widely-used benchmark for affordability. Find out more about how we estimated these"
           title="How we estimated these figures"
           description={<ReactMarkdown className="space-y-4">{processedContent}</ReactMarkdown>}
         />

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -149,10 +149,50 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
               <Bar dataKey="monthly" strokeWidth={2} activeIndex={2}>
               <LabelList
                 dataKey="monthly"
-                position="center"
-                formatter={formatValue}
-                fill="white"
-                fontSize={12}
+                position="top"
+                content={(props) => {
+                  if (!props.x || !props.y || !props.value || props.index === undefined ) return null;
+
+                  const xPos = typeof props.x === 'number' ? props.x - 2 : 0;
+                  const yPos = typeof props.y === 'number' ? props.y - 30 : 0;
+                  const value = typeof props.value === 'number' ? props.value : parseFloat(props.value as string);
+                  const formattedValue = formatValue(value);
+
+                  const labelColor = (() => {
+                    switch (chartData[props.index].tenure) {
+                      case "Freehold":
+                        return "rgb(var(--freehold-equity-color-rgb))";
+                      case "Private Rent":
+                        return "rgb(var(--private-rent-land-color-rgb))";
+                      case "Fairhold - Land Purchase":
+                        return "rgb(var(--fairhold-equity-color-rgb))";
+                      case "Fairhold - Land Rent":
+                        return "rgb(var(--fairhold-equity-color-rgb))";
+                      case "Social Rent":
+                        return "rgb(var(--social-rent-land-color-rgb))";
+                      default:
+                        return "#666";
+                    }
+                  })();
+
+                  return (
+                    <foreignObject x={xPos} y={yPos} width={100} height={30}>
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: 0,
+                          top: 0,
+                          color: labelColor,
+                          fontSize: "18px",
+                          fontWeight: 600,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {formattedValue}
+                      </div>
+                    </foreignObject>
+                  );
+                }}
               />
             </Bar>
             <ReferenceLine 

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -85,6 +85,22 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
               interval={0} 
               height={60} 
               tick={({ x, y, payload }) => {
+                const labelColor = (() => {
+                  switch (payload.value) {
+                    case "Freehold":
+                      return "rgb(var(--freehold-equity-color-rgb))";
+                    case "Private Rent":
+                      return "rgb(var(--private-rent-land-color-rgb))";
+                    case "Fairhold - Land Purchase":
+                      return "rgb(var(--fairhold-equity-color-rgb))";
+                    case "Fairhold - Land Rent":
+                      return "rgb(var(--fairhold-equity-color-rgb))";
+                    case "Social Rent":
+                      return "rgb(var(--social-rent-land-color-rgb))";
+                    default:
+                      return "#666";
+                  }
+                })();
                 const label = (() => {
                   switch (payload.value) {
                     case "Freehold":
@@ -110,8 +126,9 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
                                       y={i * 20}
                                       dy={10}
                                       textAnchor="middle"
-                                      fill="#666"
+                                      style={{ fill: labelColor }}
                                       fontSize="12px"
+                                      fontWeight={600}
                                     >
                                       {line}
                                     </text>

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -140,29 +140,19 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
             </Bar>
             <ReferenceLine 
               y={data[0].affordabilityMonthly} 
-              stroke="rgb(var(--text-inaccessible-rgb))" 
-              strokeDasharray="6 6" 
+              stroke="rgb(var(--text-default-rgb))" 
               label={(props) => { // formatting here is to ensure line break
                 const { viewBox } = props;
                 return (
                   <g>
                     <text
-                      x={viewBox.width + 30}  
-                      y={viewBox.y - 30}
-                      textAnchor="end"
-                      fill="rgb(var(--text-inaccessible-rgb))"
-                      fontSize={12}
-                    >
-                      Affordability threshold
-                    </text>
-                    <text
-                      x={viewBox.width + 30} 
+                      x={viewBox.width} 
                       y={viewBox.y - 15} 
                       textAnchor="end"
-                      fill="rgb(var(--text-inaccessible-rgb))"
+                      fill="rgb(var(--text-default-rgb))"
                       fontSize={12}
                     >
-                      (35% median household income)
+                      Affordable
                     </text>
                   </g>
                 );

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -11,6 +11,7 @@ import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
 import { formatValue } from "@/app/lib/format";
+import { Props } from "recharts/types/component/LabelList";
 
 type DataInput = {
   category: string;
@@ -23,16 +24,32 @@ type DataInput = {
   [key: string]: string | number;
 };
 
+interface CustomLabelListProps 
+  extends Props<{value: number}> {
+  index: number;
+  x: number;
+  y: number;
+  value: number;
+}
+
 interface StackedBarChartProps {
   data: DataInput[];
   maxY: number;
+}
+
+type ChartData = {
+  tenure: string;
+  land: number;
+  house: number;
+  monthly: number;
+  fill: string;
 }
 
 const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ 
   data, 
   maxY 
 }) => {
-  const chartData = [
+  const chartData:ChartData[] = [
     {
       tenure: "Freehold",
       land: data[0].marketPurchase,
@@ -153,14 +170,13 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="monthly"
                 position="top"
                 content={(props) => {
-                  if (!props.x || !props.y || !props.value || props.index === undefined ) return null;
+                  const { x, y, value, index } = props as CustomLabelListProps;
 
-                  const xPos = typeof props.x === 'number' ? props.x - 2 : 0;
-                  const yPos = typeof props.y === 'number' ? props.y - 30 : 0;
-                  const value = typeof props.value === 'number' ? props.value : parseFloat(props.value as string);
+                  const xPos = x - 2;
+                  const yPos = y - 30;
                   const formattedValue = formatValue(value);
 
-                  const labelColor = getLabelColor(chartData[props.index].tenure);
+                  const labelColor = getLabelColor(chartData[index].tenure);
 
                   return (
                     <foreignObject x={xPos} y={yPos} width={100} height={30}>

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -72,6 +72,23 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
     },
   ];
 
+  const getLabelColor = (tenure: string): string => {
+    switch (tenure) {
+      case "Freehold":
+        return "rgb(var(--freehold-equity-color-rgb))";
+      case "Private Rent":
+        return "rgb(var(--private-rent-land-color-rgb))";
+      case "Fairhold - Land Purchase":
+        return "rgb(var(--fairhold-equity-color-rgb))";
+      case "Fairhold - Land Rent":
+        return "rgb(var(--fairhold-equity-color-rgb))";
+      case "Social Rent":
+        return "rgb(var(--social-rent-land-color-rgb))";
+      default:
+        return "#666";
+    }
+  }
+
   return (
     <Card className="h-full w-full">
       <CardContent className="h-full w-full p-0 md:p-4">
@@ -85,22 +102,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
               interval={0} 
               height={60} 
               tick={({ x, y, payload }) => {
-                const labelColor = (() => {
-                  switch (payload.value) {
-                    case "Freehold":
-                      return "rgb(var(--freehold-equity-color-rgb))";
-                    case "Private Rent":
-                      return "rgb(var(--private-rent-land-color-rgb))";
-                    case "Fairhold - Land Purchase":
-                      return "rgb(var(--fairhold-equity-color-rgb))";
-                    case "Fairhold - Land Rent":
-                      return "rgb(var(--fairhold-equity-color-rgb))";
-                    case "Social Rent":
-                      return "rgb(var(--social-rent-land-color-rgb))";
-                    default:
-                      return "#666";
-                  }
-                })();
+                const labelColor = getLabelColor(payload.value);
                 const label = (() => {
                   switch (payload.value) {
                     case "Freehold":
@@ -158,22 +160,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
                   const value = typeof props.value === 'number' ? props.value : parseFloat(props.value as string);
                   const formattedValue = formatValue(value);
 
-                  const labelColor = (() => {
-                    switch (chartData[props.index].tenure) {
-                      case "Freehold":
-                        return "rgb(var(--freehold-equity-color-rgb))";
-                      case "Private Rent":
-                        return "rgb(var(--private-rent-land-color-rgb))";
-                      case "Fairhold - Land Purchase":
-                        return "rgb(var(--fairhold-equity-color-rgb))";
-                      case "Fairhold - Land Rent":
-                        return "rgb(var(--fairhold-equity-color-rgb))";
-                      case "Social Rent":
-                        return "rgb(var(--social-rent-land-color-rgb))";
-                      default:
-                        return "#666";
-                    }
-                  })();
+                  const labelColor = getLabelColor(chartData[props.index].tenure);
 
                   return (
                     <foreignObject x={xPos} y={yPos} width={100} height={30}>

--- a/app/components/graphs/HowMuchPerMonthWrapper.tsx
+++ b/app/components/graphs/HowMuchPerMonthWrapper.tsx
@@ -23,7 +23,7 @@ const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
     household.forecastParameters
       .affordabilityThresholdIncomePercentage || 0
   const highestValue = Math.max(fairholdLandPurchaseMonthly, marketPurchaseMonthly, affordabilityMonthly)
-  const maxY = Math.ceil(highestValue / 500) * 500
+  const maxY = Math.ceil(1.1 * highestValue / 500) * 500
 
   const formatData = (household: Household) => {
     return [

--- a/app/components/graphs/HowMuchPerMonthWrapper.tsx
+++ b/app/components/graphs/HowMuchPerMonthWrapper.tsx
@@ -23,7 +23,8 @@ const HowMuchPerMonthWrapper: React.FC<HowMuchPerMonthWrapperProps> = ({
     household.forecastParameters
       .affordabilityThresholdIncomePercentage || 0
   const highestValue = Math.max(fairholdLandPurchaseMonthly, marketPurchaseMonthly, affordabilityMonthly)
-  const maxY = Math.ceil(1.1 * highestValue / 500) * 500
+  const scaleFactor = 1.1
+  const maxY = Math.ceil(scaleFactor * highestValue / 500) * 500
 
   const formatData = (household: Household) => {
     return [


### PR DESCRIPTION
- Moves labels on top of bars
- Colour codes bar labels and x-axis labels too
- Makes affordability threshold line and text black and solid
- Updates copy
- Adds 35% explainer to help text button

Desktop
![image](https://github.com/user-attachments/assets/2de1f900-7ec0-4640-96b9-3d78a1e85f58)

Mobile
![image](https://github.com/user-attachments/assets/ae9016fb-86a1-4d77-95d0-905a0376df9a)

Closes #405