### PR TITLE
feat: mobile tenure selector

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -12,7 +12,7 @@ import { DEFAULT_FORECAST_PARAMETERS } from "@/app/models/ForecastParameters";
 import { SOCIAL_RENT_ADJUSTMENT_FORECAST } from "@/app/models/constants";
 import { remark } from "remark";
 import { visit } from 'unist-util-visit';
-import type { TextNode } from "./types";
+import { TENURE_COLORS_DARK, TENURE_COLORS_LIGHT, TextNode } from "./types";
 
 const TENURES = ['marketPurchase', 'marketRent', 'fairholdLandPurchase', 'fairholdLandRent', 'socialRent'] as const
 const TENURE_LABELS = {
@@ -23,21 +23,7 @@ const TENURE_LABELS = {
   socialRent: 'Social rent'
 }
 
-const TENURE_COLORS = {
-  marketPurchase: 'rgb(var(--freehold-equity-color-rgb))',
-  marketRent: 'rgb(var(--private-rent-land-color-rgb))',
-  fairholdLandPurchase: 'rgb(var(--fairhold-equity-color-rgb))',
-  fairholdLandRent: 'rgb(var(--fairhold-equity-color-rgb))',
-  socialRent: 'rgb(var(--social-rent-land-color-rgb))'
-} as const;
 
-const TENURE_COLORS_LIGHT = {
-  marketPurchase: 'rgb(var(--freehold-detail-color-rgb))',
-  marketRent: 'rgb(var(--private-rent-detail-color-rgb))',
-  fairholdLandPurchase: 'rgb(var(--fairhold-detail-color-rgb))',
-  fairholdLandRent: 'rgb(var(--fairhold-detail-color-rgb))',
-  socialRent: 'rgb(var(--social-rent-detail-color-rgb))'
-} as const;
 
 export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const [selectedTenure, setSelectedTenure] = useState<TenureType>('marketPurchase');
@@ -92,7 +78,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
       subtitle={
         <span>
           Over {DEFAULT_FORECAST_PARAMETERS.yearsForecast} years, the home would cost{' '}
-          <span style={{ color: TENURE_COLORS[selectedTenure] }}>
+          <span style={{ color: TENURE_COLORS_DARK[selectedTenure] }}>
             {formatValue(lifetimeTotal)}
           </span>
         </span>
@@ -105,7 +91,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
               onChange={(tenure) => setSelectedTenure(tenure as TenureType)}
               tenures={[...TENURES]}
               tenureLabels={TENURE_LABELS}
-              tenureColors={TENURE_COLORS}
+              tenureColorsDark={TENURE_COLORS_DARK}
               tenureColorsLight={TENURE_COLORS_LIGHT}
             />
           ) : (
@@ -115,6 +101,8 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
                 isSelected={selectedTenure === tenure}
                 onClick={() => setSelectedTenure(tenure)}
                 tenureType={tenure}
+                tenureColorsDark={TENURE_COLORS_DARK}
+                tenureColorsLight={TENURE_COLORS_LIGHT}
               >
                 {TENURE_LABELS[tenure]}
               </TenureSelector>

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -3,6 +3,7 @@ import GraphCard from "../../ui/GraphCard";
 import CostOverTimeWrapper, { TenureType } from "../../graphs/CostOverTimeWrapper";
 import { Drawer } from "../../ui/Drawer";
 import TenureSelector from "../../ui/TenureSelector";
+import TenureSelectorMobile from "../../ui/TenureSelectorMobile";
 import { DashboardProps } from "../../ui/Dashboard";
 import { formatValue } from "@/app/lib/format";
 import ReactMarkdown from 'react-markdown';
@@ -32,6 +33,7 @@ const TENURE_COLORS = {
 
 export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const [selectedTenure, setSelectedTenure] = useState<TenureType>('marketPurchase');
+  const [isMobile, setIsMobile] = useState(false);
   const lifetimeTotal = processedData.lifetime.lifetimeData[processedData.lifetime.lifetimeData.length - 1].cumulativeCosts[selectedTenure];
   const [processedContent, setProcessedContent] = useState('');
   
@@ -67,6 +69,15 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
     processMarkdown();
   }, [replacements]);
 
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768); // Adjust breakpoint as needed
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   return (
     <GraphCard
       title="How would the cost change over my life?"
@@ -79,7 +90,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
         </span>
       }
       >
