### PR TITLE
Revert "fix: more info button colours"

### DIFF
--- a/app/components/ui/BackgroundAssumptions.tsx
+++ b/app/components/ui/BackgroundAssumptions.tsx
@@ -1,7 +1,7 @@
 import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 
 export const BackgroundAssumptions: React.FC = () =>  (
-  <a href="https://github.com/theopensystemslab/fairhold-dashboard/wiki" className="flex text-sm items-center text-[rgb(var(--text-inaccessible-rgb))] decoration-[rgb(var(--text-inaccessible-rgb))]">
+  <a href="https://github.com/theopensystemslab/fairhold-dashboard/wiki" className="flex text-sm items-center">
     <QuestionMarkCircledIcon className="mr-2"/>
     Explore other background assumptions we have made in this calculator
   </a>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,4 @@
 import type { Config } from "tailwindcss";
-import plugin from "tailwindcss/plugin";
 
 const config: Config = {
   darkMode: ["class"],
@@ -86,13 +85,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [
-    require("tailwindcss-animate"),
-    plugin(function({ addBase }) {
-      addBase({
-        'span, a': { color: 'rgb(var(--text-inaccessible-rgb))' },
-      });
-    })
-],
+  plugins: [require("tailwindcss-animate")],
 };
 export default config;


### PR DESCRIPTION
Reverts theopensystemslab/fairhold-dashboard#418

I think this PR made the dropdown menu the wrong colour:
![image](https://github.com/user-attachments/assets/8f53078e-b241-40cc-8673-02fc9d7100c2)

I also thought this would be a quick fix and I've spent about an hour on it and can't crack it, so opting for revert