### PR TITLE
fix: match tenure colours to selected TenureSelector button

### DIFF
--- a/app/components/ui/TenureSelector.tsx
+++ b/app/components/ui/TenureSelector.tsx
@@ -30,15 +30,13 @@ const TenureSelector: React.FC<TenureSelectorProps> = ({
       color: tenureColorsDark[tenureType],
     };
   };
-    
 
   return (
     <button
       onClick={onClick}
       className={cn(
-        "px-4 py-2 rounded-xl transition-colors duration-200",
+        "px-4 py-1 rounded-2xl transition-colors duration-200 bg-gray-200",
         "text-sm font-medium",
-        !isSelected ? "hover:bg-gray-200" : "",
         className
       )}
       style={isSelected ? getColors() : undefined}

--- a/app/components/ui/TenureSelector.tsx
+++ b/app/components/ui/TenureSelector.tsx
@@ -21,10 +21,16 @@ const TenureSelector: React.FC<TenureSelectorProps> = ({
   tenureType
 }) => {
   const getColors = () => {
-    if (!isSelected) return "bg-[rgb(var(--button-background-rgb))] text-gray-700 hover:bg-gray-200";
-    
-    return `bg-[${tenureColorsLight[tenureType]}] text-[${tenureColorsDark[tenureType]}] hover:bg-[${tenureColorsLight[tenureType]}]`;
+    if (!isSelected) {
+      return {};
+    }
+
+    return {
+      backgroundColor: tenureColorsLight[tenureType],
+      color: tenureColorsDark[tenureType],
+    };
   };
+    
 
   return (
     <button
@@ -32,9 +38,10 @@ const TenureSelector: React.FC<TenureSelectorProps> = ({
       className={cn(
         "px-4 py-2 rounded-xl transition-colors duration-200",
         "text-sm font-medium",
-        getColors(),
+        !isSelected ? "hover:bg-gray-200" : "",
         className
       )}
+      style={isSelected ? getColors() : undefined}
     >
       {children}
     </button>


### PR DESCRIPTION
Fixes a styling bug. 

The issue was with the fact I was trying to dynamically create Tailwind classes using template literals, which wouldn't work at buildtime. 

Before:
![image](https://github.com/user-attachments/assets/26bc91ac-427b-444b-ad49-fc45c1911c57)

This PR:
![image](https://github.com/user-attachments/assets/80b0291f-9121-4512-8a76-b53248892517)

Designs:
![image](https://github.com/user-attachments/assets/c75a1b45-885c-4a79-ad36-8ce72e1eb342)

Closes #467 