### PR TITLE
chore: 'not viable' view refactor

### DIFF
--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -9,8 +9,7 @@ import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
 import { useState } from "react";
-import { formatValue } from "@/app/lib/format";
-import { CustomLabelListContentProps } from "./types";
+import { BarLabelListTopLeft, CustomTick, getLabel, getColor } from "./shared"
 
 const chartConfig = {
   freeholdLand: {
@@ -27,34 +26,6 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-const CustomLabelListContent: React.FC<CustomLabelListContentProps> = ({ x, y, value, color }) => {
-  if (x === undefined || y === undefined || value === undefined) return null;
-  const xAdjust = 2;
-  const yAdjust = 30;
-  const xPos = typeof x === "number" ? x - xAdjust : Number(x) - xAdjust;
-  const yPos = typeof y === "number" ? y - yAdjust : Number(y) - yAdjust;
-  const numValue = typeof value === "number" ? value : parseFloat(value as string);
-  const formattedValue = formatValue(numValue);
-
-  return (
-    <foreignObject x={xPos} y={yPos} width={100} height={30}>
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          color,
-          fontSize: "18px",
-          fontWeight: 600,
-          whiteSpace: "nowrap",
-        }}
-      >
-        {formattedValue}
-      </div>
-    </foreignObject>
-  );
-};
-
 type DataInput = {
   category: string;
   marketPurchase: number;
@@ -68,52 +39,6 @@ interface StackedBarChartProps {
   maxY: number;
 }
 
-interface CustomTickProps {
-  x: number;
-  y: number;
-  payload: { value: string };
-}
-const CustomTick: React.FC<CustomTickProps> = ({ x, y, payload }) => {
-  const label = (() => {
-    switch (payload.value) {
-      case "freehold":
-        return "Freehold";
-      case "fairhold: land purchase":
-        return "Fairhold /\nLand Purchase";
-      case "fairhold: land rent":
-        return "Fairhold /\nLand Rent";
-      default:
-        return payload.value;
-    }
-  })();
-  const labelColor = (() => {
-    switch (payload.value) {
-      case "freehold":
-        return "rgb(var(--freehold-equity-color-rgb))";
-      default:
-        return "rgb(var(--fairhold-equity-color-rgb))";
-    }
-  })();
-
-  return (
-    <g transform={`translate(${x},${y})`}>
-      {label.split('\n').map((line: string, i: number) => (
-        <text
-          key={i}
-          x={0}
-          y={i * 20}
-          dy={10}
-          textAnchor="middle"
-          style={{ fill: labelColor }}
-          fontSize="12px"
-          fontWeight={600}
-        >
-          {line}
-        </text>
-      ))}
-    </g>
-  );
-}
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
   maxY,
@@ -136,7 +61,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
 
   const chartData = [
     {
-      tenure: "freehold",
+      tenure: "Freehold",
       freeholdLand: data[0].marketPurchase,
       freeholdLandLabel: "Land",
       freeholdHouse: data[1].marketPurchase,
@@ -144,7 +69,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       freeholdTotal: data[0].marketPurchase + data[1].marketPurchase,
     },
     {
-      tenure: "fairhold: land purchase",
+      tenure: "Fairhold - Land Purchase",
       fairholdLand: data[0].fairholdLandPurchase,
       fairholdLandLabel: "Land",
       fairholdHouse: data[2].fairholdLandPurchase,
@@ -152,7 +77,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       fairholdTotal: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
     },
     {
-      tenure: "fairhold: land rent",
+      tenure: "Fairhold - Land Rent",
       fairholdHouse: data[2].fairholdLandRent,
       fairholdHouseLabel: "House",
       fairholdTotal: data[2].fairholdLandRent,
@@ -171,8 +96,13 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               tickLine={false}
               interval={0} 
               height={60}  
-                            tick={(props) => (
-                <CustomTick {...props} />
+              tick={(props) => (
+                <CustomTick 
+                  {...props} 
+                  getLabel={getLabel}
+                  getColor={getColor}
+                  index={props.index}
+                  />
               )}
             >
             </XAxis>
@@ -219,7 +149,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="freeholdTotal"
                 position="top"
                 content={(props) => (
-                  <CustomLabelListContent {...props} color="rgb(var(--freehold-equity-color-rgb))" />
+                  <BarLabelListTopLeft {...props} color="rgb(var(--freehold-equity-color-rgb))" />
                 )}
               />
             </Bar>
@@ -258,7 +188,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="fairholdTotal"
                 position="top"
                 content={(props) => (
-                  <CustomLabelListContent {...props} color="rgb(var(--fairhold-equity-color-rgb))" />
+                  <BarLabelListTopLeft {...props} color="rgb(var(--fairhold-equity-color-rgb))" />
                 )}
               />
             </Bar>

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis, LabelList, Tooltip, ReferenceLine } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, LabelList, ReferenceLine } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
@@ -224,7 +224,6 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               hide={true}
               ></YAxis>
 
-            <Tooltip isAnimationActive={false} />
             <ReferenceLine 
                 y={newBuildPrice} 
                 z={0}

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -20,15 +20,59 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-const CustomLabelListContent: React.FC<CustomLabelListContentProps> = ({
+const CenterLabelListContent: React.FC<CustomLabelListContentProps> = ({
   x,
   y,
   value,
-  index
+  width,
+  height,
 }) => {
+  if ( typeof x !== 'number' || 
+    typeof y !== 'number' || 
+    typeof width !== 'number' ||
+    typeof height !== 'number' ||
+    !value
+  ) return null;
 
-  if (x === undefined || y === undefined || value === undefined) return null;
+  const labelColor = (() => {
+      switch (value) {
+        case "Not viable":
+          return "rgb(var(--not-viable-dark-color-rgb))";
+        case "House":
+          return "white";
+        default:
+          return "black";
+      }
+    })();
 
+  const labelWidth = 80;
+  const xPos = x + width / 2 - labelWidth / 2;
+  const yPos = y + height / 2 - 10;
+
+  return (
+    <foreignObject x={xPos} y={yPos} width={80} height={20}>
+        <div
+        style={{
+            color: labelColor,
+            fontSize: "12px",
+            fontWeight: 600,
+            textAlign: "center",
+        }}
+        >
+        {value}
+        </div>
+    </foreignObject>
+  );
+}
+
+const TopLabelListContent: React.FC<CustomLabelListContentProps> = ({
+  x,
+  y,
+  index,
+  value  
+}) => {
+    if (!x || !y || !value) return null;
+                  
   const labelColor = (() => {
     switch (index) {
       case 0:
@@ -37,11 +81,12 @@ const CustomLabelListContent: React.FC<CustomLabelListContentProps> = ({
         return "rgb(var(--fairhold-equity-color-rgb))";
     }
   })();
-
-  const xPos = typeof x === 'number' ? x - 2 : 0;
-  const yPos = typeof y === 'number' ? y - 30 : 0;
-  const checkedValue = typeof value === 'number' ? value : parseFloat(value as string);
-  const formattedValue = formatValue(checkedValue);
+  const xAdjust = 2;
+  const yAdjust = 30;
+  const xPos = typeof x === 'number' ? x - xAdjust : 0;
+  const yPos = typeof y === 'number' ? y - yAdjust : 0;
+  value = typeof value === 'number' ? value : parseFloat(value as string);
+  const formattedValue = formatValue(value);
 
   return (
     <foreignObject x={xPos} y={yPos} width={100} height={30}>
@@ -209,51 +254,15 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 position="center"
                 fontSize={12}
                 content={(props) => (
-                  <CustomLabelListContent {...props}/>
+                  <CenterLabelListContent {...props}/>
                 )}
               />
               <LabelList
                 dataKey="total"
                 position="top"
-                content={(props) => {
-                  if (!props.x || !props.y || !props.value) return null;
-                  
-                  const labelColor = (() => {
-                    switch (props.index) {
-                      case 0:
-                        return "rgb(var(--not-viable-dark-color-rgb))";
-                      default:
-                        return "rgb(var(--fairhold-equity-color-rgb))";
-                    }
-                  })();
-                  const xAdjust = 2;
-                  const yAdjust = 30;
-                  const xPos = typeof props.x === 'number' ? props.x - xAdjust : 0;
-                  const yPos = typeof props.y === 'number' ? props.y - yAdjust : 0;
-                  const value = typeof props.value === 'number' ? props.value : parseFloat(props.value as string);
-                  const formattedValue = formatValue(value);
-
-                  return (
-                    <foreignObject x={xPos} y={yPos} width={100} height={30}>
-                      <div
-                        style={{
-                          position: "absolute",
-                          left: 0,
-                          top: 0,
-                          color: labelColor,
-                          backgroundColor: "rgb(var(--background-end-rgb))",
-                          fontSize: "18px",
-                          fontWeight: 600,
-                          whiteSpace: "nowrap",
-                          padding: "2px 6px",
-                          zIndex: 10,
-                        }}
-                      >
-                        {formattedValue}
-                      </div>
-                    </foreignObject>
-                  );
-                }}
+                content={(props) => (
+                  <TopLabelListContent {...props} />
+                )}
               />
             </Bar>
              

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -8,8 +8,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { formatValue } from "@/app/lib/format";
-import { CustomLabelListContentProps } from "./types";
+import { BarLabelListTopLeft, CustomLabelListContentProps, CustomTick, getLabel } from "./shared"
 
 const chartConfig = {
   freehold: {
@@ -63,52 +62,7 @@ const CenterLabelListContent: React.FC<CustomLabelListContentProps> = ({
         </div>
     </foreignObject>
   );
-}
-
-const TopLabelListContent: React.FC<CustomLabelListContentProps> = ({
-  x,
-  y,
-  index,
-  value  
-}) => {
-    if (!x || !y || !value) return null;
-                  
-  const labelColor = (() => {
-    switch (index) {
-      case 0:
-        return "rgb(var(--not-viable-dark-color-rgb))";
-      default:
-        return "rgb(var(--fairhold-equity-color-rgb))";
-    }
-  })();
-  const xAdjust = 2;
-  const yAdjust = 30;
-  const xPos = typeof x === 'number' ? x - xAdjust : 0;
-  const yPos = typeof y === 'number' ? y - yAdjust : 0;
-  value = typeof value === 'number' ? value : parseFloat(value as string);
-  const formattedValue = formatValue(value);
-
-  return (
-    <foreignObject x={xPos} y={yPos} width={100} height={30}>
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          color: labelColor,
-          backgroundColor: "rgb(var(--background-end-rgb))",
-          fontSize: "18px",
-          fontWeight: 600,
-          whiteSpace: "nowrap",
-          padding: "2px 6px",
-          zIndex: 10,
-        }}
-      >
-        {formattedValue}
-      </div>
-    </foreignObject>
-  );
-}
+};
 
 type DataInput = {
   category: string;
@@ -124,54 +78,6 @@ interface StackedBarChartProps { // TODO: refactor so there is only one exported
   maxY: number;
 }
 
-interface CustomTickProps {
-  x: number; 
-  y: number; 
-  payload: { value: string } 
-}
-
-const CustomTick: React.FC<CustomTickProps> = ({ x, y, payload }) => {
-    const label = (() => {
-      switch (payload.value) {
-        case "freehold":
-          return "Freehold";
-        case "fairhold: land purchase":
-          return "Fairhold /\nLand Purchase";
-        case "fairhold: land rent":
-          return "Fairhold /\nLand Rent";
-        default:
-          return payload.value;
-      }
-    })();
-    const labelColor = (() => {
-      switch (payload.value) {
-        case "freehold":
-          return "rgb(var(--not-viable-dark-color-rgb))";
-        default:
-          return "rgb(var(--fairhold-equity-color-rgb))";
-      }
-    })();
-
-    return (
-      <g transform={`translate(${x},${y})`}>
-        {label.split('\n').map((line: string, i: number) => (
-          <text
-            key={i}
-            x={0}
-            y={i * 20}
-            dy={10}
-            textAnchor="middle"
-            style={{ fill: labelColor }}
-            fontSize="12px"
-            fontWeight={600}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    );
-  }
-
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
   newBuildPrice,
@@ -179,22 +85,25 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
 }) => {
   const chartData = [
     {
-      tenure: "freehold",
+      tenure: "Freehold",
       total: data[0].marketPurchase + data[1].marketPurchase,
       label: "Not viable",    
       fill: "rgb(var(--not-viable-light-color-rgb))",
+      color: "rgb(var(--not-viable-dark-color-rgb))",
     },
     {
-      tenure: "fairhold: land purchase",
+      tenure: "Fairhold - Land Purchase",
       total: data[2].fairholdLandPurchase,
       label: "House",
       fill: "rgb(var(--fairhold-interest-color-rgb))",
+      color: "rgb(var(--fairhold-equity-color-rgb))",
     },
     {
-      tenure: "fairhold: land rent",
+      tenure: "Fairhold - Land Rent",
       total: data[2].fairholdLandRent,
       label: "House",
       fill: "rgb(var(--fairhold-interest-color-rgb))",
+      color: "rgb(var(--fairhold-equity-color-rgb))",
     },
   ];
 
@@ -211,8 +120,17 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               interval={0} 
               height={60}  
               tick={(props) => (
-                  <CustomTick {...props} />
-                )}
+                <CustomTick
+                  {...props}
+                  getLabel={getLabel}
+                  getColor={(value) =>
+                    value === "Freehold"
+                      ? "rgb(var(--not-viable-dark-color-rgb))"
+                      : "rgb(var(--fairhold-equity-color-rgb))"
+                  }
+                  index={props.index}
+                />
+              )}
             >
             </XAxis>
 
@@ -260,7 +178,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="total"
                 position="top"
                 content={(props) => (
-                  <TopLabelListContent {...props} />
+                  <BarLabelListTopLeft {...props} color={props.index !== undefined ? chartData[props.index].color : "#666"}/>
                 )}
               />
             </Bar>

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -9,8 +9,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { formatValue } from "@/app/lib/format";
-import { CustomLabelListContentProps } from "./types";
+import { BarLabelListTopLeft, CustomTick, getLabel, getColor } from "./shared";
 
 type DataInput = {
   category: string;
@@ -35,82 +34,6 @@ type ChartData = {
   monthly: number;
   fill: string;
 }
-
-interface CustomTickProps {
-  x: number; 
-  y: number; 
-  payload: { value: string }; 
-  color: string
-}
-
-const CustomTick: React.FC<CustomTickProps> = ({ x, y, payload, color }) => {
-  const label = (() => {
-    switch (payload.value) {
-      case "Freehold":
-        return "Freehold";
-      case "Private Rent":
-        return "Private\nrent";
-      case "Fairhold - Land Purchase":
-        return "Fairhold \n/LP";
-      case "Fairhold - Land Rent":
-        return "Fairhold \n/LR";
-      case "Social Rent":
-        return "Social\nRent";
-      default:
-        return payload.value;
-    }
-  })();
-  return (
-    <g transform={`translate(${x},${y})`}>
-      {label.split('\n').map((line: string, i: number) => (
-        <text
-          key={i}
-          x={0}
-          y={i * 20}
-          dy={10}
-          textAnchor="middle"
-          style={{ fill: color }}
-          fontSize="12px"
-          fontWeight={600}
-        >
-          {line}
-        </text>
-      ))}
-    </g>
-  );
-  }
-
-const CustomLabelListContent: React.FC<CustomLabelListContentProps> = ({
-  x,
-  y,
-  value,
-  color
-}) => {
-  const xAdjust = 2;
-  const yAdjust = 30;
-  const xPos = typeof x === "number" ? x - xAdjust : Number(x) - xAdjust;
-  const yPos = typeof y === "number" ? y - yAdjust : Number(y) - yAdjust;
-
-  const numValue = typeof value === "number" ? value : Number(value);
-  const formattedValue = formatValue(numValue);
-
-  return (
-    <foreignObject x={xPos} y={yPos} width={100} height={30}>
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          color: color,
-          fontSize: "18px",
-          fontWeight: 600,
-          whiteSpace: "nowrap",
-        }}
-      >
-        {formattedValue}
-      </div>
-    </foreignObject>
-  )};
 
 const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ 
   data, 
@@ -155,7 +78,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
       fill: "rgb(var(--social-rent-land-color-rgb))",
     },
   ];
-
+  
   return (
     <Card className="h-full w-full">
       <CardContent className="h-full w-full p-0 md:p-4">
@@ -169,8 +92,12 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
               interval={0} 
               height={60} 
               tick={(props) => (
-                <CustomTick {...props}
-                color={props.index >= 0 ? chartData[props.index].fill : '#666'} />
+                <CustomTick 
+                  {...props} 
+                  getLabel={getLabel}
+                  getColor={getColor}
+                  index={props.index}
+                  />
                 )}
               >
             </XAxis>
@@ -187,7 +114,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="monthly"
                 position="top"
                 content={(props) => (
-                  <CustomLabelListContent
+                  <BarLabelListTopLeft
                     {...props}
                     color={props.index !== undefined ? chartData[props.index].fill : "#666"}
                   />

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -9,7 +9,7 @@ import {
 } from "../ui/StyledChartContainer";
 import { formatValue } from "@/app/lib/format";
 import { MaintenanceLevel } from "@/app/models/constants";
-import { CustomLabelListContentProps } from "./types";
+import { CustomLabelListContentProps } from "./shared";
 
 type CustomTooltipProps = TooltipProps<number, string> & {
   payload?: Array<{

--- a/app/components/graphs/shared.tsx
+++ b/app/components/graphs/shared.tsx
@@ -1,0 +1,113 @@
+import { formatValue } from "@/app/lib/format";
+
+export interface CustomLabelListContentProps {
+    x?: number | string | undefined;
+    y?: number | string | undefined;
+    value?: number | string;
+    index?: number;
+    color?: string | undefined;
+    width?: string | number | undefined;
+    height?: string | number | undefined;
+}
+
+export const BarLabelListTopLeft: React.FC<CustomLabelListContentProps> = ({ x, y, value, color }) => {
+  if (x === undefined || y === undefined || value === undefined) return null;
+  const xAdjust = 2;
+  const yAdjust = 30;
+  const xPos = typeof x === "number" ? x - xAdjust : Number(x) - xAdjust;
+  const yPos = typeof y === "number" ? y - yAdjust : Number(y) - yAdjust;
+  const numValue = typeof value === "number" ? value : parseFloat(value as string);
+  const formattedValue = formatValue(numValue);
+
+  return (
+    <foreignObject x={xPos} y={yPos} width={100} height={30}>
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          color,
+          fontSize: "18px",
+          fontWeight: 600,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {formattedValue}
+      </div>
+    </foreignObject>
+  );
+};
+
+export interface CustomTickProps {
+  x: number;
+  y: number;
+  payload: { value: string };
+  getLabel: (value: string) => string;
+  getColor: (value: string, index?: number) => string;
+  index?: number;
+}
+
+export const CustomTick: React.FC<CustomTickProps> = ({
+  x,
+  y,
+  payload,
+  getLabel,
+  getColor,
+  index,
+}) => {
+  const label = getLabel(payload.value);
+  const color = getColor(payload.value, index);
+
+  return (
+    <g transform={`translate(${x},${y})`}>
+      {label.split('\n').map((line: string, i: number) => (
+        <text
+          key={i}
+          x={0}
+          y={i * 20}
+          dy={10}
+          textAnchor="middle"
+          style={{ fill: color }}
+          fontSize="12px"
+          fontWeight={600}
+        >
+          {line}
+        </text>
+      ))}
+    </g>
+  );
+};
+
+export const getLabel = (value: string) => {
+    switch (value) {
+      case "Freehold":
+        return "Freehold";
+      case "Private Rent":
+        return "Private Rent";
+      case "Fairhold - Land Purchase":
+        return "Fairhold /\nLand Purchase";
+      case "Fairhold - Land Rent":
+        return "Fairhold /\nLand Rent";
+      case "Social Rent":
+        return "Social Rent";
+      default:
+        return value;
+    }
+  };
+
+export const getColor = (value: string) => {
+    switch (value) {
+      case "Freehold":
+        return "rgb(var(--freehold-equity-color-rgb))";
+      case "Private Rent":
+        return "rgb(var(--private-rent-land-color-rgb))";
+      case "Fairhold - Land Purchase":
+        return "rgb(var(--fairhold-equity-color-rgb))";
+      case "Fairhold - Land Rent":
+        return "rgb(var(--fairhold-interest-color-rgb))";
+      case "Social Rent":
+        return "rgb(var(--social-rent-land-color-rgb))";
+      default:
+        return "rgb(var(--fairhold-equity-color-rgb))";
+    }
+  };

--- a/app/components/graphs/types.tsx
+++ b/app/components/graphs/types.tsx
@@ -1,9 +1,0 @@
-export interface CustomLabelListContentProps {
-    x?: number | string | undefined;
-    y?: number | string | undefined;
-    value?: number | string;
-    index?: number;
-    color?: string | undefined;
-    width?: string | number | undefined;
-    height?: string | number | undefined;
-}

--- a/app/components/graphs/types.tsx
+++ b/app/components/graphs/types.tsx
@@ -4,4 +4,6 @@ export interface CustomLabelListContentProps {
     value?: number | string;
     index?: number;
     color?: string | undefined;
+    width?: string | number | undefined;
+    height?: string | number | undefined;
 }


### PR DESCRIPTION
My `CustomLabelList` refactor from before (#510) messed up the labels in the 'not viable' view, which I only just noticed today. 

This PR fixes that label, refactors another set of complex inline props that I neglected, and removes the unnecessary tooltip from the 'not viable' view (not in designs!). 

The custom tooltips could do with yet another refactor given repetition but hoping to fix-forward. 

Before fix:
![Screenshot 2025-06-11 152725](https://github.com/user-attachments/assets/bb91b2f7-0d67-47a1-aec1-f4f7430e8bd8)

After fix:
![Screenshot 2025-06-11 152743](https://github.com/user-attachments/assets/51a4f998-8099-4806-aeac-2f56d3011308)
