### PR TITLE
refactor: share custom components where possible

### DIFF
--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -9,7 +9,7 @@ import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
 import { useState } from "react";
-import { BarLabelListTopLeft, CustomTick} from "./types"
+import { BarLabelListTopLeft, CustomTick, getLabel, getColor } from "./shared"
 
 const chartConfig = {
   freeholdLand: {
@@ -58,28 +58,6 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       </div>
     );
   };
-
-    const getLabel = (value: string) => {
-    switch (value) {
-      case "Freehold":
-        return "Freehold";
-      case "Fairhold - Land Purchase":
-        return "Fairhold /\nLand Purchase";
-      case "Fairhold - Land Rent":
-        return "Fairhold /\nLand Rent";
-      default:
-        return value;
-    }
-  };
-
-    const getColor = (value: string) => {
-      switch (value) {
-        case "freehold":
-          return "rgb(var(--not-viable-dark-color-rgb))";
-        default:
-          return "rgb(var(--fairhold-equity-color-rgb))";
-      }
-    };
 
   const chartData = [
     {

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -9,8 +9,7 @@ import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
 import { useState } from "react";
-import { formatValue } from "@/app/lib/format";
-import { CustomLabelListContentProps } from "./types";
+import { BarLabelListTopLeft } from "./types"
 
 const chartConfig = {
   freeholdLand: {
@@ -26,34 +25,6 @@ const chartConfig = {
     color: "rgb(var(--fairhold-interest-color-rgb))",
   },
 } satisfies ChartConfig;
-
-const CustomLabelListContent: React.FC<CustomLabelListContentProps> = ({ x, y, value, color }) => {
-  if (x === undefined || y === undefined || value === undefined) return null;
-  const xAdjust = 2;
-  const yAdjust = 30;
-  const xPos = typeof x === "number" ? x - xAdjust : Number(x) - xAdjust;
-  const yPos = typeof y === "number" ? y - yAdjust : Number(y) - yAdjust;
-  const numValue = typeof value === "number" ? value : parseFloat(value as string);
-  const formattedValue = formatValue(numValue);
-
-  return (
-    <foreignObject x={xPos} y={yPos} width={100} height={30}>
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          color,
-          fontSize: "18px",
-          fontWeight: 600,
-          whiteSpace: "nowrap",
-        }}
-      >
-        {formattedValue}
-      </div>
-    </foreignObject>
-  );
-};
 
 type DataInput = {
   category: string;
@@ -219,7 +190,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="freeholdTotal"
                 position="top"
                 content={(props) => (
-                  <CustomLabelListContent {...props} color="rgb(var(--freehold-equity-color-rgb))" />
+                  <BarLabelListTopLeft {...props} color="rgb(var(--freehold-equity-color-rgb))" />
                 )}
               />
             </Bar>
@@ -258,7 +229,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="fairholdTotal"
                 position="top"
                 content={(props) => (
-                  <CustomLabelListContent {...props} color="rgb(var(--fairhold-equity-color-rgb))" />
+                  <BarLabelListTopLeft {...props} color="rgb(var(--fairhold-equity-color-rgb))" />
                 )}
               />
             </Bar>

--- a/app/components/graphs/HowMuchFHCostBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostBarChart.tsx
@@ -9,7 +9,7 @@ import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
 import { useState } from "react";
-import { BarLabelListTopLeft } from "./types"
+import { BarLabelListTopLeft, CustomTick} from "./types"
 
 const chartConfig = {
   freeholdLand: {
@@ -39,52 +39,6 @@ interface StackedBarChartProps {
   maxY: number;
 }
 
-interface CustomTickProps {
-  x: number;
-  y: number;
-  payload: { value: string };
-}
-const CustomTick: React.FC<CustomTickProps> = ({ x, y, payload }) => {
-  const label = (() => {
-    switch (payload.value) {
-      case "freehold":
-        return "Freehold";
-      case "fairhold: land purchase":
-        return "Fairhold /\nLand Purchase";
-      case "fairhold: land rent":
-        return "Fairhold /\nLand Rent";
-      default:
-        return payload.value;
-    }
-  })();
-  const labelColor = (() => {
-    switch (payload.value) {
-      case "freehold":
-        return "rgb(var(--freehold-equity-color-rgb))";
-      default:
-        return "rgb(var(--fairhold-equity-color-rgb))";
-    }
-  })();
-
-  return (
-    <g transform={`translate(${x},${y})`}>
-      {label.split('\n').map((line: string, i: number) => (
-        <text
-          key={i}
-          x={0}
-          y={i * 20}
-          dy={10}
-          textAnchor="middle"
-          style={{ fill: labelColor }}
-          fontSize="12px"
-          fontWeight={600}
-        >
-          {line}
-        </text>
-      ))}
-    </g>
-  );
-}
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
   maxY,
@@ -105,9 +59,31 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
     );
   };
 
+    const getLabel = (value: string) => {
+    switch (value) {
+      case "Freehold":
+        return "Freehold";
+      case "Fairhold - Land Purchase":
+        return "Fairhold /\nLand Purchase";
+      case "Fairhold - Land Rent":
+        return "Fairhold /\nLand Rent";
+      default:
+        return value;
+    }
+  };
+
+    const getColor = (value: string) => {
+      switch (value) {
+        case "freehold":
+          return "rgb(var(--not-viable-dark-color-rgb))";
+        default:
+          return "rgb(var(--fairhold-equity-color-rgb))";
+      }
+    };
+
   const chartData = [
     {
-      tenure: "freehold",
+      tenure: "Freehold",
       freeholdLand: data[0].marketPurchase,
       freeholdLandLabel: "Land",
       freeholdHouse: data[1].marketPurchase,
@@ -115,7 +91,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       freeholdTotal: data[0].marketPurchase + data[1].marketPurchase,
     },
     {
-      tenure: "fairhold: land purchase",
+      tenure: "Fairhold - Land Purchase",
       fairholdLand: data[0].fairholdLandPurchase,
       fairholdLandLabel: "Land",
       fairholdHouse: data[2].fairholdLandPurchase,
@@ -123,7 +99,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       fairholdTotal: data[0].fairholdLandPurchase + data[2].fairholdLandPurchase,
     },
     {
-      tenure: "fairhold: land rent",
+      tenure: "Fairhold - Land Rent",
       fairholdHouse: data[2].fairholdLandRent,
       fairholdHouseLabel: "House",
       fairholdTotal: data[2].fairholdLandRent,
@@ -142,8 +118,13 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               tickLine={false}
               interval={0} 
               height={60}  
-                            tick={(props) => (
-                <CustomTick {...props} />
+              tick={(props) => (
+                <CustomTick 
+                  {...props} 
+                  getLabel={getLabel}
+                  getColor={getColor}
+                  index={props.index}
+                  />
               )}
             >
             </XAxis>

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -8,8 +8,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { BarLabelListTopLeft } from "./types"
-import { CustomLabelListContentProps } from "./types";
+import { BarLabelListTopLeft, CustomLabelListContentProps, CustomTick } from "./types"
 
 const chartConfig = {
   freehold: {
@@ -79,54 +78,6 @@ interface StackedBarChartProps { // TODO: refactor so there is only one exported
   maxY: number;
 }
 
-interface CustomTickProps {
-  x: number; 
-  y: number; 
-  payload: { value: string } 
-}
-
-const CustomTick: React.FC<CustomTickProps> = ({ x, y, payload }) => {
-    const label = (() => {
-      switch (payload.value) {
-        case "freehold":
-          return "Freehold";
-        case "fairhold: land purchase":
-          return "Fairhold /\nLand Purchase";
-        case "fairhold: land rent":
-          return "Fairhold /\nLand Rent";
-        default:
-          return payload.value;
-      }
-    })();
-    const labelColor = (() => {
-      switch (payload.value) {
-        case "freehold":
-          return "rgb(var(--not-viable-dark-color-rgb))";
-        default:
-          return "rgb(var(--fairhold-equity-color-rgb))";
-      }
-    })();
-
-    return (
-      <g transform={`translate(${x},${y})`}>
-        {label.split('\n').map((line: string, i: number) => (
-          <text
-            key={i}
-            x={0}
-            y={i * 20}
-            dy={10}
-            textAnchor="middle"
-            style={{ fill: labelColor }}
-            fontSize="12px"
-            fontWeight={600}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    );
-  }
-
 const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
   data,
   newBuildPrice,
@@ -156,6 +107,28 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
     },
   ];
 
+  const getLabel = (value: string) => {
+    switch (value) {
+      case "freehold":
+        return "Freehold";
+      case "fairhold: land purchase":
+        return "Fairhold /\nLand Purchase";
+      case "fairhold: land rent":
+        return "Fairhold /\nLand Rent";
+      default:
+        return value;
+    }
+  };
+
+  const getColor = (value: string) => {
+    switch (value) {
+      case "freehold":
+        return "rgb(var(--not-viable-dark-color-rgb))";
+      default:
+        return "rgb(var(--fairhold-equity-color-rgb))";
+    }
+  };
+
   return (
     <Card className="h-full w-full">
       <CardContent className="h-full w-full p-0 md:p-4">
@@ -169,8 +142,13 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
               interval={0} 
               height={60}  
               tick={(props) => (
-                  <CustomTick {...props} />
-                )}
+                <CustomTick
+                  {...props}
+                  getLabel={getLabel}
+                  getColor={getColor}
+                  index={props.index}
+                />
+              )}
             >
             </XAxis>
 

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -8,7 +8,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { formatValue } from "@/app/lib/format";
+import { BarLabelListTopLeft } from "./types"
 import { CustomLabelListContentProps } from "./types";
 
 const chartConfig = {
@@ -63,52 +63,7 @@ const CenterLabelListContent: React.FC<CustomLabelListContentProps> = ({
         </div>
     </foreignObject>
   );
-}
-
-const TopLabelListContent: React.FC<CustomLabelListContentProps> = ({
-  x,
-  y,
-  index,
-  value  
-}) => {
-    if (!x || !y || !value) return null;
-                  
-  const labelColor = (() => {
-    switch (index) {
-      case 0:
-        return "rgb(var(--not-viable-dark-color-rgb))";
-      default:
-        return "rgb(var(--fairhold-equity-color-rgb))";
-    }
-  })();
-  const xAdjust = 2;
-  const yAdjust = 30;
-  const xPos = typeof x === 'number' ? x - xAdjust : 0;
-  const yPos = typeof y === 'number' ? y - yAdjust : 0;
-  value = typeof value === 'number' ? value : parseFloat(value as string);
-  const formattedValue = formatValue(value);
-
-  return (
-    <foreignObject x={xPos} y={yPos} width={100} height={30}>
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          color: labelColor,
-          backgroundColor: "rgb(var(--background-end-rgb))",
-          fontSize: "18px",
-          fontWeight: 600,
-          whiteSpace: "nowrap",
-          padding: "2px 6px",
-          zIndex: 10,
-        }}
-      >
-        {formattedValue}
-      </div>
-    </foreignObject>
-  );
-}
+};
 
 type DataInput = {
   category: string;
@@ -183,18 +138,21 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
       total: data[0].marketPurchase + data[1].marketPurchase,
       label: "Not viable",    
       fill: "rgb(var(--not-viable-light-color-rgb))",
+      color: "rgb(var(--not-viable-dark-color-rgb))",
     },
     {
       tenure: "fairhold: land purchase",
       total: data[2].fairholdLandPurchase,
       label: "House",
       fill: "rgb(var(--fairhold-interest-color-rgb))",
+      color: "rgb(var(--fairhold-equity-color-rgb))",
     },
     {
       tenure: "fairhold: land rent",
       total: data[2].fairholdLandRent,
       label: "House",
       fill: "rgb(var(--fairhold-interest-color-rgb))",
+      color: "rgb(var(--fairhold-equity-color-rgb))",
     },
   ];
 
@@ -260,7 +218,7 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="total"
                 position="top"
                 content={(props) => (
-                  <TopLabelListContent {...props} />
+                  <BarLabelListTopLeft {...props} color={props.index !== undefined ? chartData[props.index].color : "#666"}/>
                 )}
               />
             </Bar>

--- a/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
+++ b/app/components/graphs/HowMuchFHCostNotViableBarChart.tsx
@@ -8,7 +8,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { BarLabelListTopLeft, CustomLabelListContentProps, CustomTick } from "./types"
+import { BarLabelListTopLeft, CustomLabelListContentProps, CustomTick, getLabel } from "./shared"
 
 const chartConfig = {
   freehold: {
@@ -85,49 +85,27 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
 }) => {
   const chartData = [
     {
-      tenure: "freehold",
+      tenure: "Freehold",
       total: data[0].marketPurchase + data[1].marketPurchase,
       label: "Not viable",    
       fill: "rgb(var(--not-viable-light-color-rgb))",
       color: "rgb(var(--not-viable-dark-color-rgb))",
     },
     {
-      tenure: "fairhold: land purchase",
+      tenure: "Fairhold - Land Purchase",
       total: data[2].fairholdLandPurchase,
       label: "House",
       fill: "rgb(var(--fairhold-interest-color-rgb))",
       color: "rgb(var(--fairhold-equity-color-rgb))",
     },
     {
-      tenure: "fairhold: land rent",
+      tenure: "Fairhold - Land Rent",
       total: data[2].fairholdLandRent,
       label: "House",
       fill: "rgb(var(--fairhold-interest-color-rgb))",
       color: "rgb(var(--fairhold-equity-color-rgb))",
     },
   ];
-
-  const getLabel = (value: string) => {
-    switch (value) {
-      case "freehold":
-        return "Freehold";
-      case "fairhold: land purchase":
-        return "Fairhold /\nLand Purchase";
-      case "fairhold: land rent":
-        return "Fairhold /\nLand Rent";
-      default:
-        return value;
-    }
-  };
-
-  const getColor = (value: string) => {
-    switch (value) {
-      case "freehold":
-        return "rgb(var(--not-viable-dark-color-rgb))";
-      default:
-        return "rgb(var(--fairhold-equity-color-rgb))";
-    }
-  };
 
   return (
     <Card className="h-full w-full">
@@ -145,7 +123,11 @@ const HowMuchFHCostBarChart: React.FC<StackedBarChartProps> = ({
                 <CustomTick
                   {...props}
                   getLabel={getLabel}
-                  getColor={getColor}
+                  getColor={(value) =>
+                    value === "Freehold"
+                      ? "rgb(var(--not-viable-dark-color-rgb))"
+                      : "rgb(var(--fairhold-equity-color-rgb))"
+                  }
                   index={props.index}
                 />
               )}

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -9,8 +9,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { formatValue } from "@/app/lib/format";
-import { CustomLabelListContentProps } from "./types";
+import { BarLabelListTopLeft } from "./types";
 
 type DataInput = {
   category: string;
@@ -79,38 +78,6 @@ const CustomTick: React.FC<CustomTickProps> = ({ x, y, payload, color }) => {
     </g>
   );
   }
-
-const CustomLabelListContent: React.FC<CustomLabelListContentProps> = ({
-  x,
-  y,
-  value,
-  color
-}) => {
-  const xAdjust = 2;
-  const yAdjust = 30;
-  const xPos = typeof x === "number" ? x - xAdjust : Number(x) - xAdjust;
-  const yPos = typeof y === "number" ? y - yAdjust : Number(y) - yAdjust;
-
-  const numValue = typeof value === "number" ? value : Number(value);
-  const formattedValue = formatValue(numValue);
-
-  return (
-    <foreignObject x={xPos} y={yPos} width={100} height={30}>
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          color: color,
-          fontSize: "18px",
-          fontWeight: 600,
-          whiteSpace: "nowrap",
-        }}
-      >
-        {formattedValue}
-      </div>
-    </foreignObject>
-  )};
 
 const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ 
   data, 
@@ -187,7 +154,7 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
                 dataKey="monthly"
                 position="top"
                 content={(props) => (
-                  <CustomLabelListContent
+                  <BarLabelListTopLeft
                     {...props}
                     color={props.index !== undefined ? chartData[props.index].fill : "#666"}
                   />

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -9,7 +9,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { BarLabelListTopLeft, CustomTick } from "./types";
+import { BarLabelListTopLeft, CustomTick, getLabel, getColor } from "./shared";
 
 type DataInput = {
   category: string;
@@ -79,40 +79,6 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
     },
   ];
   
-  const getLabel = (value: string) => {
-    switch (value) {
-      case "Freehold":
-        return "Freehold";
-      case "Private Rent":
-        return "Private Rent";
-      case "Fairhold - Land Purchase":
-        return "Fairhold /\nLand Purchase";
-      case "Fairhold - Land Rent":
-        return "Fairhold /\nLand Rent";
-      case "Social Rent":
-        return "Social Rent";
-      default:
-        return value;
-    }
-  };
-
-  const getColor = (value: string) => {
-    switch (value) {
-      case "Freehold":
-        return "rgb(var(--not-viable-dark-color-rgb))";
-      case "Private Rent":
-        return "rgb(var(--private-rent-land-color-rgb))";
-      case "Fairhold - Land Purchase":
-        return "rgb(var(--fairhold-equity-color-rgb))";
-      case "Fairhold - Land Rent":
-        return "rgb(var(--fairhold-interest-color-rgb))";
-      case "Social Rent":
-        return "rgb(var(--social-rent-land-color-rgb))";
-      default:
-        return "rgb(var(--fairhold-equity-color-rgb))";
-    }
-  };
-
   return (
     <Card className="h-full w-full">
       <CardContent className="h-full w-full p-0 md:p-4">

--- a/app/components/graphs/HowMuchPerMonthBarChart.tsx
+++ b/app/components/graphs/HowMuchPerMonthBarChart.tsx
@@ -9,7 +9,7 @@ import {
 import {
   StyledChartContainer,
 } from "../ui/StyledChartContainer";
-import { BarLabelListTopLeft } from "./types";
+import { BarLabelListTopLeft, CustomTick } from "./types";
 
 type DataInput = {
   category: string;
@@ -34,50 +34,6 @@ type ChartData = {
   monthly: number;
   fill: string;
 }
-
-interface CustomTickProps {
-  x: number; 
-  y: number; 
-  payload: { value: string }; 
-  color: string
-}
-
-const CustomTick: React.FC<CustomTickProps> = ({ x, y, payload, color }) => {
-  const label = (() => {
-    switch (payload.value) {
-      case "Freehold":
-        return "Freehold";
-      case "Private Rent":
-        return "Private\nrent";
-      case "Fairhold - Land Purchase":
-        return "Fairhold \n/LP";
-      case "Fairhold - Land Rent":
-        return "Fairhold \n/LR";
-      case "Social Rent":
-        return "Social\nRent";
-      default:
-        return payload.value;
-    }
-  })();
-  return (
-    <g transform={`translate(${x},${y})`}>
-      {label.split('\n').map((line: string, i: number) => (
-        <text
-          key={i}
-          x={0}
-          y={i * 20}
-          dy={10}
-          textAnchor="middle"
-          style={{ fill: color }}
-          fontSize="12px"
-          fontWeight={600}
-        >
-          {line}
-        </text>
-      ))}
-    </g>
-  );
-  }
 
 const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({ 
   data, 
@@ -122,6 +78,40 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
       fill: "rgb(var(--social-rent-land-color-rgb))",
     },
   ];
+  
+  const getLabel = (value: string) => {
+    switch (value) {
+      case "Freehold":
+        return "Freehold";
+      case "Private Rent":
+        return "Private Rent";
+      case "Fairhold - Land Purchase":
+        return "Fairhold /\nLand Purchase";
+      case "Fairhold - Land Rent":
+        return "Fairhold /\nLand Rent";
+      case "Social Rent":
+        return "Social Rent";
+      default:
+        return value;
+    }
+  };
+
+  const getColor = (value: string) => {
+    switch (value) {
+      case "Freehold":
+        return "rgb(var(--not-viable-dark-color-rgb))";
+      case "Private Rent":
+        return "rgb(var(--private-rent-land-color-rgb))";
+      case "Fairhold - Land Purchase":
+        return "rgb(var(--fairhold-equity-color-rgb))";
+      case "Fairhold - Land Rent":
+        return "rgb(var(--fairhold-interest-color-rgb))";
+      case "Social Rent":
+        return "rgb(var(--social-rent-land-color-rgb))";
+      default:
+        return "rgb(var(--fairhold-equity-color-rgb))";
+    }
+  };
 
   return (
     <Card className="h-full w-full">
@@ -136,8 +126,12 @@ const HowMuchPerMonthBarChart: React.FC<StackedBarChartProps> = ({
               interval={0} 
               height={60} 
               tick={(props) => (
-                <CustomTick {...props}
-                color={props.index >= 0 ? chartData[props.index].fill : '#666'} />
+                <CustomTick 
+                  {...props} 
+                  getLabel={getLabel}
+                  getColor={getColor}
+                  index={props.index}
+                  />
                 )}
               >
             </XAxis>

--- a/app/components/graphs/ResaleValueLineChart.tsx
+++ b/app/components/graphs/ResaleValueLineChart.tsx
@@ -9,7 +9,7 @@ import {
 } from "../ui/StyledChartContainer";
 import { formatValue } from "@/app/lib/format";
 import { MaintenanceLevel } from "@/app/models/constants";
-import { CustomLabelListContentProps } from "./types";
+import { CustomLabelListContentProps } from "./shared";
 
 type CustomTooltipProps = TooltipProps<number, string> & {
   payload?: Array<{

--- a/app/components/graphs/shared.tsx
+++ b/app/components/graphs/shared.tsx
@@ -77,3 +77,37 @@ export const CustomTick: React.FC<CustomTickProps> = ({
     </g>
   );
 };
+
+export const getLabel = (value: string) => {
+    switch (value) {
+      case "Freehold":
+        return "Freehold";
+      case "Private Rent":
+        return "Private Rent";
+      case "Fairhold - Land Purchase":
+        return "Fairhold /\nLand Purchase";
+      case "Fairhold - Land Rent":
+        return "Fairhold /\nLand Rent";
+      case "Social Rent":
+        return "Social Rent";
+      default:
+        return value;
+    }
+  };
+
+export const getColor = (value: string) => {
+    switch (value) {
+      case "Freehold":
+        return "rgb(var(--freehold-equity-color-rgb))";
+      case "Private Rent":
+        return "rgb(var(--private-rent-land-color-rgb))";
+      case "Fairhold - Land Purchase":
+        return "rgb(var(--fairhold-equity-color-rgb))";
+      case "Fairhold - Land Rent":
+        return "rgb(var(--fairhold-interest-color-rgb))";
+      case "Social Rent":
+        return "rgb(var(--social-rent-land-color-rgb))";
+      default:
+        return "rgb(var(--fairhold-equity-color-rgb))";
+    }
+  };

--- a/app/components/graphs/types.tsx
+++ b/app/components/graphs/types.tsx
@@ -37,3 +37,43 @@ export const BarLabelListTopLeft: React.FC<CustomLabelListContentProps> = ({ x, 
     </foreignObject>
   );
 };
+
+export interface CustomTickProps {
+  x: number;
+  y: number;
+  payload: { value: string };
+  getLabel: (value: string) => string;
+  getColor: (value: string, index?: number) => string;
+  index?: number;
+}
+
+export const CustomTick: React.FC<CustomTickProps> = ({
+  x,
+  y,
+  payload,
+  getLabel,
+  getColor,
+  index,
+}) => {
+  const label = getLabel(payload.value);
+  const color = getColor(payload.value, index);
+
+  return (
+    <g transform={`translate(${x},${y})`}>
+      {label.split('\n').map((line: string, i: number) => (
+        <text
+          key={i}
+          x={0}
+          y={i * 20}
+          dy={10}
+          textAnchor="middle"
+          style={{ fill: color }}
+          fontSize="12px"
+          fontWeight={600}
+        >
+          {line}
+        </text>
+      ))}
+    </g>
+  );
+};

--- a/app/components/graphs/types.tsx
+++ b/app/components/graphs/types.tsx
@@ -1,3 +1,5 @@
+import { formatValue } from "@/app/lib/format";
+
 export interface CustomLabelListContentProps {
     x?: number | string | undefined;
     y?: number | string | undefined;
@@ -7,3 +9,31 @@ export interface CustomLabelListContentProps {
     width?: string | number | undefined;
     height?: string | number | undefined;
 }
+
+export const BarLabelListTopLeft: React.FC<CustomLabelListContentProps> = ({ x, y, value, color }) => {
+  if (x === undefined || y === undefined || value === undefined) return null;
+  const xAdjust = 2;
+  const yAdjust = 30;
+  const xPos = typeof x === "number" ? x - xAdjust : Number(x) - xAdjust;
+  const yPos = typeof y === "number" ? y - yAdjust : Number(y) - yAdjust;
+  const numValue = typeof value === "number" ? value : parseFloat(value as string);
+  const formattedValue = formatValue(numValue);
+
+  return (
+    <foreignObject x={xPos} y={yPos} width={100} height={30}>
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          color,
+          fontSize: "18px",
+          fontWeight: 600,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {formattedValue}
+      </div>
+    </foreignObject>
+  );
+};


### PR DESCRIPTION
# What does this PR do?
- Renames `types.ts` to `shared.ts` (not strictly types anymore, nor utils)
- Creates a shared `CustomTick` component for coloured tenure labels and `BarLabelListTopLeft` for labels coloured by tenure that sit on the top left of bars
    - We do use custom LabelList components elsewhere, but their styling / formatting is different and it didn't make sense to combine

# Why? 
- Continuing the refactor started in #510 but I think my brain needed to do it incrementally! 

Closes #526