### PR TITLE
feat: implement 'not viable' view

### DIFF
--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -15,11 +15,11 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
 
   const subtitle = data.property.landPrice < 0 ? (
     <span>
-      In this area, homes cost less than construction, so&nbsp;
+      Here, freehold homes are worth less than their build cost.&nbsp;
       <span style={{ color: "rgb(var(--not-viable-dark-color-rgb))" }}>
-       conventional development is unviable
+        Conventional development is unviable
       </span>
-      . While Fairhold is less essential here, £1 Fairhold plots could help revitalise the local economy.
+      &nbsp;and Fairhold homes may be hard to sell or finance for their full value. While less needed here, £1 Fairhold plots could help revive the local economy.
     </span>
   ) : (
     <span>

--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -15,11 +15,11 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
 
   const subtitle = data.property.landPrice < 0 ? (
     <span>
-      In this area, a freehold home is worth less than its build cost. 
+      In this area, homes cost less than construction, so&nbsp;
       <span style={{ color: "rgb(var(--not-viable-dark-color-rgb))" }}>
-        This means conventional development is not viable. 
+       conventional development is unviable
       </span>
-       {/* Fairhold is not as urgently needed here, but £1 Fairhold plots could be a way to renew the local economy. */}
+      . While Fairhold is less essential here, £1 Fairhold plots could help revitalise the local economy.
     </span>
   ) : (
     <span>

--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -13,18 +13,27 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
   const fairholdPercentage = Math.round((data.tenure.fairholdLandPurchase.discountedLandPrice + data.property.depreciatedBuildPrice) // shows FairholdLP
     / data.property.averageMarketPrice * 100)
 
+  const subtitle = data.property.landPrice < 0 ? (
+    <span>
+      In this area, a freehold home is worth less than its build cost. 
+      <span style={{ color: "rgb(var(--not-viable-dark-color-rgb))" }}>
+        This means conventional development is not viable. 
+      </span>
+       {/* Fairhold is not as urgently needed here, but £1 Fairhold plots could be a way to renew the local economy. */}
+    </span>
+  ) : (
+    <span>
+      A Fairhold home could cost 
+      <span style={{ color: "rgb(var(--fairhold-equity-color-rgb))" }} className="font-semibold">
+        {` ${fairholdPercentage}% `}
+      </span>
+      of its freehold price.
+    </span>
+  );
   return (
     <GraphCard
       title="How much would a home cost?"
-      subtitle={
-              <span>
-                A Fairhold home could cost 
-                <span style={{ color: "rgb(var(--fairhold-equity-color-rgb))" }} className="font-semibold">
-                  {` ${fairholdPercentage}% `}
-                </span>
-                of its freehold price.
-              </span>
-            }
+      subtitle={subtitle}
           >
       <div className="flex flex-col h-full w-full justify-between">
         <HowMuchFHCostWrapper household={data} />

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, LabelList, Tooltip } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, LabelList, Tooltip, YAxis } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
@@ -38,10 +38,12 @@ type DataInput = {
 
 interface StackedBarChartProps {
   data: DataInput[];
+  maxY: number;
 }
 
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
+  maxY,
 }) => {
   const [hoveredBar, setHoveredBar] = useState<{ dataKey: string; value: number } | null>(null);
   const CustomTooltip: React.FC<{ hoveredBar: { dataKey: string; value: number } | null }> = ({ hoveredBar }) => {
@@ -140,6 +142,13 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
             >
             </XAxis>
 
+            <YAxis
+              domain={[0, maxY]}
+              tick={false}
+              tickLine={false}
+              axisLine={false}
+              hide={true}
+              ></YAxis>  
             <Tooltip content={<CustomTooltip hoveredBar={hoveredBar} />} isAnimationActive={false} />
             <Bar
               dataKey="freeholdLand"

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -127,6 +127,27 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               ></YAxis>
 
             <Tooltip isAnimationActive={false} />
+            <ReferenceLine 
+                y={newBuildPrice} 
+                z={0}
+                stroke="rgb(var(--text-default-rgb))" 
+                label={(props) => {
+                  const { viewBox } = props;
+                  return (
+                    <g>
+                      <text
+                        x={viewBox.width}  
+                        y={viewBox.y - 15}
+                        textAnchor="end"
+                        fill="rgb(var(--text-default-rgb))"
+                        fontSize={12}
+                      >
+                        Build cost
+                      </text>
+                    </g>
+                  );
+                }}
+              />   
             <Bar
               dataKey="total"
               >
@@ -200,9 +221,12 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                           left: 0,
                           top: 0,
                           color: labelColor,
+                          backgroundColor: "rgb(var(--background-end-rgb))",
                           fontSize: "18px",
                           fontWeight: 600,
                           whiteSpace: "nowrap",
+                          padding: "2px 6px",
+                          zIndex: 10,
                         }}
                       >
                         {formattedValue}
