### PR TITLE
feat: order results descending or custom

### DIFF
--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -1,3 +1,12 @@
+export const AGE_ORDER = [
+  "0-18",
+  "19-24",
+  "25-34",
+  "35-44",
+  "45-54",
+  "65+"
+]
+
 export const AFFORD_FAIRHOLD = [
   { label: "Yes", colour: "rgb(var(--fairhold-equity-color-rgb))" },
   { label: "Yes, but Fairhold Land Rent only, because the deposit is lower", colour: "rgb(var(--fairhold-interest-color-rgb))" },

--- a/app/survey/utils.tsx
+++ b/app/survey/utils.tsx
@@ -1,6 +1,6 @@
 import { RawResults, BarOrPieResults, SankeyResults, SankeyResult } from "./types"
 import {
-  AFFORD_FAIRHOLD_ORDER,
+  AFFORD_FAIRHOLD,
   AGE_ORDER,
   SUPPORT_DEVELOPMENT_ORDER,
   SUPPORT_FAIRHOLD_ORDER,
@@ -14,7 +14,7 @@ const SANKEY_MAPPINGS = [
 ];
 
 const CUSTOM_ORDERS: Record<string, string[]> = {
-  affordFairhold: AFFORD_FAIRHOLD_ORDER,
+  affordFairhold: AFFORD_FAIRHOLD.map(item => item.label),
   ageGroup: AGE_ORDER,
   supportDevelopment: SUPPORT_DEVELOPMENT_ORDER,
   supportNewFairhold: SUPPORT_FAIRHOLD_ORDER,

--- a/app/survey/utils.tsx
+++ b/app/survey/utils.tsx
@@ -1,4 +1,10 @@
 import { RawResults, BarOrPieResults, SankeyResults, SankeyResult } from "./types"
+import {
+  AFFORD_FAIRHOLD_ORDER,
+  AGE_ORDER,
+  SUPPORT_DEVELOPMENT_ORDER,
+  SUPPORT_FAIRHOLD_ORDER,
+} from "./constants";
 
 const SANKEY_MAPPINGS = [
   { fromKey: 'houseType', toKey: 'idealHouseType', newKey: 'idealHouseType', isArray: false },
@@ -7,16 +13,38 @@ const SANKEY_MAPPINGS = [
   { fromKey: 'currentTenure', toKey: 'anyMeansTenureChoice', newKey: 'anyMeansTenureChoice', isArray: true }
 ];
 
+const CUSTOM_ORDERS: Record<string, string[]> = {
+  affordFairhold: AFFORD_FAIRHOLD_ORDER,
+  ageGroup: AGE_ORDER,
+  supportDevelopment: SUPPORT_DEVELOPMENT_ORDER,
+  supportNewFairhold: SUPPORT_FAIRHOLD_ORDER,
+};
+
 export const aggregateResults = (rawResults: RawResults[]) => {
     // There are two different data types we might need, both need to be initialised then handled separately
     const barOrPie = initializeBarOrPieResultsObject();
     const sankey = initializeSankeyResultsObject();
     const numberResponses = rawResults.length;
 
-        for (const rawResult of rawResults) {
-            addBarOrPieResult(barOrPie, rawResult);
-            addSankeyResult(sankey, rawResult);
+    for (const rawResult of rawResults) {
+        addBarOrPieResult(barOrPie, rawResult);
+        addSankeyResult(sankey, rawResult);
     }
+
+    Object.entries(barOrPie).forEach(([key, arr]) => {
+        if (Array.isArray(arr)) {
+            const customOrder = CUSTOM_ORDERS[key];
+            if (customOrder) {
+                arr.sort(
+                  (a, b) =>
+                    customOrder.indexOf((a.answer ?? "") as string) -
+                    customOrder.indexOf((b.answer ?? "") as string)
+                );
+            } else {
+                arr.sort((a, b) => b.value - a.value);
+            }
+        }
+    });
     return { numberResponses, barOrPie, sankey };
 }
 


### PR DESCRIPTION
# What does this PR do?
- Adds `ageGroup` custom order to `constants.ts`
- Creates custom ordering functionality in `utils.ts`, sort descending if no custom order found

# Why?
- The new designs have a mixture of custom orders for bar / pie graphs, and descending--need to be able to handle both. 