### PR TITLE
feat: hide carousel dots on mobile

### DIFF
--- a/app/components/ui/Carousel.tsx
+++ b/app/components/ui/Carousel.tsx
@@ -43,7 +43,7 @@ export const Carousel: React.FC<CarouselProps> = ({ scrollContainerRef, currentP
       <div className={cn("invisible", { "visible": currentPage > 0 })}>
         <NavigationIcon Icon={ArrowUpIcon} onClick={handlePrevious} />
       </div>
-      <div className="flex flex-col items-center">
+      <div className="hidden md:flex flex-col items-center">
         {Array.from({ length: totalPages + 1 }, (_, index) => (
           <button key={index} onClick={() => scrollTo(index)}>
             <DotFilledIcon 


### PR DESCRIPTION
Following mobile designs.

Before:
![image](https://github.com/user-attachments/assets/d282eb21-8bcf-4b34-be19-0792528a77b3)

After:
![image](https://github.com/user-attachments/assets/00814873-2558-429c-86f3-1b11ebfd02bb)