@@ -212,26 +236,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 }}
               />
             </Bar>
-            <ReferenceLine 
-                y={newBuildPrice} 
-                stroke="rgb(var(--text-default-rgb))" 
-                label={(props) => {
-                  const { viewBox } = props;
-                  return (
-                    <g>
-                      <text
-                        x={viewBox.width}  
-                        y={viewBox.y - 15}
-                        textAnchor="end"
-                        fill="rgb(var(--text-default-rgb))"
-                        fontSize={12}
-                      >
-                        Build cost
-                      </text>
-                    </g>
-                  );
-                }}
-              />    
+             
           </BarChart>
         </StyledChartContainer>
       </CardContent>

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis, LabelList, Tooltip } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, LabelList, Tooltip, ReferenceLine } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
@@ -31,11 +31,13 @@ type DataInput = {
 
 interface StackedBarChartProps { // TODO: refactor so there is only one exported StackedBarChartProps type?
   data: DataInput[];
+  newBuildPrice: number;
   maxY: number;
 }
 
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
+  newBuildPrice,
   maxY
 }) => {
 
@@ -210,6 +212,26 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 }}
               />
             </Bar>
+            <ReferenceLine 
+                y={newBuildPrice} 
+                stroke="rgb(var(--text-default-rgb))" 
+                label={(props) => {
+                  const { viewBox } = props;
+                  return (
+                    <g>
+                      <text
+                        x={viewBox.width}  
+                        y={viewBox.y - 15}
+                        textAnchor="end"
+                        fill="rgb(var(--text-default-rgb))"
+                        fontSize={12}
+                      >
+                        Build cost
+                      </text>
+                    </g>
+                  );
+                }}
+              />    
           </BarChart>
         </StyledChartContainer>
       </CardContent>

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, LabelList, Tooltip } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  ChartConfig,
+} from "@/components/ui/chart";
+import {
+  StyledChartContainer,
+} from "../ui/StyledChartContainer";
+import { formatValue } from "@/app/lib/format";
+
+const chartConfig = {
+  freehold: {
+    color: "rgb(var(--not-viable-light-color-rgb))",
+  },
+  fairhold: {
+    color: "rgb(var(--fairhold-interest-color-rgb))",
+  },
+} satisfies ChartConfig;
+
+import React from "react";
+
+type DataInput = {
+  category: string;
+  marketPurchase: number;
+  fairholdLandPurchase: number;
+  fairholdLandRent: number;
+  [key: string]: string | number;
+};
+
+interface StackedBarChartProps {
+  data: DataInput[];
+}
+
+const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
+  data,
+}) => {
+    console.log({data})
+//   const [hoveredBar, setHoveredBar] = useState<{ dataKey: string; value: number } | null>(null);
+//   const CustomTooltip: React.FC<{ hoveredBar: { dataKey: string; value: number } | null }> = ({ hoveredBar }) => {
+//     if (!hoveredBar) return null;
+  
+//     const { dataKey, value } = hoveredBar;
+//     const label = dataKey.includes("Land") ? "Land" : "House";
+  
+//     return (
+//       <div className="bg-[rgb(var(--text-default-rgb))] p-2 shadow-sm rounded-xl">
+//         <div style={{ color: "rgb(var(--button-background-rgb))" }}>
+//           {label} £{value.toLocaleString()}
+//         </div>
+//       </div>
+//     );
+//   };
+
+  const chartData = [
+    {
+      tenure: "freehold",
+      total: data[0].marketPurchase + data[1].marketPurchase,
+      label: "Not viable",    
+      fill: "rgb(var(--not-viable-light-color-rgb))",
+    },
+    {
+      tenure: "fairhold: land purchase",
+      total: data[2].fairholdLandPurchase,
+      label: "House",
+      fill: "rgb(var(--fairhold-interest-color-rgb))",
+    },
+    {
+      tenure: "fairhold: land rent",
+      total: data[2].fairholdLandRent,
+      label: "House",
+      fill: "rgb(var(--fairhold-interest-color-rgb))",
+    },
+  ];
+
+  console.log({chartData})
+
+  return (
+    <Card className="h-full w-full">
+      <CardContent className="h-full w-full p-0 md:p-4">
+        <StyledChartContainer config={chartConfig}
+        className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent h-full w-full">
+          <BarChart className="w-full" accessibilityLayer data={chartData}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="tenure"
+              tickLine={false}
+              interval={0} 
+              height={60}  
+              tick={({ x, y, payload }) => {
+                const label = (() => {
+                  switch (payload.value) {
+                    case "freehold":
+                      return "Freehold";
+                    case "fairhold: land purchase":
+                      return "Fairhold /\nLand Purchase";
+                    case "fairhold: land rent":
+                      return "Fairhold /\nLand Rent";
+                    default:
+                      return payload.value;
+                  }
+                })();
+                const labelColor = (() => {
+                  switch (payload.value) {
+                    case "freehold":
+                      return "rgb(var(--not-viable-dark-color-rgb))";
+                    default:
+                      return "rgb(var(--fairhold-equity-color-rgb))";
+                  }
+                })();
+
+                return (
+                  <g transform={`translate(${x},${y})`}>
+                    {label.split('\n').map((line: string, i: number) => (
+                      <text
+                        key={i}
+                        x={0}
+                        y={i * 20}
+                        dy={10}
+                        textAnchor="middle"
+                        style={{ fill: labelColor }}
+                        fontSize="12px"
+                        fontWeight={600}
+                      >
+                        {line}
+                      </text>
+                    ))}
+                  </g>
+                );
+              }}
+            >
+            </XAxis>
+
+            <Tooltip isAnimationActive={false} />
+            <Bar
+              dataKey="total"
+              >
+              <LabelList
+                dataKey="label"
+                position="center"
+                fontSize={12}
+                content={(props) => {
+                    if ( typeof props.x !== 'number' || 
+                        typeof props.y !== 'number' || 
+                        typeof props.width !== 'number' ||
+                        typeof props.height !== 'number' ||
+                        !props.value
+                    ) return null;
+                    const labelColor = (() => {
+                        switch (props.value) {
+                          case "Not viable":
+                            return "rgb(var(--not-viable-dark-color-rgb))";
+                          case "House":
+                            return "white";
+                          default:
+                            return "black";
+                        }
+                      })();
+
+                    const labelWidth = 80;
+                    const xPos = props.x + props.width / 2 - labelWidth / 2;
+                    const yPos = props.y + props.height / 2 - 10;
+
+                    return (
+                    <foreignObject x={xPos} y={yPos} width={80} height={20}>
+                        <div
+                        style={{
+                            color: labelColor,
+                            fontSize: "12px",
+                            fontWeight: 600,
+                            textAlign: "center",
+                        }}
+                        >
+                        {props.value}
+                        </div>
+                    </foreignObject>
+                    );
+                }}
+              />
+              <LabelList
+                dataKey="total"
+                position="top"
+                content={(props) => {
+                  if (!props.x || !props.y || !props.value) return null;
+                  
+                  const labelColor = (() => {
+                    switch (props.index) {
+                      case 0:
+                        return "rgb(var(--not-viable-dark-color-rgb))";
+                      default:
+                        return "rgb(var(--fairhold-equity-color-rgb))";
+                    }
+                  })();
+
+                  const xPos = typeof props.x === 'number' ? props.x - 2 : 0;
+                  const yPos = typeof props.y === 'number' ? props.y - 30 : 0;
+                  const value = typeof props.value === 'number' ? props.value : parseFloat(props.value as string);
+                  const formattedValue = formatValue(value);
+
+                  return (
+                    <foreignObject x={xPos} y={yPos} width={100} height={30}>
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: 0,
+                          top: 0,
+                          color: labelColor,
+                          fontSize: "18px",
+                          fontWeight: 600,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {formattedValue}
+                      </div>
+                    </foreignObject>
+                  );
+                }}
+              />
+            </Bar>
+          </BarChart>
+        </StyledChartContainer>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default HowMuchFHCostBarChart;

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, LabelList, Tooltip } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, LabelList, Tooltip } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
@@ -29,29 +29,15 @@ type DataInput = {
   [key: string]: string | number;
 };
 
