### PR TITLE
style: restyle bar graphs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,7 @@
   --private-rent-land-color-rgb: 45 155 240;
   --private-rent-house-color-rgb: 119 188 242;
   --private-rent-detail-color-rgb: 203 225 242;
+  --shared-ownership-color-rgb: 149, 151, 202;
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
   --social-rent-detail-color-rgb: 242 196 202;

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -8,7 +8,7 @@ type Props = React.PropsWithChildren<{
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
     <div className="justify-center w-full bg-white m-4 p-4">
-        <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`}>{title}</h3>
+        <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`} dangerouslySetInnerHTML={{ __html: title }}/>
         {subtitle && <p className={`text-md md:text-lg text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
       {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
     </div>

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -3,14 +3,20 @@ import React from "react";
 type Props = React.PropsWithChildren<{
   title: React.ReactNode;
   subtitle?: React.ReactNode;
+  action?: React.ReactNode;
 }>;
 
-const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
+const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children }) => {
   return (
     <div className="justify-center w-full bg-white m-4 p-4">
         <h3 className="text-xl md:text-lg sm:text-md font-bold text-black">{title}</h3>
-        {subtitle && <p className={`text-md text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
-      {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
+        {(subtitle || action) && (
+          <div className="flex items-center gap-4 mt-2">
+            {subtitle && <p className="text-md text-gray-600 font-normal">{subtitle}</p>}
+            {action}
+          </div>
+        )}      
+        {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
     </div>
   );
 };

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -9,7 +9,7 @@ const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
     <div className="justify-center w-full bg-white m-4 p-4">
         <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`} dangerouslySetInnerHTML={{ __html: title }}/>
-        {subtitle && <p className={`text-md md:text-lg text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
+        {subtitle && <p className={`text-md text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
       {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
     </div>
   );

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
 type Props = React.PropsWithChildren<{
-  title: string;
+  title: React.ReactNode;
   subtitle?: React.ReactNode;
 }>;
 
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
   return (
     <div className="justify-center w-full bg-white m-4 p-4">
-        <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`} dangerouslySetInnerHTML={{ __html: title }}/>
+        <h3 className="text-xl md:text-lg sm:text-md font-bold text-black">{title}</h3>
         {subtitle && <p className={`text-md text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
       {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
     </div>

--- a/app/survey/components/TenureSelector.tsx
+++ b/app/survey/components/TenureSelector.tsx
@@ -1,0 +1,29 @@
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+
+interface TenureSelectorProps {
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+  color: string;
+}
+
+const TenureSelector: React.FC<TenureSelectorProps> = ({ options, value, onChange, color }) => (
+  <div>
+    <label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-[180px]" style={{ color, border: 'none' }}>
+          <SelectValue placeholder="Select tenure" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map(option => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </label>
+  </div>
+);
+
+export default TenureSelector;

--- a/app/survey/components/graphs/AnyMeansTenureChoice.tsx
+++ b/app/survey/components/graphs/AnyMeansTenureChoice.tsx
@@ -1,20 +1,107 @@
 import React from "react"
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { CustomSankey } from "../CustomSankey";
-import { ResponsiveContainer } from "recharts";
+import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer, Cell, LabelList } from "recharts";
 import { useSurveyContext } from "../../context";
+import { TENURE_COLORS } from "../../constants"
+import { CustomLabelListContentProps } from "@/app/components/graphs/shared";
+
+export interface CustomYTickProps {
+  x: number;
+  y: number;
+  payload: { value: string };
+  index?: number;
+}
+
+const RankLabel: React.FC<CustomLabelListContentProps> = ({ index, x, y }) => {
+    const rank = typeof index === "number" ? index + 1 : "";
+    return (
+        <text
+            x={Number(x) + 5}
+            y={Number(y) + 15}
+            fill="white"
+            fontSize={12}
+        >
+            {rank}
+        </text>
+    );
+};
+
+const ColoredYAxisTick: React.FC<CustomYTickProps> = ({ x, y, payload: { value: label }  }) => {
+    const answerStr = Array.isArray(label) ? label[0] : label;
+    return (
+        <text
+            x={x}
+            y={y + 5}
+            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+            fontSize={10}
+            textAnchor="end"
+        >
+            {answerStr}
+        </text>
+    );
+};
 
 export const AnyMeansTenureChoice = () => {
-    const anyMeansTenureChoice = useSurveyContext().sankey.anyMeansTenureChoice;
-    
+    const { anyMeansTenureChoice } = useSurveyContext().barOrPie;
     return (
-        <SurveyGraphCard title="What tenure would you choose?">
-            <ResponsiveContainer width="100%" height="100%">
-                <CustomSankey
-                    nodes={anyMeansTenureChoice.nodes}
-                    links={anyMeansTenureChoice.links}            >
-                </CustomSankey>
-            </ResponsiveContainer>
+        <SurveyGraphCard 
+            title="Rank the tenures by preference"
+            subtitle="If you could afford (and were eligible for) any type of home, which would you prefer?"
+            >
+          <ResponsiveContainer height={anyMeansTenureChoice.length * 30}>
+          <BarChart
+              data={anyMeansTenureChoice}
+              barSize={20}
+              barGap={0}
+              layout="vertical"
+          >
+              <XAxis 
+                  type="number"
+                  height={20}
+                  fontSize={10}
+                  interval={10}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={false}
+                  /> 
+              <YAxis 
+                  type="category"    
+                  dataKey="answer" 
+                  width={350} 
+                  fontSize={10}
+                  interval={0}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={(props) => (
+                    <ColoredYAxisTick 
+                    {...props}
+                    />
+                )}
+                  /> 
+              <Bar dataKey="value">
+                {anyMeansTenureChoice.map((entry, index) => {
+                    let answerStr = "";
+                    if (Array.isArray(entry.answer)) {
+                        answerStr = entry.answer[0] ?? "";
+                    } else if (typeof entry.answer === "string") {
+                        answerStr = entry.answer;
+                    }
+                    return (
+                        <Cell
+                            key={`cell-${index}`}
+                            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+                        />
+                    );
+                })}
+                <LabelList 
+                    dataKey="value"
+                    position="insideStart"
+                    fill="white"    
+                    content={RankLabel}
+                />
+                </Bar>  
+          </BarChart>
+          </ResponsiveContainer>
         </SurveyGraphCard>
     )
 }

--- a/app/survey/components/graphs/HousingOutcomes.tsx
+++ b/app/survey/components/graphs/HousingOutcomes.tsx
@@ -1,11 +1,24 @@
-import React from "react"
+import React, { useState } from "react"
 import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
+import TenureSelector from "../TenureSelector";
+import { TENURE_COLORS } from "../../constants";
+import { getTopFive } from "../../utils";
 
 export const HousingOutcomes = () => {
     const housingOutcomes = useSurveyContext().barOrPie.housingOutcomes;
+
+    // Get available tenure keys (we might not have all of them, eg if no shared ownership residents fill out the survey)
+    const tenureOptions = Object.keys(housingOutcomes);
+
+    const [selectedTenure, setSelectedTenure] = useState(
+        tenureOptions.length > 0 ? tenureOptions[0] : ""
+    );
+    const housingOutcomesTopFive = getTopFive(housingOutcomes[selectedTenure] || []);
+    
+    const color = TENURE_COLORS[selectedTenure] || "rgb(var(--text-default-rgb))";
 
     const Tick = (props: TickProps) => {
         const { x, y, payload } = props;
@@ -16,7 +29,7 @@ export const HousingOutcomes = () => {
                 y={0} 
                 dy={4} 
                 textAnchor="end" 
-                fill="#333" 
+                fill={color} 
                 fontSize={10}
                 width={240}
             >
@@ -27,22 +40,43 @@ export const HousingOutcomes = () => {
     }
 
     return (
-        <SurveyGraphCard title="What do you most want from housing that you don't currently get?">
+        <SurveyGraphCard 
+            title="What do you most want from housing that you don't currently get?" 
+            subtitle="Showing top 10 responses for"
+            action={
+            <TenureSelector
+                options={tenureOptions}
+                value={selectedTenure}
+                onChange={setSelectedTenure}
+                color={color}
+            />
+            }  
+            >
+
             <ResponsiveContainer width="100%" height="100%">
                 <BarChart
-                    data={housingOutcomes}
+                    data={housingOutcomesTopFive}
                     barSize={20}
                     layout="vertical"
                 >
-                    <XAxis type="number" /> 
+                    <XAxis 
+                        type="number"
+                        tickLine={false}
+                        axisLine={false}
+                        tickCount={2}
+                        tickFormatter={(value: number) => Math.round(value).toString()}
+                        /> 
                     <YAxis 
                         type="category"    
                         dataKey="answer" 
                         width={350} 
                         fontSize={10}
                         interval={0}
-                        tick={Tick}/> 
-                    <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+                        tick={Tick}
+                        tickLine={false}
+                        axisLine={false}
+                        /> 
+                    <Bar dataKey="value" fill={color} /> 
                 </BarChart>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/app/survey/components/graphs/SupportDevelopmentFactors.tsx
+++ b/app/survey/components/graphs/SupportDevelopmentFactors.tsx
@@ -28,20 +28,29 @@ export const SupportDevelopmentFactors = () => {
     
     return (
         <SurveyGraphCard title="Which of these factors would make you more likely to support new homes near where you live?">
-            <ResponsiveContainer>
+          <ResponsiveContainer height={supportDevelopmentFactors.length * 30}>
             <BarChart
                 data={supportDevelopmentFactors}
                 barSize={20}
+                barGap={0}
                 layout="vertical"
             >
-                <XAxis type="number" /> 
+                <XAxis 
+                  type="number" 
+                  tickLine={false}
+                  axisLine={false}
+                  hide={true}
+                  /> 
                 <YAxis 
                     type="category"    
                     dataKey="answer" 
                     width={350} 
                     fontSize={10}
                     interval={0}
-                    tick={Tick}/> 
+                    tick={Tick}
+                    tickLine={false}
+                    axisLine={false}
+                    /> 
                 <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
             </BarChart>
             </ResponsiveContainer>

--- a/app/survey/components/graphs/SupportDevelopmentFactors.tsx
+++ b/app/survey/components/graphs/SupportDevelopmentFactors.tsx
@@ -27,7 +27,7 @@ export const SupportDevelopmentFactors = () => {
   }
     
     return (
-        <SurveyGraphCard title="Which of these factors would make you more likely to support new homes being created near where you live?">
+        <SurveyGraphCard title="Which of these factors would make you more likely to support new homes near where you live?">
             <ResponsiveContainer>
             <BarChart
                 data={supportDevelopmentFactors}

--- a/app/survey/components/graphs/SupportDevelopmentFactors.tsx
+++ b/app/survey/components/graphs/SupportDevelopmentFactors.tsx
@@ -51,7 +51,7 @@ export const SupportDevelopmentFactors = () => {
                     tickLine={false}
                     axisLine={false}
                     /> 
-                <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+                <Bar dataKey="value" fill="rgb(var(--fairhold-equity-color-rgb))" /> 
             </BarChart>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/app/survey/components/graphs/WhyFairhold.tsx
+++ b/app/survey/components/graphs/WhyFairhold.tsx
@@ -3,13 +3,12 @@ import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
+import { getTopFive, calculateChartMaximum } from "../../utils";
 
 export const WhyFairhold = () => {
-  let { whyFairhold } = useSurveyContext().barOrPie;
-  whyFairhold = whyFairhold.slice(0,5);
-  const maxValue = whyFairhold.length > 0 ? whyFairhold[0].value : 0;
-  const maxResponses = Math.ceil(maxValue / 10) * 10;
-  const xDomainMax = maxResponses < 10 ? 10 : maxResponses;
+  const { whyFairhold } = useSurveyContext().barOrPie;
+  const chartMax = calculateChartMaximum(whyFairhold);
+  const whyFairholdTopFive = getTopFive(whyFairhold);
 
   const Tick = (props: TickProps) => {
       const { x, y, payload } = props;
@@ -35,9 +34,9 @@ export const WhyFairhold = () => {
         title="Why would you choose Fairhold?" 
         subtitle="Top 5 responses from people who would choose Fairhold"
       >
-          <ResponsiveContainer height={whyFairhold.length * 30}>
+          <ResponsiveContainer height={whyFairholdTopFive.length * 30}>
           <BarChart
-              data={whyFairhold}
+              data={whyFairholdTopFive}
               barSize={20}
               barGap={0}
               layout="vertical"
@@ -47,7 +46,7 @@ export const WhyFairhold = () => {
                   height={20}
                   fontSize={10}
                   interval={10}
-                  domain={[0, xDomainMax]}
+                  domain={[0, chartMax]}
                   axisLine={false}
                   tickLine={false}
                   tick={true}

--- a/app/survey/components/graphs/WhyFairhold.tsx
+++ b/app/survey/components/graphs/WhyFairhold.tsx
@@ -5,7 +5,12 @@ import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
 
 export const WhyFairhold = () => {
-  const whyFairhold = useSurveyContext().barOrPie.whyFairhold;
+  let { whyFairhold } = useSurveyContext().barOrPie;
+  whyFairhold = whyFairhold.slice(0,5);
+  const maxValue = whyFairhold.length > 0 ? whyFairhold[0].value : 0;
+  const maxResponses = Math.ceil(maxValue / 10) * 10;
+  const xDomainMax = maxResponses < 10 ? 10 : maxResponses;
+
   const Tick = (props: TickProps) => {
       const { x, y, payload } = props;
       return (
@@ -26,16 +31,26 @@ export const WhyFairhold = () => {
   }
   
   return (
-      <SurveyGraphCard title="Why would you choose Fairhold?">
-          <ResponsiveContainer>
+      <SurveyGraphCard 
+        title="Why would you choose Fairhold?" 
+        subtitle="Top 5 responses from people who would choose Fairhold"
+      >
+          <ResponsiveContainer height={whyFairhold.length * 30}>
           <BarChart
               data={whyFairhold}
               barSize={20}
+              barGap={0}
               layout="vertical"
           >
               <XAxis 
                   type="number"
-                  hide={true}
+                  height={20}
+                  fontSize={10}
+                  interval={10}
+                  domain={[0, xDomainMax]}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={true}
                   /> 
               <YAxis 
                   type="category"    
@@ -43,8 +58,10 @@ export const WhyFairhold = () => {
                   width={350} 
                   fontSize={10}
                   interval={0}
+                  tickLine={false}
+                  axisLine={false}
                   tick={Tick}/> 
-              <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+              <Bar dataKey="value" fill="rgb(var(--fairhold-equity-color-rgb))" /> 
           </BarChart>
           </ResponsiveContainer>
       </SurveyGraphCard>

--- a/app/survey/components/graphs/WhyNotFairhold.tsx
+++ b/app/survey/components/graphs/WhyNotFairhold.tsx
@@ -27,7 +27,7 @@ export const WhyNotFairhold = () => {
   }
   
   return (
-      <SurveyGraphCard title="Why wouldn't you choose Fairhold?">
+      <SurveyGraphCard title="Why <em>not</em> Fairhold?">
           <ResponsiveContainer>
           <BarChart
               data={whyNotFairhold}

--- a/app/survey/components/graphs/WhyNotFairhold.tsx
+++ b/app/survey/components/graphs/WhyNotFairhold.tsx
@@ -5,7 +5,11 @@ import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
 
 export const WhyNotFairhold = () => {
-  const whyNotFairhold = useSurveyContext().barOrPie.whyNotFairhold;
+  let whyNotFairhold = useSurveyContext().barOrPie.whyNotFairhold;
+  whyNotFairhold = whyNotFairhold.slice(0,5)
+  const maxValue = whyNotFairhold.length > 0 ? whyNotFairhold[0].value : 0;
+  const maxResponses = Math.ceil(maxValue / 10) * 10;
+  const xDomainMax = maxResponses < 10 ? 10 : maxResponses;
 
   const Tick = (props: TickProps) => {
       const { x, y, payload } = props;
@@ -27,16 +31,25 @@ export const WhyNotFairhold = () => {
   }
   
   return (
-      <SurveyGraphCard title="Why <em>not</em> Fairhold?">
-          <ResponsiveContainer>
+      <SurveyGraphCard 
+        title="Why <em>not</em> Fairhold?"
+        subtitle="Top 5 responses from people who would not choose Fairhold">
+          <ResponsiveContainer height={whyNotFairhold.length * 30}>
           <BarChart
               data={whyNotFairhold}
               barSize={20}
+              barGap={0}
               layout="vertical"
           >
               <XAxis 
-                  type="number" 
-                  hide={true}
+                  type="number"
+                  height={20}
+                  fontSize={10}
+                  interval={10}
+                  domain={[0, xDomainMax]}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={true}
                   /> 
               <YAxis 
                   type="category"    
@@ -44,6 +57,8 @@ export const WhyNotFairhold = () => {
                   width={350} 
                   fontSize={10}
                   interval={0}
+                   tickLine={false}
+                  axisLine={false}
                   tick={Tick}/> 
               <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
           </BarChart>

--- a/app/survey/components/graphs/WhyNotFairhold.tsx
+++ b/app/survey/components/graphs/WhyNotFairhold.tsx
@@ -32,7 +32,7 @@ export const WhyNotFairhold = () => {
   
   return (
       <SurveyGraphCard 
-        title="Why <em>not</em> Fairhold?"
+        title={<>Why <em>not</em> Fairhold?</>}
         subtitle="Top 5 responses from people who would not choose Fairhold">
           <ResponsiveContainer height={whyNotFairhold.length * 30}>
           <BarChart

--- a/app/survey/components/graphs/WhyNotFairhold.tsx
+++ b/app/survey/components/graphs/WhyNotFairhold.tsx
@@ -3,13 +3,12 @@ import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
+import { getTopFive, calculateChartMaximum } from "../../utils";
 
 export const WhyNotFairhold = () => {
-  let whyNotFairhold = useSurveyContext().barOrPie.whyNotFairhold;
-  whyNotFairhold = whyNotFairhold.slice(0,5)
-  const maxValue = whyNotFairhold.length > 0 ? whyNotFairhold[0].value : 0;
-  const maxResponses = Math.ceil(maxValue / 10) * 10;
-  const xDomainMax = maxResponses < 10 ? 10 : maxResponses;
+  const whyNotFairhold = useSurveyContext().barOrPie.whyNotFairhold;
+  const chartMax = calculateChartMaximum(whyNotFairhold);
+  const whyNotFairholdTopFive = getTopFive(whyNotFairhold);
 
   const Tick = (props: TickProps) => {
       const { x, y, payload } = props;
@@ -34,9 +33,9 @@ export const WhyNotFairhold = () => {
       <SurveyGraphCard 
         title={<>Why <em>not</em> Fairhold?</>}
         subtitle="Top 5 responses from people who would not choose Fairhold">
-          <ResponsiveContainer height={whyNotFairhold.length * 30}>
+          <ResponsiveContainer height={whyNotFairholdTopFive.length * 30}>
           <BarChart
-              data={whyNotFairhold}
+              data={whyNotFairholdTopFive}
               barSize={20}
               barGap={0}
               layout="vertical"
@@ -46,7 +45,7 @@ export const WhyNotFairhold = () => {
                   height={20}
                   fontSize={10}
                   interval={10}
-                  domain={[0, xDomainMax]}
+                  domain={[0, chartMax]}
                   axisLine={false}
                   tickLine={false}
                   tick={true}

--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -1,3 +1,11 @@
+export const TENURE_COLORS: Record<string, string> = {
+    "Social rent": "rgb(var(--social-rent-land-color-rgb))",
+    "Shared ownership": "rgb(var(--shared-ownership-color-rgb))",
+    "Private rent": "rgb(var(--private-rent-land-color-rgb))",
+    "Market purchase": "rgb(var(--freehold-equity-color-rgb))",
+    "Fairhold": "rgb(var(--fairhold-equity-color-rgb))"
+};
+
 export const AGE_ORDER = [
   "0-18",
   "19-24",

--- a/app/survey/types.tsx
+++ b/app/survey/types.tsx
@@ -24,28 +24,33 @@ export type RawResults = {
     supportNewFairhold: string;
 };
 
-export type BarOrPieResults = Record<Exclude<keyof RawResults, 
-    'id' | 
-    'houseType' | 
-    'idealHouseType' | 
-    'liveWith' | 
-    'idealLiveWith' | 
-    'currentTenure' | 
-    'currentMeansTenureChoice' | 
-    'anyMeansTenureChoice'
-    >, 
-    BarOrPieResult[]>
+// These are excluded because they are either not relevant (eg id) or will be formatted separately to bar / pie results (eg houseType, idealHouseType)
+type ExcludedRawResults =
+    | "id"
+    | "houseType"
+    | "idealHouseType"
+    | "liveWith"
+    | "idealLiveWith"
+    | "currentTenure"
+    | "currentMeansTenureChoice";
+
+type ResultKeys = Exclude<keyof RawResults, ExcludedRawResults>;
+
+export type BarOrPieResults = {
+    [K in ResultKeys]: K extends "housingOutcomes"
+        ? Record<string, BarOrPieResult[]>
+        : BarOrPieResult[];
+};
 
 export type BarOrPieResult = {
-    answer: string | string[] | undefined;
+    answer: string;
     value: number;
 }
 
 export type SankeyResults = Record<Extract<keyof RawResults, 
     'idealHouseType' | 
     'idealLiveWith' | 
-    'currentMeansTenureChoice' | 
-    'anyMeansTenureChoice'
+    'currentMeansTenureChoice'
     >, 
     SankeyResult>
 

--- a/app/survey/utils.tsx
+++ b/app/survey/utils.tsx
@@ -5,6 +5,7 @@ import {
   SUPPORT_DEVELOPMENT_ORDER,
   SUPPORT_FAIRHOLD_ORDER,
 } from "./constants";
+import { BarOrPieResult } from "./types";
 
 const SANKEY_MAPPINGS = [
   { fromKey: 'houseType', toKey: 'idealHouseType', newKey: 'idealHouseType', isArray: false },
@@ -149,3 +150,12 @@ const updateSankeyNodesAndLinks = (
         links.push({ source: sourceIndex, target: targetIndex, value: 1 });
     }
 };
+
+export const getTopFive = (data: BarOrPieResult[]) => data.slice(0,5);
+
+export const calculateChartMaximum = (data: BarOrPieResult[]) => {
+const maxValue = data[0]?.value ?? 0;
+const maxResponses = Math.ceil(maxValue / 10) * 10;
+const chartMax = maxResponses < 10 ? 10 : maxResponses;
+return chartMax;
+}

--- a/app/survey/utils.tsx
+++ b/app/survey/utils.tsx
@@ -1,17 +1,15 @@
-import { RawResults, BarOrPieResults, SankeyResults, SankeyResult } from "./types"
+import { RawResults, BarOrPieResults, BarOrPieResult, SankeyResults, SankeyResult } from "./types"
 import {
   AFFORD_FAIRHOLD_ORDER,
   AGE_ORDER,
   SUPPORT_DEVELOPMENT_ORDER,
   SUPPORT_FAIRHOLD_ORDER,
 } from "./constants";
-import { BarOrPieResult } from "./types";
 
 const SANKEY_MAPPINGS = [
   { fromKey: 'houseType', toKey: 'idealHouseType', newKey: 'idealHouseType', isArray: false },
   { fromKey: 'liveWith', toKey: 'idealLiveWith', newKey: 'idealLiveWith', isArray: false },
   { fromKey: 'currentTenure', toKey: 'currentMeansTenureChoice', newKey: 'currentMeansTenureChoice', isArray: false },
-  { fromKey: 'currentTenure', toKey: 'anyMeansTenureChoice', newKey: 'anyMeansTenureChoice', isArray: true }
 ];
 
 const CUSTOM_ORDERS: Record<string, string[]> = {
@@ -46,6 +44,11 @@ export const aggregateResults = (rawResults: RawResults[]) => {
             }
         }
     });
+
+    Object.values(barOrPie.housingOutcomes).forEach((arr) => {
+        arr.sort((a, b) => b.value - a.value);
+    });
+
     return { numberResponses, barOrPie, sankey };
 }
 
@@ -55,10 +58,11 @@ const initializeBarOrPieResultsObject = (): BarOrPieResults => {
         nonUk: [],
         postcode: [],
         ageGroup: [],
+        anyMeansTenureChoice: [],
         ownershipModel: [],
         rentalModel: [],
         secondHomes: [],
-        housingOutcomes: [],
+        housingOutcomes: {},
         fairholdCalculator: [],
         affordFairhold: [],
         whyFairhold: [],
@@ -74,31 +78,34 @@ const initializeSankeyResultsObject = (): SankeyResults => {
         idealHouseType: { nodes: [], links: [] },
         idealLiveWith: { nodes: [], links: [] },
         currentMeansTenureChoice: { nodes: [], links: [] },
-        anyMeansTenureChoice: { nodes: [], links: [] },
     } as SankeyResults;
 };
 
 const addBarOrPieResult = (results: BarOrPieResults, rawResult: RawResults) => {
-    const getExistingResult = (key: keyof BarOrPieResults, answer: string) => 
-        results[key].find(result => result.answer === answer);
-
-    const addResultItem = (key: keyof BarOrPieResults, item: string) => {
-        const existingResult = getExistingResult(key, item);
-        existingResult
-            ? existingResult.value++
-            : results[key].push({ answer: item, value: 1 });
-    };
 
     Object.entries(rawResult).forEach(([key, value]) => {
         if (key === "id" || !(key in results)) return;
 
         const validKey = key as keyof BarOrPieResults;
-        
-        const isMultipleChoiceAnswer = Array.isArray(value);
-        
-        isMultipleChoiceAnswer
-            ? value.forEach(item => addResultItem(validKey, item))
-            : addResultItem(validKey, value);
+
+        // We handle anyMeansTenureChoice differently because it's ranked choice, and each rank has a points-based weight
+        if (validKey === "anyMeansTenureChoice") { 
+            handleAnyMeansTenureChoice(results, value);
+            return;
+        }
+
+        if (validKey === "housingOutcomes") {
+            handleHousingOutcomes(results, value, rawResult.currentTenure);
+            return;
+        }
+
+        if (Array.isArray(results[validKey])) {
+            const arr = results[validKey] as BarOrPieResult[];
+            const isMultipleChoiceAnswer = Array.isArray(value);
+            isMultipleChoiceAnswer
+                ? value.forEach(item => addResultItem(arr, item))
+                : addResultItem(arr, value);
+        }
     });
 };
 
@@ -159,3 +166,58 @@ const maxResponses = Math.ceil(maxValue / 10) * 10;
 const chartMax = maxResponses < 10 ? 10 : maxResponses;
 return chartMax;
 }
+
+const mapTenureCategory = (tenure: string): string => {
+    tenure = tenure.trim();
+    
+    switch (tenure) {
+    case "I own it outright":
+        return "Market purchase";
+    case "I own it with a mortgage":
+        return "Market purchase";
+    case "I rent it":
+        return "Private rent";
+    case "Part own, part rent":
+        return "Shared ownership";
+    }
+    return "Other";
+};
+
+const handleHousingOutcomes = (
+    results: BarOrPieResults,
+    value: unknown,
+    currentTenure: string
+) => {
+    const tenure = mapTenureCategory(currentTenure || "Unknown");
+    if (!results.housingOutcomes[tenure]) {
+        results.housingOutcomes[tenure] = [];
+    }
+    if (Array.isArray(value)) {
+        value.forEach(item =>
+            addResultItem(results.housingOutcomes[tenure], item)
+        );
+    }
+};
+
+const getExistingResult = (arr: BarOrPieResult[], answer: string) =>
+    arr.find((result) => result.answer === answer);
+
+const addResultItem = (arr: BarOrPieResult[], item: string, weight: number = 1) => {
+    const existingResult = getExistingResult(arr, item);
+    existingResult
+        ? existingResult.value += weight
+        : arr.push({ answer: item, value: 1 });
+};
+
+const handleAnyMeansTenureChoice = (results: BarOrPieResults, value: unknown) => {
+    if (Array.isArray(value)) {
+        value.forEach((item, idx) => {
+            // Tidying the string
+            let shortAnswer = item.split("––")[0].trim();
+            shortAnswer = shortAnswer.replace("Freehold", "Market purchase");
+            // For now: 5 weight for position 1, 4 for position 2, etc.
+            const weight = Math.max(5 - idx, 1);
+            addResultItem(results.anyMeansTenureChoice, shortAnswer, weight);
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.0",
         "airtable": "^0.12.2",
-        "chart.js": "^4.4.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv-cli": "^8.0.0",
@@ -39,7 +38,6 @@
         "tailwindcss-animate": "^1.0.7",
         "ts-node": "^10.9.2",
         "unist-util-visit": "^5.0.0",
-        "vaul": "^1.1.2",
         "zod": "^3.25.56"
       },
       "devDependencies": {
@@ -2878,11 +2876,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
@@ -6651,18 +6644,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
-      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -17819,19 +17800,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/vaul": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
-      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-dialog": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.0",
     "airtable": "^0.12.2",
-    "chart.js": "^4.4.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv-cli": "^8.0.0",
@@ -58,7 +57,6 @@
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.9.2",
     "unist-util-visit": "^5.0.0",
-    "vaul": "^1.1.2",
     "zod": "^3.25.56"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates styles for bar graphs that do _not_ need the data shape to change. 

Will do the more elaborate changes in further PRs (eg housing outcomes with ability to select tenure)
![image](https://github.com/user-attachments/assets/51c41bf5-293f-4ea1-8502-aac2006b9e48)