-      <div className="flex flex-col h-full w-full justify-between">
+      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
         <div className="flex gap-2 mb-4">
         {TENURES.map(tenure => (
           <TenureSelector

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -31,6 +31,14 @@ const TENURE_COLORS = {
   socialRent: 'rgb(var(--social-rent-land-color-rgb))'
 } as const;
 
+const TENURE_COLORS_LIGHT = {
+  marketPurchase: 'rgb(var(--freehold-detail-color-rgb))',
+  marketRent: 'rgb(var(--private-rent-detail-color-rgb))',
+  fairholdLandPurchase: 'rgb(var(--fairhold-detail-color-rgb))',
+  fairholdLandRent: 'rgb(var(--fairhold-detail-color-rgb))',
+  socialRent: 'rgb(var(--social-rent-detail-color-rgb))'
+} as const;
+
 export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const [selectedTenure, setSelectedTenure] = useState<TenureType>('marketPurchase');
   const [isMobile, setIsMobile] = useState(false);
@@ -91,17 +99,27 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
       }
       >
       <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
-        <div className="flex gap-2 mb-4">
-        {TENURES.map(tenure => (
-          <TenureSelector
-            key={tenure}
-            isSelected={selectedTenure === tenure}
-            onClick={() => setSelectedTenure(tenure)}
-            tenureType={tenure}
-          >
-            {TENURE_LABELS[tenure]}
-          </TenureSelector>
-        ))}
+        <div className="flex gap-2 mb-4">{isMobile ? (
+            <TenureSelectorMobile
+              selectedTenure={selectedTenure}
+              onChange={(tenure) => setSelectedTenure(tenure as TenureType)}
+              tenures={[...TENURES]}
+              tenureLabels={TENURE_LABELS}
+              tenureColors={TENURE_COLORS}
+              tenureColorsLight={TENURE_COLORS_LIGHT}
+            />
+          ) : (
+            TENURES.map((tenure) => (
+              <TenureSelector
+                key={tenure}
+                isSelected={selectedTenure === tenure}
+                onClick={() => setSelectedTenure(tenure)}
+                tenureType={tenure}
+              >
+                {TENURE_LABELS[tenure]}
+              </TenureSelector>
+            ))
+          )}
         </div>
 
         <CostOverTimeWrapper 

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -35,12 +35,16 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const lifetimeTotal = processedData.lifetime.lifetimeData[processedData.lifetime.lifetimeData.length - 1].cumulativeCosts[selectedTenure];
   const [processedContent, setProcessedContent] = useState('');
   
+  const constructionPriceGrowthPerYear = DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear * 100;
+  const rentGrowthPerYear = DEFAULT_FORECAST_PARAMETERS.rentGrowthPerYear * 100;
+  const propertyPriceGrowthPerYear = DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear * 100;
+  const incomeGrowthPerYear = (DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear * 100).toString();
   // We don't hard code the variables in markdown because then we'd have to maintain them in multiple places
   const replacements = useMemo(() => ({
-    constructionPriceGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.constructionPriceGrowthPerYear * 100).toString(),
-    rentGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.rentGrowthPerYear * 100).toString(),
-    propertyPriceGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.propertyPriceGrowthPerYear * 100).toString(),
-    incomeGrowthPerYear: (DEFAULT_FORECAST_PARAMETERS.incomeGrowthPerYear * 100).toString(),
+    constructionPriceGrowthPerYear: constructionPriceGrowthPerYear.toString(),
+    rentGrowthPerYear: rentGrowthPerYear.toString(),
+    propertyPriceGrowthPerYear: propertyPriceGrowthPerYear.toString(),
+    incomeGrowthPerYear: incomeGrowthPerYear.toString(),
     SOCIAL_RENT_ADJUSTMENT_FORECAST: (SOCIAL_RENT_ADJUSTMENT_FORECAST * 100).toString()
   }), []);
 
