### PR TITLE
style: update doughnut headers, colours and order

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -31,8 +31,18 @@
   --error-text-rgb: 181 31 20;
   --not-viable-light-color-rgb: 251 164 164;
   --not-viable-dark-color-rgb: 255 0 0;
+
+  --survey-black: 0, 0, 0;
+  --survey-grey-dark: 0, 0, 0, 0.68;
+  --survey-grey-mid: 0, 0, 0, 0.54;
+  --survey-grey-light: 0, 0, 0, 0.15;
+  --survey-grey-lightest: 0, 0, 0, 0.05;
+  --survey-orange: 255, 164, 53;
+  --survey-pink: 255, 170, 179;
   
-  --survey-placeholder: 34 139 230;
+  --survey-blue: 34 138 230;
+  --survey-blue-light: 141 193 239;
+  
 }
 
 @layer utilities {

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -8,7 +8,7 @@ type Props = React.PropsWithChildren<{
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
     <div className="justify-center w-full bg-white m-4 p-4">
-        <h3 className={`text-xl md:text-lg sm:text-md font-normal text-black`}>{title}</h3>
+        <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`}>{title}</h3>
         {subtitle && <p className={`text-md md:text-lg text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
       {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
     </div>

--- a/app/survey/components/graphs/AffordFairhold.tsx
+++ b/app/survey/components/graphs/AffordFairhold.tsx
@@ -1,9 +1,21 @@
 import React from "react"
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "../../context";
+import { AFFORD_FAIRHOLD_ORDER } from "../../constants";
+
 export const AffordFairhold = () => {
-    const affordFairhold = useSurveyContext().barOrPie.affordFairhold;
+    let { affordFairhold } = useSurveyContext().barOrPie;
+
+    affordFairhold = affordFairhold.slice().sort(
+        (a, b) =>
+            AFFORD_FAIRHOLD_ORDER.indexOf(a.answer as string) -
+            AFFORD_FAIRHOLD_ORDER.indexOf(b.answer as string)
+        );
+
+    const COLORS = [
+      "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--social-rent-land-color-rgb))" 
+    ];
 
     return (
         <SurveyGraphCard title="Could you afford a Fairhold home in your area?">
@@ -14,9 +26,13 @@ export const AffordFairhold = () => {
                         dataKey="value" 
                         nameKey="answer" 
                         fill="rgb(var(--survey-placeholder))" 
-                        innerRadius="40%"
+                        innerRadius="60%"
                         outerRadius="80%"
-                        />
+                        >
+                        {affordFairhold.map((entry, index) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                    </Pie>
                     <Legend align="center" verticalAlign="bottom" />
                 </PieChart>
             </ResponsiveContainer>

--- a/app/survey/components/graphs/AffordFairhold.tsx
+++ b/app/survey/components/graphs/AffordFairhold.tsx
@@ -18,7 +18,7 @@ export const AffordFairhold = () => {
     ];
 
     return (
-        <SurveyGraphCard title="Could you afford a Fairhold home in your area?">
+        <SurveyGraphCard title="Could you afford to buy a Fairhold home in your area?">
             <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                     <Pie 

--- a/app/survey/components/graphs/Age.tsx
+++ b/app/survey/components/graphs/Age.tsx
@@ -1,11 +1,15 @@
 import React from "react"
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "../../context";
 
 export const Age = () => {
-    const ageGroup = useSurveyContext().barOrPie.ageGroup;
+    const { ageGroup } = useSurveyContext().barOrPie;
     
+    const COLORS = [
+      "rgb(var(--survey-grey-lightest))", "rgb(var(--survey-grey-light))", "rgb(var(--survey-grey-mid))", "rgb(var(--survey-grey-dark))", "rgb(var(--survey-black))"  
+    ];
+  
     return (
         <SurveyGraphCard title="How old are you?">
             <ResponsiveContainer width="100%" height="100%">
@@ -15,9 +19,13 @@ export const Age = () => {
                         dataKey="value" 
                         nameKey="answer" 
                         fill="rgb(var(--survey-placeholder))" 
-                        innerRadius="40%"
+                        innerRadius="60%"
                         outerRadius="80%"
-                        />
+                        >
+                        {ageGroup.map((entry, index) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                    </Pie>
                     <Legend align="center" verticalAlign="bottom" />
                 </PieChart>
         </ResponsiveContainer>

--- a/app/survey/components/graphs/Country.tsx
+++ b/app/survey/components/graphs/Country.tsx
@@ -11,7 +11,7 @@ import { useSurveyContext } from "../../context";
     ];
   
     return (
-      <SurveyGraphCard title="Which country?">
+      <SurveyGraphCard title="Where do you live?">
         <ResponsiveContainer width="100%" height="100%">
             <PieChart>
             <Pie 

--- a/app/survey/components/graphs/Country.tsx
+++ b/app/survey/components/graphs/Country.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "../../context";
 
   export const Country = () => {
-    const uk = useSurveyContext().barOrPie.uk;
+    const { uk } = useSurveyContext().barOrPie;
     
+   const COLORS = [
+      "rgb(var(--survey-blue))", "rgb(var(--survey-blue-light))"
+    ];
+  
     return (
       <SurveyGraphCard title="Which country?">
         <ResponsiveContainer width="100%" height="100%">
@@ -15,9 +19,13 @@ import { useSurveyContext } from "../../context";
               dataKey="value" 
               nameKey="answer" 
               fill="rgb(var(--survey-placeholder))" 
-              innerRadius="40%"
+              innerRadius="60%"
               outerRadius="80%"
-              />
+              >
+              {uk.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+              </Pie>
             <Legend align="center" verticalAlign="bottom" />
             </PieChart>
         </ResponsiveContainer>

--- a/app/survey/components/graphs/SupportDevelopment.tsx
+++ b/app/survey/components/graphs/SupportDevelopment.tsx
@@ -1,11 +1,22 @@
 import React from "react"
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "../../context";
+import { SUPPORT_DEVELOPMENT_ORDER } from "../../constants";
 
 export const SupportDevelopment = () => {
-    const supportDevelopment = useSurveyContext().barOrPie.supportDevelopment;
+    let { supportDevelopment } = useSurveyContext().barOrPie;
     
+    supportDevelopment = supportDevelopment.slice().sort(
+        (a, b) =>
+            SUPPORT_DEVELOPMENT_ORDER.indexOf(a.answer as string) -
+            SUPPORT_DEVELOPMENT_ORDER.indexOf(b.answer as string)
+        );
+        
+    const COLORS = [
+      "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--survey-orange))", "rgb(var(--survey-pink))", "rgb(var(--social-rent-land-color-rgb))", "rgb(var(--survey-grey-light))"
+    ];
+
     return (
         <SurveyGraphCard title="Would you support development in general?">
              <ResponsiveContainer width="100%" height="100%">
@@ -15,9 +26,13 @@ export const SupportDevelopment = () => {
                         dataKey="value" 
                         nameKey="answer" 
                         fill="rgb(var(--survey-placeholder))"
-                        innerRadius="40%"
+                        innerRadius="60%"
                         outerRadius="80%"
-                        />
+                        >
+                        {supportDevelopment.map((entry, index) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                    </Pie>
                     <Legend align="center" verticalAlign="bottom" />
              </PieChart>
             </ResponsiveContainer>

--- a/app/survey/components/graphs/SupportDevelopment.tsx
+++ b/app/survey/components/graphs/SupportDevelopment.tsx
@@ -18,7 +18,7 @@ export const SupportDevelopment = () => {
     ];
 
     return (
-        <SurveyGraphCard title="Would you support development in general?">
+        <SurveyGraphCard title="In general, do you support the development of new homes in your area?">
              <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                     <Pie 

--- a/app/survey/components/graphs/SupportNewFairhold.tsx
+++ b/app/survey/components/graphs/SupportNewFairhold.tsx
@@ -1,10 +1,22 @@
 import React from "react"
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { PieChart, Pie, Legend, ResponsiveContainer } from "recharts";
+import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "../../context";
+import { SUPPORT_FAIRHOLD_ORDER } from "../../constants";
+
 
 export const SupportNewFairhold = () => {
-    const supportNewFairhold = useSurveyContext().barOrPie.supportNewFairhold;
+    let supportNewFairhold = useSurveyContext().barOrPie.supportNewFairhold;
+
+    supportNewFairhold = supportNewFairhold.slice().sort(
+        (a, b) =>
+            SUPPORT_FAIRHOLD_ORDER.indexOf(a.answer as string) -
+            SUPPORT_FAIRHOLD_ORDER.indexOf(b.answer as string)
+        );
+
+    const COLORS = [
+      "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--survey-orange))", "rgb(var(--survey-pink))", "rgb(var(--social-rent-land-color-rgb))", "rgb(var(--survey-grey-light))"
+    ];
     
     return (
         <SurveyGraphCard title="Would you support the creation of Fairhold homes in the area where you want to live?">
@@ -15,9 +27,13 @@ export const SupportNewFairhold = () => {
                         dataKey="value" 
                         nameKey="answer" 
                         fill="rgb(var(--survey-placeholder))" 
-                        innerRadius="40%"
+                        innerRadius="60%"
                         outerRadius="80%"
-                        />
+                        >
+                        {supportNewFairhold.map((entry, index) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                    </Pie>
                     <Legend align="center" verticalAlign="bottom" />
              </PieChart>
             </ResponsiveContainer>

--- a/app/survey/components/graphs/SupportNewFairhold.tsx
+++ b/app/survey/components/graphs/SupportNewFairhold.tsx
@@ -19,7 +19,7 @@ export const SupportNewFairhold = () => {
     ];
     
     return (
-        <SurveyGraphCard title="Would you support the creation of Fairhold homes in the area where you want to live?">
+        <SurveyGraphCard title="Would you support the creation of new Fairhold homes (or plots) in your area?">
              <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                     <Pie 

--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -12,3 +12,12 @@ export const SUPPORT_DEVELOPMENT_ORDER = [
     "Strongly opposed to any development",
     "Don't know",
 ]
+
+export const SUPPORT_FAIRHOLD_ORDER = [
+    "Strongly support", 
+    "Somewhat support", 
+    "Neighter support nor oppose", 
+    "Somewhat oppose",
+    "Strongly oppose",
+    "Other",
+]

--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -3,3 +3,12 @@ export const AFFORD_FAIRHOLD_ORDER = [
   "Yes, but Fairhold Land Rent only, because the deposit is lower",
   "No, it's still too expensive",
 ];
+
+export const SUPPORT_DEVELOPMENT_ORDER = [
+    "Strongly supportive of any development", 
+    "Quite supportive of any development", 
+    "It depends", 
+    "Quite opposed to most development",
+    "Strongly opposed to any development",
+    "Don't know",
+]

--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -1,0 +1,5 @@
+export const AFFORD_FAIRHOLD_ORDER = [
+  "Yes",
+  "Yes, but Fairhold Land Rent only, because the deposit is lower",
+  "No, it's still too expensive",
+];


### PR DESCRIPTION
# What does this PR do? 
Restyles doughnuts following new [Figma] designs:
- Creates a new set of survey colours in `globals.css` (https://www.figma.com/design/SThTPsRJbUzhgPJIgjIXdo/Fairhold-Calculator?node-id=338-2&t=udF92HfupHl8Ild3-1) designs from Alastair
- Updates font weight in `SurveyGraphCard`, also per designs
- In pie charts (`Country`, `Age`, `AffordFairhold`, `SupportDevelopment`, `SupportFairhold`) updates `innerRadius`, creates `COLORS` array importing new colours from `globals.css`
- Creates new `survey/constants.ts` to save response order

# Questions
Is storing arrays with answer orders in `constants.ts` (and then using `.slice().sort()` on answers) the best way to handle this? I thought about creating more granular types, but then thought that might be unnecessarily complicated (eg to have types for certain answers but not others (order doesn't matter for all).