### PR TITLE
feat: snap scroll

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -75,7 +75,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
         </span>
       }
       >
-      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
         <div className="flex gap-2 mb-4">
         {TENURES.map(tenure => (
           <TenureSelector

--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -26,7 +26,7 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
               </span>
             }
           >
-      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
         <HowMuchFHCostWrapper household={data} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -49,7 +49,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
       title="How much would Fairhold cost me every month?"
       subtitle="Monthly cost of housing, excluding bills and maintenance"
     >
-      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
         <HowMuchPerMonthWrapper household={processedData} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -51,7 +51,7 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
       title="How much could I sell it for?"
       subtitle="Estimated sale price at any time"
     >
-      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
       <div className="flex gap-2 mb-4">
           {TENURES.map(tenure => ( 
             <TenureSelector 

--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -21,7 +21,7 @@ type WhatDifferenceProps = {
 }
 
 const Card: React.FC<React.PropsWithChildren<CardProps>> = ({ title, children }) => (
-  <div className="px-4 py-4 flex flex-col flex-1 max-w-[300px] bg-white drop-shadow-md">
+  <div className="px-4 py-4 flex flex-col flex-1 flex-grow bg-white drop-shadow-md">
       <p className="text-2xl font-semibold mb-0 text-[rgb(var(--text-default-rgb))]">{title}</p>
     <div className="text-sm">{children}</div>
   </div>
@@ -53,7 +53,7 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
   const maintenanceCost = `£${Math.round(household.lifetime.lifetimeData[0].maintenanceCost[household.property.maintenanceLevel]).toLocaleString()}`;
   const localJobs = household.socialValue.localJobs.toFixed(1);
 
-  return <div className="flex md:flex-row flex-col gap-6 w-3/4 justify-center py-4">
+  return <div className="flex md:flex-row flex-col gap-6 w-full justify-between items-start py-4">
     <Card title="Economy">
       <SubCard figure={moneySaved} title="Savings on housing costs">Over {lifetime} years.</SubCard>
       <SubCard figure={savingsToNHSPerHouseLifetime} title="Health savings">If moving from substandard accommodation, the home would save the NHS <Highlight>{savingsToNHSYear1}</Highlight> per year and the wider economy <Highlight>{savingsToSocietyPerHouseLifetime}</Highlight> over {lifetime} years.</SubCard>

--- a/app/components/Dashboard/Cards/WhatWouldYouChoose.tsx
+++ b/app/components/Dashboard/Cards/WhatWouldYouChoose.tsx
@@ -1,32 +1,23 @@
 import { Button } from "@/components/ui/button"
-import GraphCard from "../../ui/GraphCard"
-import { ArrowRightIcon, ReloadIcon } from "@radix-ui/react-icons"
+import { ReloadIcon } from "@radix-ui/react-icons"
 
 export const WhatWouldYouChoose: React.FC = () => {
   return (
-    <GraphCard title="What would you choose?">
-      <div className="flex flex-col h-full justify-between">
-        <div className="w-2/3">
-          <p>
-            Would Fairhold be affordable for you? Would you support the creation of more Fairhold homes in your area? If you could pick any way to rent or own a home, which would you choose?
-          </p>
-          <p>
-            Take our survey to see how your preferences compare with other people&apos;s.
-          </p>
-          <div className="flex mt-20">
-            <Button type="submit" className="calculate-button-style px-10">
-              Take the survey
-            </Button>
-            <a href="#" className="ml-10 text-sm flex items-center">Find out more about Fairhold
-              <ArrowRightIcon className="ml-1" />
-            </a>
-          </div>
+    <div className="min-h-screen h-screen snap-start w-full md:w-3/4 items-center justify-center p-10 flex flex-col overflow-y-auto my-2 pb-6">
+      <div className="h-2/3 flex flex-col w-full md:w-3/4 gap-6">
+        <h1 className={`text-2xl md:text-3xl lg:text-4xl sm:text-xl font-bold text-black`}>What would you choose?</h1>
+        <h2 className={`text-lg md:text-xl lg:text-2xl text-gray-600 mt-2 font-normal`}>Would Fairhold be affordable for you? Would you support the creation of Fairhold homes in your area? Would you live in a Fairhold home if you could?</h2>
+        <h2 className={`text-lg md:text-xl lg:text-2xl text-gray-600 mt-2 font-normal`}>Take our quick survey, make your voice heard, and see how your housing preferences compare with other peoples&apos;.</h2>
+        <div className="flex flex-col md:flex-row gap-4 mt-10 justify-between">
+          <Button type="submit" className="calculate-button-style px-10">
+            Take the survey
+          </Button>
+          <button className="flex items-center gap-2" onClick={() => window.location.reload()}>
+            <ReloadIcon />
+            Start again
+          </button>
         </div>
-        <button className="flex items-center gap-2" onClick={() => window.location.reload()}>
-          <ReloadIcon />
-          Start again
-        </button>
-      </div>
-    </GraphCard>
+        </div>
+    </div>
   )
 };

--- a/app/components/ui/Dashboard.tsx
+++ b/app/components/ui/Dashboard.tsx
@@ -31,9 +31,9 @@ const Dashboard: React.FC<DashboardProps> = ({ inputData, processedData }) => {
   const someUnusedVariable = inputData;
 
   return (
-    <div className="snap-container">
+    <div className="snap-container md:h-screen overflow-hidden">
       <div
-        className="snap-scroll"
+        className="snap-y snap-mandatory h-full overflow-y-auto flex flex-col items-center align-center"
         ref={scrollContainerRef}
         onScroll={handleScroll}
       >

--- a/app/components/ui/GraphCard.tsx
+++ b/app/components/ui/GraphCard.tsx
@@ -7,7 +7,7 @@ type Props = React.PropsWithChildren<{
 
 const GraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
-    <div className="min-h-screen snap-start w-full p-10 flex flex-col overflow-y-auto my-2">
+    <div className="min-h-screen snap-start w-full p-10 flex flex-col overflow-y-auto my-2 pb-6">
       <div className="justify-center w-3/4">
         <h1 className={`text-2xl md:text-3xl lg:text-4xl sm:text-xl font-bold text-black`}>{title}</h1>
         {subtitle && <h2 className={`text-lg md:text-xl lg:text-2xl text-gray-600 mt-2 font-normal`}>{subtitle}</h2>}

--- a/app/components/ui/GraphCard.tsx
+++ b/app/components/ui/GraphCard.tsx
@@ -7,12 +7,12 @@ type Props = React.PropsWithChildren<{
 
 const GraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
-    <div className="h-screen snap-start p-10 flex flex-col">
-      <div className="w-full md:w-3/4">
-        <h1 className={`text-2xl md:text-3xl lg:text-4xl  sm:text-xl font-bold text-black`}>{title}</h1>
+    <div className="min-h-screen snap-start w-full p-10 flex flex-col overflow-y-auto my-2">
+      <div className="justify-center w-3/4">
+        <h1 className={`text-2xl md:text-3xl lg:text-4xl sm:text-xl font-bold text-black`}>{title}</h1>
         {subtitle && <h2 className={`text-lg md:text-xl lg:text-2xl text-gray-600 mt-2 font-normal`}>{subtitle}</h2>}
       </div>
-      {children && <div className="mt-4 flex-1">{children}</div>}
+      {children && <div className="mt-4 h-[calc(100vh-16rem)]">{children}</div>}
     </div>
   );
 };

--- a/app/components/ui/GraphCard.tsx
+++ b/app/components/ui/GraphCard.tsx
@@ -7,8 +7,8 @@ type Props = React.PropsWithChildren<{
 
 const GraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
-    <div className="min-h-screen snap-start w-full p-10 flex flex-col overflow-y-auto my-2 pb-6">
-      <div className="justify-center w-3/4">
+    <div className="min-h-screen snap-start w-full md:w-3/4 p-10 flex flex-col overflow-y-auto my-2 pb-6">
+      <div className="justify-center">
         <h1 className={`text-2xl md:text-3xl lg:text-4xl sm:text-xl font-bold text-black`}>{title}</h1>
         {subtitle && <h2 className={`text-lg md:text-xl lg:text-2xl text-gray-600 mt-2 font-normal`}>{subtitle}</h2>}
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -134,6 +134,7 @@ body {
   transition:
     transform 0.3s ease,
     background-color 0.3s ease;
+  border-radius: 20px;
 }
 
 .calculate-button-style:hover {


### PR DESCRIPTION
Enables snap _and_ scroll on mobile (when cards are too long for screen height)

Should close #392 

Can anyone identify the bug (described in the issue above ^) persisting? Not seeing it in my tests! 