@@ -95,7 +99,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
         />
 
         <Drawer
-          buttonTitle="Find out more about how we calculated these"
+          buttonTitle={`Assuming ${constructionPriceGrowthPerYear}% house price inflation and ${propertyPriceGrowthPerYear}% general inflation. Find out more about how we calculated these`}
           title="How we calculated these figures"
           description={<div className="space-y-4"><ReactMarkdown>{processedContent}</ReactMarkdown></div>}
         />

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -27,7 +27,6 @@ const TENURE_LABELS = {
 
 export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
   const [selectedTenure, setSelectedTenure] = useState<TenureType>('marketPurchase');
-  const [isMobile, setIsMobile] = useState(false);
   const lifetimeTotal = processedData.lifetime.lifetimeData[processedData.lifetime.lifetimeData.length - 1].cumulativeCosts[selectedTenure];
   const [processedContent, setProcessedContent] = useState('');
   
@@ -63,15 +62,6 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
     processMarkdown();
   }, [replacements]);
 
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth <= 768); // Adjust breakpoint as needed
-    };
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
   return (
     <GraphCard
       title="How would the cost change over my life?"
@@ -85,30 +75,33 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
       }
       >
       <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
-        <div className="flex gap-2 mb-4">{isMobile ? (
-            <TenureSelectorMobile
-              selectedTenure={selectedTenure}
-              onChange={(tenure) => setSelectedTenure(tenure as TenureType)}
-              tenures={[...TENURES]}
-              tenureLabels={TENURE_LABELS}
-              tenureColorsDark={TENURE_COLORS_DARK}
-              tenureColorsLight={TENURE_COLORS_LIGHT}
-            />
-          ) : (
-            TENURES.map((tenure) => (
-              <TenureSelector
-                key={tenure}
-                isSelected={selectedTenure === tenure}
-                onClick={() => setSelectedTenure(tenure)}
-                tenureType={tenure}
+        <div className="flex gap-2 mb-4">
+            <div className="block md:hidden w-full">
+              <TenureSelectorMobile
+                selectedTenure={selectedTenure}
+                onChange={(tenure) => setSelectedTenure(tenure as TenureType)}
+                tenures={[...TENURES]}
+                tenureLabels={TENURE_LABELS}
                 tenureColorsDark={TENURE_COLORS_DARK}
                 tenureColorsLight={TENURE_COLORS_LIGHT}
-              >
-                {TENURE_LABELS[tenure]}
-              </TenureSelector>
-            ))
-          )}
-        </div>
+              />
+            </div>
+
+            <div className="hidden md:flex gap-2">
+              {TENURES.map((tenure) => (
+                <TenureSelector
+                  key={tenure}
+                  isSelected={selectedTenure === tenure}
+                  onClick={() => setSelectedTenure(tenure)}
+                  tenureType={tenure}
+                  tenureColorsDark={TENURE_COLORS_DARK}
+                  tenureColorsLight={TENURE_COLORS_LIGHT}
+                >
+                  {TENURE_LABELS[tenure]}
+                </TenureSelector>
+              ))}
+            </div>
+          </div>
 
         <CostOverTimeWrapper 
           household={processedData}

--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -17,8 +17,8 @@ const TENURES = ['marketPurchase', 'marketRent', 'fairholdLandPurchase', 'fairho
 const TENURE_LABELS = {
   marketPurchase: 'Freehold',
   marketRent: 'Private rent',
-  fairholdLandPurchase: 'Fairhold Land Purchase',
-  fairholdLandRent: 'Fairhold Land Rent',
+  fairholdLandPurchase: 'Fairhold /LP',
+  fairholdLandRent: 'Fairhold /LR',
   socialRent: 'Social rent'
 }
 

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_FORECAST_PARAMETERS } from "@/app/models/ForecastParameters";
 import { remark } from "remark";
 import { visit } from 'unist-util-visit';
 import type { TextNode } from "./types";
+import { TENURE_COLORS_DARK, TENURE_COLORS_LIGHT } from "./types";
 
 const TENURES = ['fairholdLandPurchase', 'fairholdLandRent'] as const;
 type Tenure = (typeof TENURES)[number];
