### PR TITLE
refactor: use context for surveys

### DIFF
--- a/app/survey/components/graphs/AffordFairhold.tsx
+++ b/app/survey/components/graphs/AffordFairhold.tsx
@@ -1,9 +1,10 @@
 import React from "react"
-import { BarOrPieResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
+export const AffordFairhold = () => {
+    const affordFairhold = useSurveyContext().barOrPie.affordFairhold;
 
-export const AffordFairhold: React.FC<BarOrPieResults> = ({ affordFairhold }) => {
     return (
         <SurveyGraphCard title="Could you afford a Fairhold home in your area?">
             <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/Age.tsx
+++ b/app/survey/components/graphs/Age.tsx
@@ -1,9 +1,11 @@
 import React from "react"
-import { BarOrPieResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const Age: React.FC<BarOrPieResults> = ({ ageGroup }) => {
+export const Age = () => {
+    const ageGroup = useSurveyContext().barOrPie.ageGroup;
+    
     return (
         <SurveyGraphCard title="How old are you?">
             <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/AnyMeansTenureChoice.tsx
+++ b/app/survey/components/graphs/AnyMeansTenureChoice.tsx
@@ -1,10 +1,12 @@
 import React from "react"
-import { SankeyResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey";
 import { ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const AnyMeansTenureChoice: React.FC<SankeyResults> = ({ anyMeansTenureChoice }) => {
+export const AnyMeansTenureChoice = () => {
+    const anyMeansTenureChoice = useSurveyContext().sankey.anyMeansTenureChoice;
+    
     return (
         <SurveyGraphCard title="What tenure would you choose?">
             <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/Country.tsx
+++ b/app/survey/components/graphs/Country.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { BarOrPieResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
-  
-  export const Country: React.FC<BarOrPieResults> = ({ uk }) => {
+import { useSurveyContext } from "../../context";
+
+  export const Country = () => {
+    const uk = useSurveyContext().barOrPie.uk;
+    
     return (
       <SurveyGraphCard title="Which country?">
         <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/CurrentMeansTenureChoice.tsx
+++ b/app/survey/components/graphs/CurrentMeansTenureChoice.tsx
@@ -1,10 +1,12 @@
 import React from "react"
-import { SankeyResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey"
 import { ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const CurrentMeansTenureChoice: React.FC<SankeyResults> = ({ currentMeansTenureChoice }) => {
+export const CurrentMeansTenureChoice = () => {
+    const currentMeansTenureChoice = useSurveyContext().sankey.currentMeansTenureChoice;
+    
     return (
         <SurveyGraphCard title="Could you afford a Fairhold home in your area?">
             <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/HousingOutcomes.tsx
+++ b/app/survey/components/graphs/HousingOutcomes.tsx
@@ -1,9 +1,12 @@
 import React from "react"
-import { BarOrPieResults, TickProps } from "@/app/survey/types";
+import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const HousingOutcomes: React.FC<BarOrPieResults> = ({ housingOutcomes }) => {
+export const HousingOutcomes = () => {
+    const housingOutcomes = useSurveyContext().barOrPie.housingOutcomes;
+
     const Tick = (props: TickProps) => {
         const { x, y, payload } = props;
         return (

--- a/app/survey/components/graphs/IdealHouseType.tsx
+++ b/app/survey/components/graphs/IdealHouseType.tsx
@@ -1,10 +1,13 @@
 import React from "react"
-import { SankeyResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey";
 import { ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const IdealHouseType: React.FC<SankeyResults> = ({ idealHouseType }) => {
+
+export const IdealHouseType = () => {
+    const idealHouseType = useSurveyContext().sankey.idealHouseType;
+    
     return (
         <SurveyGraphCard title="What type of home do you want to live in?">
             <ResponsiveContainer>

--- a/app/survey/components/graphs/IdealLiveWith.tsx
+++ b/app/survey/components/graphs/IdealLiveWith.tsx
@@ -1,10 +1,12 @@
 import React from "react"
-import { SankeyResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey"
 import { ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const IdealLiveWith: React.FC<SankeyResults> = ({ idealLiveWith }) => {
+export const IdealLiveWith = () => {
+    const idealLiveWith = useSurveyContext().sankey.idealLiveWith;
+    
     return (
         <SurveyGraphCard title="Who do you want to live with?">
             <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/SupportDevelopment.tsx
+++ b/app/survey/components/graphs/SupportDevelopment.tsx
@@ -1,9 +1,11 @@
 import React from "react"
-import { BarOrPieResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const SupportDevelopment: React.FC<BarOrPieResults> = ({ supportDevelopment }) => {
+export const SupportDevelopment = () => {
+    const supportDevelopment = useSurveyContext().barOrPie.supportDevelopment;
+    
     return (
         <SurveyGraphCard title="Would you support development in general?">
              <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/SupportDevelopmentFactors.tsx
+++ b/app/survey/components/graphs/SupportDevelopmentFactors.tsx
@@ -1,27 +1,30 @@
 import React from "react"
-import { BarOrPieResults, TickProps } from "@/app/survey/types";
+import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "@/app/survey/context";
 
-export const SupportDevelopmentFactors: React.FC<BarOrPieResults> = ({ supportDevelopmentFactors }) => {
-    const Tick = (props: TickProps) => {
-        const { x, y, payload } = props;
-        return (
-          <g transform={`translate(${x},${y})`}>
-            <text 
-              x={-10} 
-              y={0} 
-              dy={4} 
-              textAnchor="end" 
-              fill="#333" 
-              fontSize={10}
-              width={240}
-            >
-              {payload.value}
-            </text>
-          </g>
-        );
-    }
+export const SupportDevelopmentFactors = () => {
+  const supportDevelopmentFactors = useSurveyContext().barOrPie.supportDevelopmentFactors;
+  
+  const Tick = (props: TickProps) => {
+      const { x, y, payload } = props;
+      return (
+        <g transform={`translate(${x},${y})`}>
+          <text 
+            x={-10} 
+            y={0} 
+            dy={4} 
+            textAnchor="end" 
+            fill="#333" 
+            fontSize={10}
+            width={240}
+          >
+            {payload.value}
+          </text>
+        </g>
+      );
+  }
     
     return (
         <SurveyGraphCard title="Which of these factors would make you more likely to support new homes being created near where you live?">

--- a/app/survey/components/graphs/SupportNewFairhold.tsx
+++ b/app/survey/components/graphs/SupportNewFairhold.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import { BarOrPieResults } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-
-export const SupportNewFairhold: React.FC<BarOrPieResults> = ({ supportNewFairhold }) => {
+export const SupportNewFairhold = () => {
+    const supportNewFairhold = useSurveyContext().barOrPie.supportNewFairhold;
+    
     return (
         <SurveyGraphCard title="Would you support the creation of Fairhold homes in the area where you want to live?">
              <ResponsiveContainer width="100%" height="100%">

--- a/app/survey/components/graphs/WhyFairhold.tsx
+++ b/app/survey/components/graphs/WhyFairhold.tsx
@@ -1,50 +1,52 @@
 import React from "react"
-import { BarOrPieResults, TickProps } from "@/app/survey/types";
+import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const WhyFairhold: React.FC<BarOrPieResults> = ({ whyFairhold }) => {
-    const Tick = (props: TickProps) => {
-        const { x, y, payload } = props;
-        return (
-          <g transform={`translate(${x},${y})`}>
-            <text 
-              x={-10} 
-              y={0} 
-              dy={4} 
-              textAnchor="end" 
-              fill="#333" 
-              fontSize={10}
-              width={240}
-            >
-              {payload.value}
-            </text>
-          </g>
-        );
-    }
-    
-    return (
-        <SurveyGraphCard title="Why would you choose Fairhold?">
-            <ResponsiveContainer>
-            <BarChart
-                data={whyFairhold}
-                barSize={20}
-                layout="vertical"
-            >
-                <XAxis 
-                    type="number"
-                    hide={true}
-                    /> 
-                <YAxis 
-                    type="category"    
-                    dataKey="answer" 
-                    width={350} 
-                    fontSize={10}
-                    interval={0}
-                    tick={Tick}/> 
-                <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
-            </BarChart>
-            </ResponsiveContainer>
-        </SurveyGraphCard>
-    )
+export const WhyFairhold = () => {
+  const whyFairhold = useSurveyContext().barOrPie.whyFairhold;
+  const Tick = (props: TickProps) => {
+      const { x, y, payload } = props;
+      return (
+        <g transform={`translate(${x},${y})`}>
+          <text 
+            x={-10} 
+            y={0} 
+            dy={4} 
+            textAnchor="end" 
+            fill="#333" 
+            fontSize={10}
+            width={240}
+          >
+            {payload.value}
+          </text>
+        </g>
+      );
+  }
+  
+  return (
+      <SurveyGraphCard title="Why would you choose Fairhold?">
+          <ResponsiveContainer>
+          <BarChart
+              data={whyFairhold}
+              barSize={20}
+              layout="vertical"
+          >
+              <XAxis 
+                  type="number"
+                  hide={true}
+                  /> 
+              <YAxis 
+                  type="category"    
+                  dataKey="answer" 
+                  width={350} 
+                  fontSize={10}
+                  interval={0}
+                  tick={Tick}/> 
+              <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+          </BarChart>
+          </ResponsiveContainer>
+      </SurveyGraphCard>
+  )
 }

--- a/app/survey/components/graphs/WhyNotFairhold.tsx
+++ b/app/survey/components/graphs/WhyNotFairhold.tsx
@@ -1,50 +1,53 @@
 import React from "react"
-import { BarOrPieResults, TickProps } from "@/app/survey/types";
+import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
+import { useSurveyContext } from "../../context";
 
-export const WhyNotFairhold: React.FC<BarOrPieResults> = ({ whyNotFairhold }) => {
-    const Tick = (props: TickProps) => {
-        const { x, y, payload } = props;
-        return (
-          <g transform={`translate(${x},${y})`}>
-            <text 
-              x={-10} 
-              y={0} 
-              dy={4} 
-              textAnchor="end" 
-              fill="#333" 
-              fontSize={10}
-              width={240}
-            >
-              {payload.value}
-            </text>
-          </g>
-        );
-    }
-    
-    return (
-        <SurveyGraphCard title="Why wouldn't you choose Fairhold?">
-            <ResponsiveContainer>
-            <BarChart
-                data={whyNotFairhold}
-                barSize={20}
-                layout="vertical"
-            >
-                <XAxis 
-                    type="number" 
-                    hide={true}
-                    /> 
-                <YAxis 
-                    type="category"    
-                    dataKey="answer" 
-                    width={350} 
-                    fontSize={10}
-                    interval={0}
-                    tick={Tick}/> 
-                <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
-            </BarChart>
-            </ResponsiveContainer>
-        </SurveyGraphCard>
-    )
+export const WhyNotFairhold = () => {
+  const whyNotFairhold = useSurveyContext().barOrPie.whyNotFairhold;
+
+  const Tick = (props: TickProps) => {
+      const { x, y, payload } = props;
+      return (
+        <g transform={`translate(${x},${y})`}>
+          <text 
+            x={-10} 
+            y={0} 
+            dy={4} 
+            textAnchor="end" 
+            fill="#333" 
+            fontSize={10}
+            width={240}
+          >
+            {payload.value}
+          </text>
+        </g>
+      );
+  }
+  
+  return (
+      <SurveyGraphCard title="Why wouldn't you choose Fairhold?">
+          <ResponsiveContainer>
+          <BarChart
+              data={whyNotFairhold}
+              barSize={20}
+              layout="vertical"
+          >
+              <XAxis 
+                  type="number" 
+                  hide={true}
+                  /> 
+              <YAxis 
+                  type="category"    
+                  dataKey="answer" 
+                  width={350} 
+                  fontSize={10}
+                  interval={0}
+                  tick={Tick}/> 
+              <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+          </BarChart>
+          </ResponsiveContainer>
+      </SurveyGraphCard>
+  )
 }

--- a/app/survey/context.tsx
+++ b/app/survey/context.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+import { SurveyResults } from './types';
+
+export const SurveyContext = createContext<SurveyResults | null>(null);
+
+export function useSurveyContext(): SurveyResults {
+    const surveyContext = useContext(SurveyContext);
+    if (surveyContext === null) { 
+        throw new Error("useSurveyContext must be used within a SurveyContext.Provider");
+    }
+    return surveyContext;
+}

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -18,6 +18,7 @@ import { SupportDevelopmentFactors } from './components/graphs/SupportDevelopmen
 import { SupportNewFairhold } from './components/graphs/SupportNewFairhold';
 import { WhyFairhold } from './components/graphs/WhyFairhold';
 import { WhyNotFairhold } from './components/graphs/WhyNotFairhold';
+import { SurveyContext } from './context';
 // list records https://api.airtable.com/v0/{baseId}/{tableIdOrName}
 // get record https://api.airtable.com/v0/{baseId}/{tableIdOrName}/{recordId}
 
@@ -57,12 +58,10 @@ export default function SurveyPage() {
   if (loading) return <div>Loading survey data...</div>;
   if (error) return <div>Error: {error}</div>;
   if (!surveyResults) return <div>No survey data available.</div>;
-  
-  const sankeyResults = surveyResults.sankey
-  const barOrPieResults = surveyResults.barOrPie
 
   return (
     <ErrorBoundary>
+      <SurveyContext.Provider value={surveyResults}>
         <main className={`${inter.className} p-4 min-h-screen bg-[rgb(var(--background-end-rgb))]`}>
           <div className="flex flex-col m-4">
             <h1 className="h1-style text-2xl md:text-4xl">Fairhold survey results</h1>
@@ -75,8 +74,8 @@ export default function SurveyPage() {
               <div className="flex flex-col py-4">
                 <h3 className="text-xl font-medium">Who has responded?</h3>
                 <div className="flex flex-col md:flex-row">
-                  <Country {...barOrPieResults} />
-                  <Age {...barOrPieResults} />
+                  <Country />
+                  <Age />
                   {/* <Postcode {...results} /> */}
                 </div>
               </div>
@@ -84,36 +83,37 @@ export default function SurveyPage() {
               <div className="flex flex-col">
                 <h3 className="text-xl font-medium">Housing preferences</h3>
                 <div className="flex flex-col md:flex-row">
-                  <IdealHouseType {...sankeyResults} />
-                  <IdealLiveWith {...sankeyResults} />
+                  <IdealHouseType />
+                  <IdealLiveWith />
                 </div>
                 <div className="flex flex-col md:flex-row">
-                  <HousingOutcomes {...barOrPieResults} />
-                  <AffordFairhold {...barOrPieResults} />
+                  <HousingOutcomes />
+                  <AffordFairhold />
                 </div>
                 <div className="flex flex-col md:flex-row">
-                  <WhyFairhold {...barOrPieResults} />
-                  <WhyNotFairhold {...barOrPieResults}/>
+                  <WhyFairhold />
+                  <WhyNotFairhold />
                 </div>
                 <div className="flex flex-col md:flex-row">
-                  <CurrentMeansTenureChoice {...sankeyResults} />
-                  <AnyMeansTenureChoice {...sankeyResults} />
+                  <CurrentMeansTenureChoice />
+                  <AnyMeansTenureChoice />
                 </div>
               </div>
 
               <div className="flex flex-col">
                 <h3 className="text-xl font-medium">Attitudes towards development</h3>
                 <div className="flex flex-col md:flex-row">
-                  <SupportDevelopment {...barOrPieResults} />
-                  <SupportNewFairhold {...barOrPieResults} />
+                  <SupportDevelopment />
+                  <SupportNewFairhold />
                 </div>
-                <SupportDevelopmentFactors {...barOrPieResults} />
+                <SupportDevelopmentFactors />
               </div>
           </div>
           )}
             </div>
           </div>
         </main>
+      </SurveyContext.Provider>
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
Instead prop-drilling and passing survey results to all child components as props, this refactor uses React context to share directly with the components. 

Closes #493