### PR TITLE
fix: use default low maintenance level in calculateFairhold

### DIFF
--- a/app/models/Lifetime.ts
+++ b/app/models/Lifetime.ts
@@ -155,7 +155,7 @@ export class Lifetime {
             MAINTENANCE_LEVELS.medium * newBuildPriceIterative;
         let maintenanceCostHighIterative = 
             MAINTENANCE_LEVELS.high * newBuildPriceIterative;
-        /* Each loop a new `Property` instance is created, this is updated by running the `calculateDepreciatedBuildPrice()` method on `iterativeProperty` */
+        /* Each loop updates the depreciated house resale values by applying depreciation methods directly to the `depreciatedHouseBreakdownOverTimeIterative` object. */        
         let depreciatedHouseResaleValueNoMaintenanceIterative = params.property.depreciatedBuildPrice;
         let depreciatedHouseResaleValueLowMaintenanceIterative = params.property.depreciatedBuildPrice;
         let depreciatedHouseResaleValueMediumMaintenanceIterative = params.property.depreciatedBuildPrice;

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -106,8 +106,7 @@ export class Property {
       const result = this.calculateComponentValue(
         key, 
         this.newBuildPrice, 
-        this.age, 
-        "low" // `calculateDepreciatedBuildPrice` is only used in `Property` and not in `Lifetime`, so we can use the default value for maintenanceLevel
+        this.age
       );
 
       depreciatedBuildPrice += result.depreciatedComponentValue;
@@ -119,10 +118,9 @@ export class Property {
   public calculateComponentValue(
     componentKey: keyof houseBreakdownType,
     newBuildPrice: number,
-    age: number,
-    maintenanceLevel: MaintenanceLevel
+    age: number
   ): ComponentCalculation {
-    const maintenancePercentage = MAINTENANCE_LEVELS[maintenanceLevel]
+    const maintenancePercentage = MAINTENANCE_LEVELS["low"] // `calculateDepreciatedBuildPrice` is only used in `Property` and not in `Lifetime`, so we can use the default value for maintenanceLevel
 
     const component = HOUSE_BREAKDOWN_PERCENTAGES[componentKey];
     

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -39,6 +39,9 @@ export class Property {
    * Size of the house in square meters
    */
   size: number;
+  /**
+   * The maintenance level sets graph options (eg for resale value), not the initial depreciated house price (default low)
+   */
   maintenanceLevel: MaintenanceLevel;
   /**
    * Average build price per metre of a new house

--- a/app/models/Property.ts
+++ b/app/models/Property.ts
@@ -94,22 +94,23 @@ export class Property {
   }
 
   public calculateDepreciatedBuildPrice() {
-  // Initialise depreciatedBuildPrice; since we need the house breakdown even for a newbuild (to store and iterate on it in Lifetime), we run calculateComponentValue instead of just assigning depreciatedHousePrice = newBuildPrice
-  let depreciatedBuildPrice = 0;
 
-  // Calculate for each component using the public method
-  for (const key of Object.keys(HOUSE_BREAKDOWN_PERCENTAGES) as (keyof houseBreakdownType)[]) {
-    const result = this.calculateComponentValue(
-      key, 
-      this.newBuildPrice, 
-      this.age, 
-      this.maintenanceLevel
-    );
+    // Initialise depreciatedBuildPrice; since we need the house breakdown even for a newbuild (to store and iterate on it in Lifetime), we run calculateComponentValue instead of just assigning depreciatedHousePrice = newBuildPrice
+    let depreciatedBuildPrice = 0;
 
-    depreciatedBuildPrice += result.depreciatedComponentValue;
-  }
-    depreciatedBuildPrice = parseFloat(depreciatedBuildPrice.toFixed(PRECISION))
-  return depreciatedBuildPrice;
+    // Calculate for each component using the public method
+    for (const key of Object.keys(HOUSE_BREAKDOWN_PERCENTAGES) as (keyof houseBreakdownType)[]) {
+      const result = this.calculateComponentValue(
+        key, 
+        this.newBuildPrice, 
+        this.age, 
+        "low" // `calculateDepreciatedBuildPrice` is only used in `Property` and not in `Lifetime`, so we can use the default value for maintenanceLevel
+      );
+
+      depreciatedBuildPrice += result.depreciatedComponentValue;
+    }
+      depreciatedBuildPrice = parseFloat(depreciatedBuildPrice.toFixed(PRECISION))
+    return depreciatedBuildPrice;
 }
 
   public calculateComponentValue(


### PR DESCRIPTION
Fixes bug where the user selected maintenance level was being used to calculate `depreciatedBuildPrice` (instead of our default `low`). User selected maintenance level should only be used in the resale value highlight graph. 

Closes #468