@@ -58,7 +59,9 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
               key={tenure} 
               isSelected={selectedTenure === tenure} 
               tenureType={tenure}
-              onClick={() => setSelectedTenure(tenure)} 
+              onClick={() => setSelectedTenure(tenure)}
+              tenureColorsDark={TENURE_COLORS_DARK}
+              tenureColorsLight={TENURE_COLORS_LIGHT}
             > 
               {`Fairhold ${tenure === 'fairholdLandPurchase' ? 'Land Purchase' : 'Land Rent'}`} 
             </TenureSelector> 

--- a/app/components/Dashboard/Cards/types.ts
+++ b/app/components/Dashboard/Cards/types.ts
@@ -4,3 +4,19 @@ export interface TextNode extends Node {
   type: 'text';
   value: string;
 }
+
+export const TENURE_COLORS_DARK = {
+  marketPurchase: 'rgb(var(--freehold-equity-color-rgb))',
+  marketRent: 'rgb(var(--private-rent-land-color-rgb))',
+  fairholdLandPurchase: 'rgb(var(--fairhold-equity-color-rgb))',
+  fairholdLandRent: 'rgb(var(--fairhold-equity-color-rgb))',
+  socialRent: 'rgb(var(--social-rent-land-color-rgb))'
+} as const;
+
+export const TENURE_COLORS_LIGHT = {
+  marketPurchase: 'rgb(var(--freehold-detail-color-rgb))',
+  marketRent: 'rgb(var(--private-rent-detail-color-rgb))',
+  fairholdLandPurchase: 'rgb(var(--fairhold-detail-color-rgb))',
+  fairholdLandRent: 'rgb(var(--fairhold-detail-color-rgb))',
+  socialRent: 'rgb(var(--social-rent-detail-color-rgb))'
+} as const;

--- a/app/components/graphs/CostOverTimeStackedBarChart.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChart.tsx
@@ -18,19 +18,32 @@ export interface LifetimeBarData {
   maintenance?: number;
 }
 
-const CostOverTimeTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+export const CostOverTimeTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
   if (!active || !payload) return null;
 
   return (
-    <div className="rounded-lg border bg-background p-2 shadow-sm">
-      <div className="grid grid-cols-2 gap-2">
-        <div className="font-medium">Year {label}{parseInt(label as string) === 1 ? " (with deposit)" : ""}</div>
-        {payload.map((entry, index) => (
+    <div className="rounded-xl bg-[rgb(var(--text-default-rgb))] p-2 shadow-sm">
+      <div className="grid grid-cols-1">
+        <div className="font-bold text-[rgb(var(--button-background-rgb))]"> Year {label}</div>
+        {payload.map((entry, index) => {
+          let barLabel 
+          if (entry.name === "Equity" && payload[0].payload.year === 1) {
+            barLabel = "Deposit"
+          } else if (entry.name === "Equity") {
+            barLabel = "Repayment"
+          } else {
+            barLabel = entry.name
+          }
+          return (
           <div key={`tooltip-${entry.name}-${index}`} className="grid grid-cols-2 gap-4">
-            <div style={{ color: entry.color }}>{entry.name}:</div>
-            <div>£{entry.value ? entry.value.toLocaleString() : '0'}</div>
+            <div style={{ color: "rgb(var(--button-background-rgb))" }}>
+              {barLabel}
+            </div>
+            <div style={{ color: entry.color }}>
+              £{entry.value ? Math.round(parseFloat(entry.value)).toLocaleString() : '0'}</div>
           </div>
-        ))}
+          )
+  })}
       </div>
     </div>
   );

--- a/app/components/graphs/CostOverTimeStackedBarChartMobile.tsx
+++ b/app/components/graphs/CostOverTimeStackedBarChartMobile.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { StyledChartContainer } from "../ui/StyledChartContainer";
 import { formatValue } from "@/app/lib/format";
 import { LifetimeBarData } from "./CostOverTimeStackedBarChart";
