### PR TITLE
style: restyle resale value card

### DIFF
--- a/app/components/Dashboard/Cards/ResaleValue.tsx
+++ b/app/components/Dashboard/Cards/ResaleValue.tsx
@@ -55,7 +55,7 @@ export const ResaleValue: React.FC<DashboardProps> = ({ data }) => {
   return (
     <GraphCard
       title="How much could I sell it for?"
-      subtitle="Estimated sale price at any time."
+      subtitle="With Fairhold, you can’t sell the land for more than you bought it for (adjusted for inflation). The value of the building is based on its condition."
     >
       <div className="flex flex-col h-full w-full justify-between">
         <div className="flex gap-2 mb-4">

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -73,16 +73,15 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
           if (typeof x !== "number" || typeof y !== "number") return null;
 
           const label = chartConfig[dataKey].label;
+          const longestLabel = Math.max(chartConfig['none'].label.length, chartConfig['low'].label.length, chartConfig['medium'].label.length, chartConfig['high'].label.length)
           const paddingX = 8;
           const paddingY = 4;
           const fontSize = 12;
 
-          // Roughly estimate text width (monospace approximation for now)
-          const textWidth = label.length * 7;
-          const rectWidth = textWidth + paddingX * 2;
+          const rectWidth = longestLabel * 7 + paddingX * 2;
           const rectHeight = fontSize + paddingY * 2;
           return (
-            <g transform={`translate(${x + 10}, ${y - rectHeight / 2})`}>
+            <g transform={`translate(${x}, ${y - rectHeight / 2})`}>
             <rect
               width={rectWidth}
               height={rectHeight}

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LineChart, Line, CartesianGrid, XAxis, YAxis, TooltipProps } from "recharts";
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, TooltipProps, LabelList } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
@@ -21,19 +21,19 @@ type CustomTooltipProps = TooltipProps<number, string> & {
 
 const chartConfig = {
   none: {
-    label: "No maintenance",
+    label: "None",
     color: "rgb(var(--fairhold-equity-color-rgb))", 
   },
   low: {
-    label: "Low maintenance",
+    label: "Low",
     color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   medium: {
-    label: "Medium maintenance",
+    label: "Medium",
     color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   high: {
-    label: "High maintenance",
+    label: "High",
     color: "rgb(var(--fairhold-equity-color-rgb))",
   },
 } satisfies ChartConfig;
@@ -65,7 +65,46 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
       strokeWidth={2}
       strokeDasharray={dataKey === selectedMaintenance ? "0" : "5 5"}
       dot={false}
-    />
+      >
+      <LabelList
+        content={({ x, y, index }) => {
+          const isLast = index === data.length - 1;
+          if (!isLast) return null;
+          if (typeof x !== "number" || typeof y !== "number") return null;
+
+          const label = chartConfig[dataKey].label;
+          const paddingX = 8;
+          const paddingY = 4;
+          const fontSize = 12;
+
+          // Roughly estimate text width (monospace approximation for now)
+          const textWidth = label.length * 7;
+          const rectWidth = textWidth + paddingX * 2;
+          const rectHeight = fontSize + paddingY * 2;
+          return (
+            <g transform={`translate(${x + 10}, ${y - rectHeight / 2})`}>
+            <rect
+              width={rectWidth}
+              height={rectHeight}
+              rx={rectHeight / 2}
+              ry={rectHeight / 2}
+              fill={`var(--color-${dataKey})`}
+            />
+            <text
+              x={rectWidth / 2}
+              y={rectHeight / 2 + fontSize / 3}
+              fill="#fff"
+              fontSize={fontSize}
+              textAnchor="middle"
+              dominantBaseline={"top"}
+            >
+              {label}
+            </text>
+          </g>
+          );
+        }}
+      />
+    </Line>
   );
   const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
     if (!active || !payload || !payload.length) return null;
@@ -100,6 +139,7 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
         <StyledChartContainer config={chartConfig}  className="h-full w-full">
           <LineChart
             data={data}
+            margin={{ top: 20, right: 70, left: 20, bottom: 20 }}
           >
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis 

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -106,27 +106,20 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
   );
   const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
     if (!active || !payload || !payload.length) return null;
+  
+    // Find the entry that matches the selected maintenance level
+    const selectedEntry = payload.find(entry => entry.name === selectedMaintenance);
+    // console.log({payload})
+    console.log({selectedEntry})
+    
+    // Only show tooltip if we're hovering over the selected line
+    if (!selectedEntry) return null;
 
     return (
-      <div className="bg-white p-3 border rounded shadow">
-        <p className="font-medium mb-2">Year {label}</p>
-        {payload.map((entry) => (
-          <div key={entry.name} className="flex items-center gap-2 mb-1">
-            <svg width="20" height="2" className="flex-shrink-0">
-              <line
-                x1="0"
-                y1="1"
-                x2="20"
-                y2="1"
-                stroke={entry.stroke}
-                strokeWidth="2"
-                strokeDasharray={entry.name === selectedMaintenance ? "0" : "5 5"}
-              />
-            </svg>
-            <span>{chartConfig[entry.name as keyof typeof chartConfig].label}:</span>
-            <span className="font-medium">{formatValue(entry.value ?? 0)}</span>
-          </div>
-        ))}
+      <div className="rounded-xl bg-[rgb(var(--text-default-rgb))] p-1 shadow">
+        <span className="mb-2 text-white">Year {label} </span>
+        <span className="text-[rgb(var(--fairhold-interest-color-rgb))] font-medium">{formatValue(selectedEntry.value ?? 0)}</span>
+
       </div>
     );
   };

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -1,9 +1,8 @@
-import React from "react";
-import { LineChart, Line, CartesianGrid, XAxis, YAxis, TooltipProps, LabelList } from "recharts";
+import React, { useState } from "react";
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, TooltipProps, Tooltip, LabelList } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
-  ChartTooltip,
 } from "@/components/ui/chart";
 import {
   StyledChartContainer,
@@ -53,6 +52,8 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
   selectedMaintenance,
   maxY
 }) => {
+  const [hoveredLine, setHoveredLine] = useState<string | null>(null); // We use useState to figure out what line is being hovered over for the tooltip
+
   const renderLine = (dataKey: keyof Omit<DataPoint, "year">) => (
     <Line
       type="monotone"
@@ -62,6 +63,9 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
         : `rgb(var(--fairhold-interest-color-rgb))`}
       strokeWidth={2}
       dot={false}
+      activeDot={false}
+      onMouseOver={() => setHoveredLine(dataKey)}
+      onMouseOut={() => setHoveredLine(null)}
       >
       <LabelList
         content={({ x, y, index }) => {
@@ -104,15 +108,12 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
       />
     </Line>
   );
-  const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
-    if (!active || !payload || !payload.length) return null;
-  
+  const CustomTooltip = ({ active, payload, label, hoveredLine }: CustomTooltipProps & { hoveredLine: string | null }) => {
+    if (!active || !payload || !payload.length || hoveredLine !== selectedMaintenance) return null; 
+
     // Find the entry that matches the selected maintenance level
     const selectedEntry = payload.find(entry => entry.name === selectedMaintenance);
-    // console.log({payload})
-    console.log({selectedEntry})
     
-    // Only show tooltip if we're hovering over the selected line
     if (!selectedEntry) return null;
 
     return (
@@ -149,7 +150,11 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
               width={40}
             >
             </YAxis>
-            <ChartTooltip content={<CustomTooltip />} />
+            <Tooltip
+              content={<CustomTooltip hoveredLine={hoveredLine} />}
+              isAnimationActive={false}
+              cursor={false}
+            />
             {renderLine("high")}
             {renderLine("medium")}
             {renderLine("low")}

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -22,19 +22,15 @@ type CustomTooltipProps = TooltipProps<number, string> & {
 const chartConfig = {
   none: {
     label: "None",
-    color: "rgb(var(--fairhold-equity-color-rgb))", 
   },
   low: {
     label: "Low",
-    color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   medium: {
     label: "Medium",
-    color: "rgb(var(--fairhold-equity-color-rgb))",
   },
   high: {
     label: "High",
-    color: "rgb(var(--fairhold-equity-color-rgb))",
   },
 } satisfies ChartConfig;
 
@@ -61,9 +57,10 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
     <Line
       type="monotone"
       dataKey={dataKey}
-      stroke={`var(--color-${dataKey})`}
+      stroke={dataKey === selectedMaintenance 
+        ? `rgb(var(--fairhold-equity-color-rgb))` 
+        : `rgb(var(--fairhold-interest-color-rgb))`}
       strokeWidth={2}
-      strokeDasharray={dataKey === selectedMaintenance ? "0" : "5 5"}
       dot={false}
       >
       <LabelList
@@ -87,7 +84,9 @@ const ResaleValueLineChart: React.FC<ResaleValueLineChartProps> = ({
               height={rectHeight}
               rx={rectHeight / 2}
               ry={rectHeight / 2}
-              fill={`var(--color-${dataKey})`}
+              fill={dataKey === selectedMaintenance 
+                ? `rgb(var(--fairhold-equity-color-rgb))` 
+                : `rgb(var(--fairhold-interest-color-rgb))`}
             />
             <text
               x={rectWidth / 2}


### PR DESCRIPTION
- Updates subtitle
- Adds `LabelList` for line labels at the right side of graph
- Restyles tooltip as per design
- Uses tooltip pattern from `HowMuchFHCostBarChart` to only show when selected maintenance level line is hovered over

Current:
![image](https://github.com/user-attachments/assets/6afbfd18-84b0-4f1c-bea7-5b5c8a6e56e8)

Before:
![image](https://github.com/user-attachments/assets/fdfd85eb-74d1-46ea-b34a-10fcefdae5fa)
