### PR TITLE
feat: restyle CostOverTime graph

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -35,12 +35,16 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const lifetimeTotal = processedData.lifetime.lifetimeData[processedData.lifetime.lifetimeData.length - 1].cumulativeCosts[selectedTenure];
   const [processedContent, setProcessedContent] = useState('');
   
+  const constructionPriceGrowthPerYear = DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear * 100;
+  const rentGrowthPerYear = DEFAULT_FORECAST_PARAMETERS.rentGrowthPerYear * 100;
+  const propertyPriceGrowthPerYear = DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear * 100;
+  const incomeGrowthPerYear = (DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear * 100).toString();
   // We don't hard code the variables in markdown because then we'd have to maintain them in multiple places
   const replacements = useMemo(() => ({
-    constructionPriceGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear * 100).toString(),
-    rentGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.rentGrowthPerYear * 100).toString(),
-    propertyPriceGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear * 100).toString(),
-    incomeGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear * 100).toString(),
+    constructionPriceGrowthPerYear: constructionPriceGrowthPerYear.toString(),
+    rentGrowthPerYear: rentGrowthPerYear.toString(),
+    propertyPriceGrowthPerYear: propertyPriceGrowthPerYear.toString(),
+    incomeGrowthPerYear: incomeGrowthPerYear.toString(),
     SOCIAL_RENT_ADJUSTMENT_FORECAST: (SOCIAL_RENT_ADJUSTMENT_FORECAST * 100).toString()
   }), []);
 
@@ -95,7 +99,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
         />
 
         <Drawer
-          buttonTitle="Find out more about how we calculated these"
+          buttonTitle={`Assuming ${constructionPriceGrowthPerYear}% house price inflation and ${propertyPriceGrowthPerYear}% general inflation. Find out more about how we calculated these`}
           title="How we calculated these figures"
           description={<ReactMarkdown className="space-y-4">{processedContent}</ReactMarkdown>}
         />

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -17,8 +17,8 @@ const TENURES = ['marketPurchase', 'marketRent', 'fairholdLandPurchase', 'fairho
 const TENURE_LABELS = {
   marketPurchase: 'Freehold',
   marketRent: 'Private rent',
-  fairholdLandPurchase: 'Fairhold Land Purchase',
-  fairholdLandRent: 'Fairhold Land Rent',
+  fairholdLandPurchase: 'Fairhold /LP',
+  fairholdLandRent: 'Fairhold /LR',
   socialRent: 'Social rent'
 }
 

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -18,19 +18,32 @@ export interface LifetimeBarData {
   maintenance?: number;
 }
 
-const CostOverTimeTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+export const CostOverTimeTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
   if (!active || !payload) return null;
 
   return (
-    <div className="rounded-lg border bg-background p-2 shadow-sm">
-      <div className="grid grid-cols-2 gap-2">
-        <div className="font-medium">Year {label}{parseInt(label as string) === 1 ? " (with deposit)" : ""}</div>
-        {payload.map((entry, index) => (
+    <div className="rounded-xl bg-[rgb(var(--text-default-rgb))] p-2 shadow-sm">
+      <div className="grid grid-cols-1">
+        <div className="font-bold text-[rgb(var(--button-background-rgb))]"> Year {label}</div>
+        {payload.map((entry, index) => {
+          let barLabel 
+          if (entry.name === "Equity" && payload[0].payload.year === 1) {
+            barLabel = "Deposit"
+          } else if (entry.name === "Equity") {
+            barLabel = "Repayment"
+          } else {
+            barLabel = entry.name
+          }
+          return (
           <div key={`tooltip-${entry.name}-${index}`} className="grid grid-cols-2 gap-4">
-            <div style={{ color: entry.color }}>{entry.name}:</div>
-            <div>£{entry.value ? entry.value.toLocaleString() : '0'}</div>
+            <div style={{ color: "rgb(var(--button-background-rgb))" }}>
+              {barLabel}
+            </div>
+            <div style={{ color: entry.color }}>
+              £{entry.value ? Math.round(parseFloat(entry.value)).toLocaleString() : '0'}</div>
           </div>
-        ))}
+          )
+  })}
       </div>
     </div>
   );

--- a/app/components/graphs/CostOverTimeStackedBarChartMobile.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChartMobile.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { StyledChartContainer } from "../ui/StyledChartContainer";
 import { formatValue } from "@/app/lib/format";
 import { LifetimeBarData } from "./CostOverTimeStackedBarChart";
+import { CostOverTimeTooltip } from "./CostOverTimeStackedBarChart";
 
 interface CostOverTimeHorizontalChartProps {
   data: LifetimeBarData[];
@@ -68,9 +69,7 @@ const CostOverTimeHorizontalChart: React.FC<CostOverTimeHorizontalChartProps> = 
               tickLine={false}
             >
             </YAxis>
-            <Tooltip 
-              formatter={(value) => formatValue(value as number)}
-              labelFormatter={(label) => `Year ${label}`}
+            <Tooltip content={<CostOverTimeTooltip />}
             />
             
             {Object.entries(config.colors).map(([key, color]) => (


### PR DESCRIPTION
- Restyles tooltip (changes colour, shape, and labels: y1 equity to "Deposit", other equity to "Repayment)
- Updates tenure selector copy
All to match new designs

Current:
![Screenshot 2025-04-15 094920](https://github.com/user-attachments/assets/a7b3ca6b-d8b5-4ed7-835e-24f67241a0d4)
![Screenshot 2025-04-15 094906](https://github.com/user-attachments/assets/af517366-12ac-4759-b0c3-182cc1201f2f)

# Questions
- What should we do about the contrast of the darker colours (thinking of Freehold specifically)
- Can we live without the little circles in the tooltip Figma? See below:
![image](https://github.com/user-attachments/assets/ecd9051f-27c5-48ee-ba0f-e19eeeaca7e5)

Closes #406 