+import { CostOverTimeTooltip } from "./CostOverTimeStackedBarChart";
 
 interface CostOverTimeHorizontalChartProps {
   data: LifetimeBarData[];
@@ -68,9 +69,7 @@ const CostOverTimeHorizontalChart: React.FC<CostOverTimeHorizontalChartProps> = 
               tickLine={false}
             >
             </YAxis>
-            <Tooltip 
-              formatter={(value) => formatValue(value as number)}
-              labelFormatter={(label) => `Year ${label}`}
+            <Tooltip content={<CostOverTimeTooltip />}
             />
             
             {Object.entries(config.colors).map(([key, color]) => (

--- a/app/components/ui/TenureSelector.tsx
+++ b/app/components/ui/TenureSelector.tsx
@@ -6,6 +6,8 @@ interface TenureSelectorProps {
   onClick?: () => void;
   className?: string;
   children: React.ReactNode;
+  tenureColorsDark: Record<string, string>; 
+  tenureColorsLight: Record<string, string>;
   tenureType: 'marketPurchase' | 'marketRent' | 'fairholdLandPurchase' | 'fairholdLandRent' | 'socialRent';
 }
 
@@ -14,25 +16,14 @@ const TenureSelector: React.FC<TenureSelectorProps> = ({
   onClick,
   className,
   children,
+  tenureColorsDark,
+  tenureColorsLight,
   tenureType
 }) => {
   const getColors = () => {
     if (!isSelected) return "bg-[rgb(var(--button-background-rgb))] text-gray-700 hover:bg-gray-200";
     
-    switch (tenureType) {
-      case 'marketPurchase':
-        return "bg-[rgb(var(--freehold-detail-color-rgb))] text-[rgb(var(--freehold-equity-color-rgb))]";
-      case 'marketRent':
-          return "bg-[rgb(var(--private-rent-detail-color-rgb))] text-[rgb(var(--private-rent-land-color-rgb))]";
-      case 'fairholdLandPurchase':
-        return "bg-[rgb(var(--fairhold-detail-color-rgb))] text-[rgb(var(--fairhold-equity-color-rgb))]";
-      case 'fairholdLandRent':
-          return "bg-[rgb(var(--fairhold-detail-color-rgb))] text-[rgb(var(--fairhold-equity-color-rgb))]";
-      case 'socialRent':
-        return "bg-[rgb(var(--social-rent-detail-color-rgb))] text-[rgb(var(--social-rent-land-color-rgb))]";
-      default:
-        return "bg-gray-100 text-gray-700";
-    }
+    return `bg-[${tenureColorsLight[tenureType]}] text-[${tenureColorsDark[tenureType]}] hover:bg-[${tenureColorsLight[tenureType]}]`;
   };
 
   return (

--- a/app/components/ui/TenureSelectorMobile.tsx
+++ b/app/components/ui/TenureSelectorMobile.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+interface TenureSelectorMobileProps {
+    selectedTenure: string;
+    onChange: (tenure: string) => void;
+    tenures: string[];
+    tenureLabels: Record<string, string>;
+    tenureColors: Record<string, string>; 
+    className?: string;
+}
+
+const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
+    selectedTenure,
+    onChange,
+    tenures,
+    tenureLabels,
+    tenureColors,
+    className,
+}) => {
+    return (
+        <div className={`relative w-full ${className}`}>
+        <select
+          value={selectedTenure}
+          onChange={(e) => onChange(e.target.value)}
+          className={`w-full px-4 py-2 rounded-xl border border-gray-300 text-sm transition-colors duration-200 ${className}`}
+          style={{
+            backgroundColor: tenureColors[selectedTenure],
+            color: 'white',
+            appearance: 'none',
+        }}
+        >
+          {tenures.map((tenure) => (
+            <option key={tenure} 
+                value={tenure}
+                style={{
+                    backgroundColor: 'white',
+                    color: 'black',
+                  }}
+                >
+              {tenureLabels[tenure]}
+            </option>
+          ))}
+        </select>
+        <div className="absolute inset-y-0 right-4 flex items-center pointer-events-none">
+            <svg
+            className="w-4 h-4 text-gray-500"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="white"
+            >
+            <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+            />
+            </svg>
+        </div>
+        </div>
+      );
+};
+
+export default TenureSelectorMobile;

--- a/app/components/ui/TenureSelectorMobile.tsx
+++ b/app/components/ui/TenureSelectorMobile.tsx
@@ -5,7 +5,7 @@ interface TenureSelectorMobileProps {
     onChange: (tenure: string) => void;
     tenures: string[];
     tenureLabels: Record<string, string>;
-    tenureColors: Record<string, string>; 
+    tenureColorsDark: Record<string, string>; 
     tenureColorsLight: Record<string, string>;
     className?: string;
 }
@@ -15,7 +15,7 @@ const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
     onChange,
     tenures,
     tenureLabels,
-    tenureColors,
+    tenureColorsDark,
     tenureColorsLight,
     className,
 }) => {
@@ -27,7 +27,7 @@ const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
           className={`w-full px-4 py-2 rounded-xl border border-gray-300 text-sm font-medium transition-colors duration-200 ${className}`}
           style={{
             backgroundColor: tenureColorsLight[selectedTenure],
-            color: tenureColors[selectedTenure],
+            color: tenureColorsDark[selectedTenure],
             appearance: 'none',
         }}
         >
@@ -49,7 +49,7 @@ const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
-            stroke={tenureColors[selectedTenure]}
+            stroke={tenureColorsDark[selectedTenure]}
             >
             <path
                 strokeLinecap="round"

--- a/app/components/ui/TenureSelectorMobile.tsx
+++ b/app/components/ui/TenureSelectorMobile.tsx
@@ -6,6 +6,7 @@ interface TenureSelectorMobileProps {
     tenures: string[];
     tenureLabels: Record<string, string>;
     tenureColors: Record<string, string>; 
+    tenureColorsLight: Record<string, string>;
     className?: string;
 }
 
@@ -15,6 +16,7 @@ const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
     tenures,
     tenureLabels,
     tenureColors,
+    tenureColorsLight,
     className,
 }) => {
     return (
@@ -22,10 +24,10 @@ const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
         <select
           value={selectedTenure}
           onChange={(e) => onChange(e.target.value)}
-          className={`w-full px-4 py-2 rounded-xl border border-gray-300 text-sm transition-colors duration-200 ${className}`}
+          className={`w-full px-4 py-2 rounded-xl border border-gray-300 text-sm font-medium transition-colors duration-200 ${className}`}
           style={{
-            backgroundColor: tenureColors[selectedTenure],
-            color: 'white',
+            backgroundColor: tenureColorsLight[selectedTenure],
+            color: tenureColors[selectedTenure],
             appearance: 'none',
         }}
         >
@@ -34,7 +36,7 @@ const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
                 value={tenure}
                 style={{
                     backgroundColor: 'white',
-                    color: 'black',
+                    color: 'rgb(var(--text-default-rgb))',
                   }}
                 >
               {tenureLabels[tenure]}
@@ -47,7 +49,7 @@ const TenureSelectorMobile: React.FC<TenureSelectorMobileProps> = ({
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
-            stroke="white"
+            stroke={tenureColors[selectedTenure]}
             >
             <path
                 strokeLinecap="round"


### PR DESCRIPTION
# What does this PR do?
- Creates a new `TenureSelectorMobile` component to render for lifetime costs graph on mobile. 
- Creates a new `TENURE_COLORS_LIGHT` object in `CostOverTime.tsx` to store the second colour and renames what was `TENURE_COLORS` to `TENURE_COLORS_DARK`. 
- Refactors `TenureSelector` to select colours using the same pattern and objects. 

Closes #403 
___
# Comments
I made a version which looked like this which I thought worked well (more contrast on mobile):
![Screenshot 2025-04-16 104132](https://github.com/user-attachments/assets/14738356-83e6-4581-b2bd-4d49951470ef)

But ultimately styled it like this, as per designs:
![Screenshot 2025-04-16 104543](https://github.com/user-attachments/assets/2de91d2b-3682-4a35-a1c3-a1d2f3775cfc)