-interface StackedBarChartProps {
+interface StackedBarChartProps { // TODO: refactor so there is only one exported StackedBarChartProps type?
   data: DataInput[];
+  maxY: number;
 }
 
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
+  maxY
 }) => {
-    console.log({data})
-//   const [hoveredBar, setHoveredBar] = useState<{ dataKey: string; value: number } | null>(null);
-//   const CustomTooltip: React.FC<{ hoveredBar: { dataKey: string; value: number } | null }> = ({ hoveredBar }) => {
-//     if (!hoveredBar) return null;
-  
-//     const { dataKey, value } = hoveredBar;
-//     const label = dataKey.includes("Land") ? "Land" : "House";
-  
-//     return (
-//       <div className="bg-[rgb(var(--text-default-rgb))] p-2 shadow-sm rounded-xl">
-//         <div style={{ color: "rgb(var(--button-background-rgb))" }}>
-//           {label} £{value.toLocaleString()}
-//         </div>
-//       </div>
-//     );
-//   };
 
   const chartData = [
     {
@@ -73,8 +59,6 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       fill: "rgb(var(--fairhold-interest-color-rgb))",
     },
   ];
-
-  console.log({chartData})
 
   return (
     <Card className="h-full w-full">
@@ -131,6 +115,14 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               }}
             >
             </XAxis>
