### PR TITLE
feat: restyle content alignment

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -75,7 +75,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
         </span>
       }
       >
-      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
         <div className="flex gap-2 mb-4">
         {TENURES.map(tenure => (
           <TenureSelector

--- a/app/components/Dashboard/Cards/HowMuchFHCost.tsx
+++ b/app/components/Dashboard/Cards/HowMuchFHCost.tsx
@@ -26,7 +26,7 @@ export const HowMuchFHCost: React.FC<DashboardProps> = ({ data }) => {
               </span>
             }
           >
-      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
         <HowMuchFHCostWrapper household={data} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -49,7 +49,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
       title="How much would Fairhold cost me every month?"
       subtitle="Monthly cost of housing, excluding bills and maintenance"
     >
-      <div className="flex flex-col h-full md:w-3/4 w-full justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
         <HowMuchPerMonthWrapper household={processedData} />
         <Drawer
           buttonTitle="Find out more about how we estimated these"

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -51,7 +51,7 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
       title="How much could I sell it for?"
       subtitle="Estimated sale price at any time"
     >
-      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
       <div className="flex gap-2 mb-4">
           {TENURES.map(tenure => ( 
             <TenureSelector 

--- a/app/components/Dashboard/Cards/WhatDifference.tsx
+++ b/app/components/Dashboard/Cards/WhatDifference.tsx
@@ -21,7 +21,7 @@ type WhatDifferenceProps = {
 }
 
 const Card: React.FC<React.PropsWithChildren<CardProps>> = ({ title, children }) => (
-  <div className="px-4 py-4 flex flex-col flex-1 max-w-[300px] bg-white drop-shadow-md">
+  <div className="px-4 py-4 flex flex-col flex-1 flex-grow bg-white drop-shadow-md">
       <p className="text-2xl font-semibold mb-0 text-[rgb(var(--text-default-rgb))]">{title}</p>
     <div className="text-sm">{children}</div>
   </div>
@@ -53,7 +53,7 @@ const Cards: React.FC<CardsProps> = ({ household }) => {
   const maintenanceCost = `£${Math.round(household.lifetime.lifetimeData[0].maintenanceCost[household.property.maintenanceLevel]).toLocaleString()}`;
   const localJobs = household.socialValue.localJobs.toFixed(1);
 
-  return <div className="flex md:flex-row flex-col gap-6 w-3/4 justify-center py-4">
+  return <div className="flex md:flex-row flex-col gap-6 w-full justify-between items-start py-4">
     <Card title="Economy">
       <SubCard figure={moneySaved} title="Savings on housing costs">Over {lifetime} years.</SubCard>
       <SubCard figure={savingsToNHSPerHouseLifetime} title="Health savings">If moving from substandard accommodation, the home would save the NHS <Highlight>{savingsToNHSYear1}</Highlight> per year and the wider economy <Highlight>{savingsToSocietyPerHouseLifetime}</Highlight> over {lifetime} years.</SubCard>

--- a/app/components/ui/GraphCard.tsx
+++ b/app/components/ui/GraphCard.tsx
@@ -7,8 +7,8 @@ type Props = React.PropsWithChildren<{
 
 const GraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
-    <div className="min-h-screen snap-start w-full p-10 flex flex-col overflow-y-auto my-2 pb-6">
-      <div className="justify-center w-3/4">
+    <div className="min-h-screen snap-start w-full md:w-3/4 p-10 flex flex-col overflow-y-auto my-2 pb-6">
+      <div className="justify-center">
         <h1 className={`text-2xl md:text-3xl lg:text-4xl sm:text-xl font-bold text-black`}>{title}</h1>
         {subtitle && <h2 className={`text-lg md:text-xl lg:text-2xl text-gray-600 mt-2 font-normal`}>{subtitle}</h2>}
       </div>


### PR DESCRIPTION
A little bit of Tailwind tweaking to get content alignment right 

Before:
![image](https://github.com/user-attachments/assets/becc8dc9-b0f6-4257-8239-a0660749db54)

After:
![image](https://github.com/user-attachments/assets/58892cbc-b72f-4d28-ad24-a6a5977c1f08)

Design:
![image](https://github.com/user-attachments/assets/cd35b2d8-8f8e-4f71-bd54-8ec5e9868c69)

Obviously still missing header!