### PR TITLE
feat: tidy styles

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -76,6 +76,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
           <span style={{ color: TENURE_COLORS[selectedTenure] }}>
             {formatValue(lifetimeTotal)}
           </span>
+          .
         </span>
       }
       >

--- a/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
+++ b/app/components/Dashboard/Cards/HowMuchPerMonth.tsx
@@ -47,7 +47,7 @@ export const HowMuchPerMonth: React.FC<ProcessedDataOnly> = ({
   return (
     <GraphCard
       title="How much would it cost every month?"
-      subtitle="Not including bills"
+      subtitle="Not including bills."
     >
       <div className="flex flex-col h-full w-full justify-between">
         <HowMuchPerMonthWrapper household={processedData} />

--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -49,7 +49,7 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
   return (
     <GraphCard
       title="How much could I sell it for?"
-      subtitle="Estimated sale price at any time"
+      subtitle="Estimated sale price at any time."
     >
       <div className="flex flex-col h-full w-full justify-between">
       <div className="flex gap-2 mb-4">

--- a/app/components/ui/Drawer.tsx
+++ b/app/components/ui/Drawer.tsx
@@ -25,9 +25,9 @@ export const Drawer: React.FC<React.PropsWithChildren<Props>> = ({
   descriptionClassName = "text-left" 
 }) => (
   <Sheet>
-    <SheetTrigger className="text-gray-400 text-xs underline flex">
-      <QuestionMarkCircledIcon/>
-      <span className="ml-1">{buttonTitle}</span>
+    <SheetTrigger className="text-gray-400 text-xs flex items-start text-left">
+      <QuestionMarkCircledIcon className="flex-shrink-0 mt-0.5"/>
+      <span className="ml-1 underline">{buttonTitle}</span>
     </SheetTrigger>
     <SheetContent className="overflow-y-auto">
       <SheetHeader>

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,10 +15,10 @@
   --text-inaccessible-rgb: 171 164 164;
   --button-background-rgb: 227 227 225;
 
-  --freehold-equity-color-rgb: 66 75 179;
+  --freehold-equity-color-rgb: 77 100 210;
   --freehold-interest-color-rgb: 131 164 255;
   --freehold-detail-color-rgb: 190 201 232;
-  --fairhold-land-rent-color-rgb: 28 117 43;
+  --fairhold-land-rent-color-rgb: 40 130 50;
   --fairhold-equity-color-rgb: 74 179 91;
   --fairhold-interest-color-rgb: 159 211 166;
   --fairhold-detail-color-rgb: 207 227 209;


### PR DESCRIPTION
- Makes full stops in subtitles consistent
- [Mobile] Make help text icon size (and text justification) uniform
- Adjust colours to improve `CostOverTime` tooltip contrast

Help text before:
![image](https://github.com/user-attachments/assets/594aaf8b-b51d-4139-9eaa-075928bb219e)

Help text after:
![image](https://github.com/user-attachments/assets/dfab341c-1da7-4662-b0fc-5c61a08bd3e5)

Tooltip before:
![image](https://github.com/user-attachments/assets/f278597c-9546-46f7-87bb-de88df145e9e)

Tooltip after:
![image](https://github.com/user-attachments/assets/82d486b7-1039-42e4-8d84-ad9b546c50aa)


Closes #452