### PR TITLE
fix: always give bedrooms input a controlled value

### DIFF
--- a/app/components/ui/CalculatorInput.tsx
+++ b/app/components/ui/CalculatorInput.tsx
@@ -258,6 +258,7 @@ const CalculatorInput = () => {
                       <InputField
                       placeholder="e.g. 2 for two bedrooms"
                       {...field}
+                      value={field.value?.toString() || ''}
                       error={!!fieldState.error}
                       className="inputfield-style text-xs"
                       />

--- a/app/components/ui/InputField.tsx
+++ b/app/components/ui/InputField.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Input } from "@/components/ui/input";
 
-interface InputFieldProps {
+interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   placeholder: string;
   error?: boolean; 
   className?: string;


### PR DESCRIPTION
This is a fix for the bug that Gabry found--but it looks like it's only happening on local / development environments. On the deployed Vercel version it doesn't seem to be a problem, I checked other PR previews too. 

Unsure if this fix is still needed? It has addressed the bug on my local branches however. 

What I've done is give the bedrooms input field a default blank value so that it's always a controlled input. I made the `InputFieldProps` type an extension of `React.InputHTMLAttributes<HTMLInputElement>` so that it would take `value` as a property. 

Closes #461 