### PR TITLE
feat: restyle form errors

### DIFF
--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -204,19 +204,30 @@ const CalculatorInput = () => {
               <FormField
                 control={form.control}
                 name="housePostcode"
-                render={({ field }) => (
+                render={({ field, fieldState }) => (
                   <FormItem>
                     <FormLabel className="h3-style text-sm lg:text-base ">
                       Postcode
                     </FormLabel>
                     <FormControl>
-                      <Input
-                        placeholder="e.g. SE17 1PE"
-                        {...field}
-                        className="inputfield-style text-xs"
-                      />
+                      <div
+                        className={`relative ${
+                          fieldState.error ? "border-red-500 pl-4" : ""
+                        }`}
+                      >
+                        {fieldState.error && (
+                          <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>
+                        )}
+                        <Input
+                          placeholder="e.g. SE17 1PE"
+                          {...field}
+                          className={`inputfield-style text-xs ${
+                            fieldState.error ? "border-red-500" : ""
+                          }`}
+                        />
+                      </div>
                     </FormControl>
-                    <FormMessage  className="error-message-style" />
+                    <FormMessage className="error-message-style" />
                   </FormItem>
                 )}
               />
@@ -224,20 +235,32 @@ const CalculatorInput = () => {
               <FormField
                 control={form.control}
                 name="houseAge"
-                render={({ field }) => (
+                render={({ field, fieldState }) => (
                   <FormItem>
                     <FormLabel className="h3-style text-sm lg:text-base">
                       When was the house built?
                     </FormLabel>
                     <FormControl>
-                      <InputDropdown
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        options={AGE_OPTIONS}
-                        placeholder="Select house age"
-                      />
+                      <div
+                        className={`relative ${
+                          fieldState.error ? "border-red-500 pl-4" : ""
+                        }`}
+                      >
+                        {fieldState.error && (
+                          <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>
+                        )}
+                        <InputDropdown
+                          value={field.value}
+                          onValueChange={field.onChange}
+                          options={AGE_OPTIONS}
+                          placeholder="Select house age"
+                          className={`inputfield-style text-xs ${
+                            fieldState.error ? "border-red-500" : ""
+                          }`}
+                        />
+                      </div>
                     </FormControl>
-                    <FormMessage  className="error-message-style" />
+                    <FormMessage className="error-message-style" />
                   </FormItem>
                 )}
               />
@@ -245,22 +268,33 @@ const CalculatorInput = () => {
               <FormField
                 control={form.control}
                 name="houseBedrooms"
-                render={({ field }) => (
+                render={({ field, fieldState }) => (
                   <FormItem>
-                    <FormLabel className="h3-style text-sm lg:text-base">
+                    <FormLabel className="h3-style text-sm lg:text-base ">
                       Number of bedrooms
                     </FormLabel>
                     <FormControl>
-                      <Input
-                        placeholder=" e.g. 2 for two bedrooms"
-                        {...field}
-                        value={field.value ?? ""}
-                        className="inputfield-style text-xs"
-                      />
+                      <div
+                        className={`relative ${
+                          fieldState.error ? "border-red-500 pl-4" : ""
+                        }`}
+                      >
+                        {fieldState.error && (
+                          <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>
+                        )}
+                        <Input
+                          placeholder="e.g. 2 for two bedrooms"
+                          {...field}
+                          className={`inputfield-style text-xs ${
+                            fieldState.error ? "border-red-500" : ""
+                          }`}
+                        />
+                      </div>
                     </FormControl>
-                    <FormMessage  className="error-message-style" />
+                    <FormMessage className="error-message-style" />
                   </FormItem>
                 )}
+                
               />
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -31,6 +31,7 @@ import { APIError } from "@/app/lib/exceptions";
 import { BackgroundAssumptions } from "./BackgroundAssumptions";
 import { MaintenanceExplainerDrawer } from "./MaintenanceExplainerDrawer";
 import InputDropdown from "./InputDropdown";
+import InputField from "./InputField";
 import { Separator } from "@/components/ui/separator"
 
 type View = "form" | "loading" | "dashboard";
@@ -210,22 +211,12 @@ const CalculatorInput = () => {
                       Postcode
                     </FormLabel>
                     <FormControl>
-                      <div
-                        className={`relative ${
-                          fieldState.error ? "border-red-500 pl-4" : ""
-                        }`}
-                      >
-                        {fieldState.error && (
-                          <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>
-                        )}
-                        <Input
-                          placeholder="e.g. SE17 1PE"
-                          {...field}
-                          className={`inputfield-style text-xs ${
-                            fieldState.error ? "border-red-500" : ""
-                          }`}
-                        />
-                      </div>
+                      <InputField
+                        placeholder="e.g. SE17 1PE"
+                        {...field}
+                        error={!!fieldState.error}
+                        className={`inputfield-style text-xs`}
+                      />
                     </FormControl>
                     <FormMessage className="error-message-style" />
                   </FormItem>
@@ -241,24 +232,14 @@ const CalculatorInput = () => {
                       When was the house built?
                     </FormLabel>
                     <FormControl>
-                      <div
-                        className={`relative ${
-                          fieldState.error ? "border-red-500 pl-4" : ""
-                        }`}
-                      >
-                        {fieldState.error && (
-                          <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>
-                        )}
-                        <InputDropdown
-                          value={field.value}
-                          onValueChange={field.onChange}
-                          options={AGE_OPTIONS}
-                          placeholder="Select house age"
-                          className={`inputfield-style text-xs ${
-                            fieldState.error ? "border-red-500" : ""
-                          }`}
-                        />
-                      </div>
+                    <InputDropdown
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      options={AGE_OPTIONS}
+                      placeholder="Select house age"
+                      error={!!fieldState.error}
+                      className="inputfield-style text-xs"
+                    />
                     </FormControl>
                     <FormMessage className="error-message-style" />
                   </FormItem>
@@ -274,22 +255,12 @@ const CalculatorInput = () => {
                       Number of bedrooms
                     </FormLabel>
                     <FormControl>
-                      <div
-                        className={`relative ${
-                          fieldState.error ? "border-red-500 pl-4" : ""
-                        }`}
-                      >
-                        {fieldState.error && (
-                          <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>
-                        )}
-                        <Input
-                          placeholder="e.g. 2 for two bedrooms"
-                          {...field}
-                          className={`inputfield-style text-xs ${
-                            fieldState.error ? "border-red-500" : ""
-                          }`}
-                        />
-                      </div>
+                      <InputField
+                      placeholder="e.g. 2 for two bedrooms"
+                      {...field}
+                      error={!!fieldState.error}
+                      className="inputfield-style text-xs"
+                      />
                     </FormControl>
                     <FormMessage className="error-message-style" />
                   </FormItem>

--- a/app/components/ui/InputDropdown.tsx
+++ b/app/components/ui/InputDropdown.tsx
@@ -18,6 +18,7 @@ interface InputDropdownProps {
   options: readonly DropdownOption[];
   placeholder: string;
   className?: string;
+  error?: boolean;
 }
 
 const InputDropdown: React.FC<InputDropdownProps> = ({
@@ -26,29 +27,33 @@ const InputDropdown: React.FC<InputDropdownProps> = ({
   options,
   placeholder,
   className,
+  error,
 }) => {
   return (
-    <Select
-      value={value?.toString() || ""}
-      onValueChange={(val) => onValueChange(Number(val))}
-    >
-      <SelectTrigger
-        className={`dropdown-style ${value !== undefined ? "selected" : ""} ${className}`}
+    <div className={`relative ${error ? "pl-4" : ""}`}>
+      {error && <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>}
+      <Select
+        value={value?.toString() || ""}
+        onValueChange={(val) => onValueChange(Number(val))}
       >
-        <SelectValue placeholder={placeholder} />
-      </SelectTrigger>
-      <SelectContent>
-        {options.map((option) => (
-          <SelectItem
-            key={option.value}
-            value={option.value.toString()}
-            className="text-xs"
-          >
-            {option.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+        <SelectTrigger
+          className={`dropdown-style ${value !== undefined ? "selected" : ""} ${className} ${error ? "border-red-500" : ""}`}
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value.toString()}
+              className="text-xs"
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
   );
 };
 

--- a/app/components/ui/InputDropdown.tsx
+++ b/app/components/ui/InputDropdown.tsx
@@ -17,6 +17,7 @@ interface InputDropdownProps {
   onValueChange: (value: number) => void;
   options: readonly DropdownOption[];
   placeholder: string;
+  className?: string;
 }
 
 const InputDropdown: React.FC<InputDropdownProps> = ({
@@ -24,6 +25,7 @@ const InputDropdown: React.FC<InputDropdownProps> = ({
   onValueChange,
   options,
   placeholder,
+  className,
 }) => {
   return (
     <Select
@@ -31,7 +33,7 @@ const InputDropdown: React.FC<InputDropdownProps> = ({
       onValueChange={(val) => onValueChange(Number(val))}
     >
       <SelectTrigger
-        className={`dropdown-style ${value !== undefined ? "selected" : ""}`}
+        className={`dropdown-style ${value !== undefined ? "selected" : ""} ${className}`}
       >
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>

--- a/app/components/ui/InputField.tsx
+++ b/app/components/ui/InputField.tsx
@@ -1,36 +1,27 @@
 import React from "react";
-import { UseFormRegister } from "react-hook-form";
-import { Calculation } from "@/app/schemas/calculationSchema";
+import { Input } from "@/components/ui/input";
 
 interface InputFieldProps {
-  id: keyof Calculation;
   placeholder: string;
-  type: string;
-  register: UseFormRegister<Calculation>;
-  error?: string;
+  error?: boolean; 
+  className?: string;
 }
 
 const InputField: React.FC<InputFieldProps> = ({
-  id,
   placeholder,
-  register,
-  type,
   error,
+  className,
+  ...rest
 }) => {
   return (
-    <>
-      <input
-        className="mb-3 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500
-      disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none
-       rounded-md "
-        type={type}
+    <div className={`relative ${error ? "pl-4" : ""}`}>
+      {error && <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500"></div>}
+      <Input
         placeholder={placeholder}
-        {...register(id)}
-        id={id}
-        key={id}
+        className={`${className || ""} ${error ? "border-red-500" : ""}`}
+        {...rest}
       />
-      {error && <p className="text-red-500">{error}</p>}
-    </>
+    </div>
   );
 };
 export default InputField;

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,7 +28,7 @@
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
   --social-rent-detail-color-rgb: 242 196 202;
-  --error-text-rgb: 181 31 20;
+  --error-text-rgb: 230 5 5;
 }
 
 @layer utilities {


### PR DESCRIPTION
Makes the error colour brighter to follow designs, and adds conditional error styling based on `fieldState`. 

Before:
![image](https://github.com/user-attachments/assets/05069a05-cf5e-45a9-bef8-4b52dfb887ac)

After:
![image](https://github.com/user-attachments/assets/32382fee-d731-4fc5-a174-92d31c0df775)

Closes #410 