+
+            <YAxis
+              domain={[0, maxY]}
+              tick={false}
+              axisLine={false}
+              tickLine={false}
+              hide={true}
+              ></YAxis>
 
             <Tooltip isAnimationActive={false} />
             <Bar

--- a/app/components/graphs/HowMuchFHCostWrapper.tsx
+++ b/app/components/graphs/HowMuchFHCostWrapper.tsx
@@ -27,7 +27,8 @@ const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
   const scaleFactor = 1.1;
   const marketPurchase = household.property.averageMarketPrice;
   const fairholdLandPurchase = household.property.depreciatedBuildPrice + household.tenure.fairholdLandPurchase.discountedLandPrice;
-  const highestValue = Math.max(marketPurchase, fairholdLandPurchase)
+  const newBuildPrice = household.property.newBuildPrice
+  const highestValue = Math.max(marketPurchase, fairholdLandPurchase, newBuildPrice) // we need newBuildPrice here to ensure the reference line when not viable can be shown
   const maxY = highestValue * scaleFactor
 
   const formatData = (household: Household) => {
@@ -62,7 +63,7 @@ const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
     return (
       <ErrorBoundary>
         <div className="h-full w-full">
-          <HowMuchFHCostNotViableBarChart data={formattedData} maxY={maxY}/>
+          <HowMuchFHCostNotViableBarChart data={formattedData} maxY={maxY} newBuildPrice={newBuildPrice}/>
         </div>
       </ErrorBoundary>
     );

--- a/app/components/graphs/HowMuchFHCostWrapper.tsx
+++ b/app/components/graphs/HowMuchFHCostWrapper.tsx
@@ -24,6 +24,11 @@ const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
   if (!household) {
     return <div>No household data available</div>;
   }
+  const scaleFactor = 1.1;
+  const marketPurchase = household.property.averageMarketPrice;
+  const fairholdLandPurchase = household.property.depreciatedBuildPrice + household.tenure.fairholdLandPurchase.discountedLandPrice;
+  const highestValue = Math.max(marketPurchase, fairholdLandPurchase)
+  const maxY = highestValue * scaleFactor
 
   const formatData = (household: Household) => {
     return [
@@ -57,7 +62,7 @@ const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
     return (
       <ErrorBoundary>
         <div className="h-full w-full">
-          <HowMuchFHCostNotViableBarChart data={formattedData} />
+          <HowMuchFHCostNotViableBarChart data={formattedData} maxY={maxY}/>
         </div>
       </ErrorBoundary>
     );
@@ -65,7 +70,7 @@ const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
   return (
     <ErrorBoundary>
       <div className="h-full w-full">
-        <HowMuchFHCostBarChart data={formattedData} />
+        <HowMuchFHCostBarChart data={formattedData} maxY={maxY} />
       </div>
     </ErrorBoundary>
   );

--- a/app/components/graphs/HowMuchFHCostWrapper.tsx
+++ b/app/components/graphs/HowMuchFHCostWrapper.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ErrorBoundary from "../ErrorBoundary";
 import { Household } from "@/app/models/Household";
 import HowMuchFHCostBarChart from "./HowMuchFHCostBarChart";
+import HowMuchFHCostNotViableBarChart from "./HowMuchFHCostNotViableBarChart";
 
 interface HowMuchFHCostWrapperProps {
   household: Household;
@@ -52,6 +53,15 @@ const HowMuchFHCostWrapper: React.FC<HowMuchFHCostWrapperProps> = ({
 
   const formattedData = formatData(household);
 
+  if(household.property.landPrice < 0) {
+    return (
+      <ErrorBoundary>
+        <div className="h-full w-full">
+          <HowMuchFHCostNotViableBarChart data={formattedData} />
+        </div>
+      </ErrorBoundary>
+    );
+  }
   return (
     <ErrorBoundary>
       <div className="h-full w-full">

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,7 +28,9 @@
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
   --social-rent-detail-color-rgb: 242 196 202;
-  --error-text-rgb: 230 5 5;
+  --error-text-rgb: 181 31 20;
+  --not-viable-light-color-rgb: 251 164 164;
+  --not-viable-dark-color-rgb: 255 0 0;
 }
 
 @layer utilities {


### PR DESCRIPTION
Current:
![image](https://github.com/user-attachments/assets/3070f637-23b6-4658-a0aa-a9eda5ec40f5)

Mobile:
![image](https://github.com/user-attachments/assets/f2a84cc5-47e0-4c4f-8035-6e7c50d463ee)

If the build cost line happens to intersect with the labels, the labels will render on top with a background too:
![image](https://github.com/user-attachments/assets/90385698-8a05-4c4d-9aed-71a92dfcb85d)

Closes #407 