### PR TITLE
feat: display housing outcomes by current tenure

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,7 @@
   --private-rent-land-color-rgb: 45 155 240;
   --private-rent-house-color-rgb: 119 188 242;
   --private-rent-detail-color-rgb: 203 225 242;
+  --shared-ownership-color-rgb: 149, 151, 202;
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
   --social-rent-detail-color-rgb: 242 196 202;

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -3,14 +3,20 @@ import React from "react";
 type Props = React.PropsWithChildren<{
   title: React.ReactNode;
   subtitle?: React.ReactNode;
+  action?: React.ReactNode;
 }>;
 
-const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
+const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children }) => {
   return (
     <div className="justify-center w-full bg-white m-4 p-4">
         <h3 className="text-xl md:text-lg sm:text-md font-bold text-black">{title}</h3>
-        {subtitle && <p className={`text-md text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
-      {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
+        {(subtitle || action) && (
+          <div className="flex items-center gap-4 mt-2">
+            {subtitle && <p className="text-md text-gray-600 font-normal">{subtitle}</p>}
+            {action}
+          </div>
+        )}      
+        {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
     </div>
   );
 };

--- a/app/survey/components/TenureSelector.tsx
+++ b/app/survey/components/TenureSelector.tsx
@@ -11,7 +11,7 @@ const TenureSelector: React.FC<TenureSelectorProps> = ({ options, value, onChang
   <div style={{ marginBottom: 16 }}>
     <label>
       <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="w-[180px]" style={{ color }}>
+        <SelectTrigger className="w-[180px]" style={{ color, border: 'none' }}>
           <SelectValue placeholder="Select tenure" />
         </SelectTrigger>
         <SelectContent>

--- a/app/survey/components/TenureSelector.tsx
+++ b/app/survey/components/TenureSelector.tsx
@@ -8,7 +8,7 @@ interface TenureSelectorProps {
 }
 
 const TenureSelector: React.FC<TenureSelectorProps> = ({ options, value, onChange, color }) => (
-  <div style={{ marginBottom: 16 }}>
+  <div>
     <label>
       <Select value={value} onValueChange={onChange}>
         <SelectTrigger className="w-[180px]" style={{ color, border: 'none' }}>

--- a/app/survey/components/TenureSelector.tsx
+++ b/app/survey/components/TenureSelector.tsx
@@ -1,0 +1,29 @@
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+
+interface TenureSelectorProps {
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+  color: string;
+}
+
+const TenureSelector: React.FC<TenureSelectorProps> = ({ options, value, onChange, color }) => (
+  <div style={{ marginBottom: 16 }}>
+    <label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-[180px]" style={{ color }}>
+          <SelectValue placeholder="Select tenure" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map(option => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </label>
+  </div>
+);
+
+export default TenureSelector;

--- a/app/survey/components/graphs/AnyMeansTenureChoice.tsx
+++ b/app/survey/components/graphs/AnyMeansTenureChoice.tsx
@@ -1,20 +1,107 @@
 import React from "react"
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { CustomSankey } from "../CustomSankey";
-import { ResponsiveContainer } from "recharts";
+import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer, Cell, LabelList } from "recharts";
 import { useSurveyContext } from "../../context";
+import { TENURE_COLORS } from "../../constants"
+import { CustomLabelListContentProps } from "@/app/components/graphs/shared";
+
+export interface CustomYTickProps {
+  x: number;
+  y: number;
+  payload: { value: string };
+  index?: number;
+}
+
+const RankLabel: React.FC<CustomLabelListContentProps> = ({ index, x, y }) => {
+    const rank = typeof index === "number" ? index + 1 : "";
+    return (
+        <text
+            x={Number(x) + 5}
+            y={Number(y) + 15}
+            fill="white"
+            fontSize={12}
+        >
+            {rank}
+        </text>
+    );
+};
+
+const ColoredYAxisTick: React.FC<CustomYTickProps> = ({ x, y, payload: { value: label }  }) => {
+    const answerStr = Array.isArray(label) ? label[0] : label;
+    return (
+        <text
+            x={x}
+            y={y + 5}
+            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+            fontSize={10}
+            textAnchor="end"
+        >
+            {answerStr}
+        </text>
+    );
+};
 
 export const AnyMeansTenureChoice = () => {
-    const anyMeansTenureChoice = useSurveyContext().sankey.anyMeansTenureChoice;
-    
+    const { anyMeansTenureChoice } = useSurveyContext().barOrPie;
     return (
-        <SurveyGraphCard title="What tenure would you choose?">
-            <ResponsiveContainer width="100%" height="100%">
-                <CustomSankey
-                    nodes={anyMeansTenureChoice.nodes}
-                    links={anyMeansTenureChoice.links}            >
-                </CustomSankey>
-            </ResponsiveContainer>
+        <SurveyGraphCard 
+            title="Rank the tenures by preference"
+            subtitle="If you could afford (and were eligible for) any type of home, which would you prefer?"
+            >
+          <ResponsiveContainer height={anyMeansTenureChoice.length * 30}>
+          <BarChart
+              data={anyMeansTenureChoice}
+              barSize={20}
+              barGap={0}
+              layout="vertical"
+          >
+              <XAxis 
+                  type="number"
+                  height={20}
+                  fontSize={10}
+                  interval={10}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={false}
+                  /> 
+              <YAxis 
+                  type="category"    
+                  dataKey="answer" 
+                  width={350} 
+                  fontSize={10}
+                  interval={0}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={(props) => (
+                    <ColoredYAxisTick 
+                    {...props}
+                    />
+                )}
+                  /> 
+              <Bar dataKey="value">
+                {anyMeansTenureChoice.map((entry, index) => {
+                    let answerStr = "";
+                    if (Array.isArray(entry.answer)) {
+                        answerStr = entry.answer[0] ?? "";
+                    } else if (typeof entry.answer === "string") {
+                        answerStr = entry.answer;
+                    }
+                    return (
+                        <Cell
+                            key={`cell-${index}`}
+                            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+                        />
+                    );
+                })}
+                <LabelList 
+                    dataKey="value"
+                    position="insideStart"
+                    fill="white"    
+                    content={RankLabel}
+                />
+                </Bar>  
+          </BarChart>
+          </ResponsiveContainer>
         </SurveyGraphCard>
     )
 }

--- a/app/survey/components/graphs/HousingOutcomes.tsx
+++ b/app/survey/components/graphs/HousingOutcomes.tsx
@@ -41,13 +41,16 @@ export const HousingOutcomes = () => {
         <SurveyGraphCard 
             title="What do you most want from housing that you don't currently get?" 
             subtitle="Showing top 10 responses for"
-            >
+            action={
             <TenureSelector
                 options={tenureOptions}
                 value={selectedTenure}
                 onChange={setSelectedTenure}
                 color={color}
             />
+            }  
+            >
+
             <ResponsiveContainer width="100%" height="100%">
                 <BarChart
                     data={housingOutcomes[selectedTenure].slice(0,5)}

--- a/app/survey/components/graphs/HousingOutcomes.tsx
+++ b/app/survey/components/graphs/HousingOutcomes.tsx
@@ -5,6 +5,7 @@ import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
 import TenureSelector from "../TenureSelector";
 import { TENURE_COLORS } from "../../constants";
+import { getTopFive } from "../../utils";
 
 export const HousingOutcomes = () => {
     const housingOutcomes = useSurveyContext().barOrPie.housingOutcomes;
@@ -15,6 +16,7 @@ export const HousingOutcomes = () => {
     const [selectedTenure, setSelectedTenure] = useState(
         tenureOptions.length > 0 ? tenureOptions[0] : ""
     );
+    const housingOutcomesTopFive = getTopFive(housingOutcomes[selectedTenure] || []);
     
     const color = TENURE_COLORS[selectedTenure] || "rgb(var(--text-default-rgb))";
 
@@ -53,7 +55,7 @@ export const HousingOutcomes = () => {
 
             <ResponsiveContainer width="100%" height="100%">
                 <BarChart
-                    data={housingOutcomes[selectedTenure].slice(0,5)}
+                    data={housingOutcomesTopFive}
                     barSize={20}
                     layout="vertical"
                 >

--- a/app/survey/components/graphs/HousingOutcomes.tsx
+++ b/app/survey/components/graphs/HousingOutcomes.tsx
@@ -1,11 +1,22 @@
-import React from "react"
+import React, { useState } from "react"
 import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
+import TenureSelector from "../TenureSelector";
+import { TENURE_COLORS } from "../../constants";
 
 export const HousingOutcomes = () => {
     const housingOutcomes = useSurveyContext().barOrPie.housingOutcomes;
+
+    // Get available tenure keys (we might not have all of them, eg if no shared ownership residents fill out the survey)
+    const tenureOptions = Object.keys(housingOutcomes);
+
+    const [selectedTenure, setSelectedTenure] = useState(
+        tenureOptions.length > 0 ? tenureOptions[0] : ""
+    );
+    
+    const color = TENURE_COLORS[selectedTenure] || "rgb(var(--text-default-rgb))";
 
     const Tick = (props: TickProps) => {
         const { x, y, payload } = props;
@@ -16,7 +27,7 @@ export const HousingOutcomes = () => {
                 y={0} 
                 dy={4} 
                 textAnchor="end" 
-                fill="#333" 
+                fill={color} 
                 fontSize={10}
                 width={240}
             >
@@ -27,22 +38,38 @@ export const HousingOutcomes = () => {
     }
 
     return (
-        <SurveyGraphCard title="What do you most want from housing that you don't currently get?">
+        <SurveyGraphCard 
+            title="What do you most want from housing that you don't currently get?" 
+            subtitle="Showing top 10 responses for"
+            >
+            <TenureSelector
+                options={tenureOptions}
+                value={selectedTenure}
+                onChange={setSelectedTenure}
+                color={color}
+            />
             <ResponsiveContainer width="100%" height="100%">
                 <BarChart
-                    data={housingOutcomes}
+                    data={housingOutcomes[selectedTenure].slice(0,5)}
                     barSize={20}
                     layout="vertical"
                 >
-                    <XAxis type="number" /> 
+                    <XAxis 
+                        type="number"
+                        tickLine={false}
+                        axisLine={false}
+                        /> 
                     <YAxis 
                         type="category"    
                         dataKey="answer" 
                         width={350} 
                         fontSize={10}
                         interval={0}
-                        tick={Tick}/> 
-                    <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+                        tick={Tick}
+                        tickLine={false}
+                        axisLine={false}
+                        /> 
+                    <Bar dataKey="value" fill={color} /> 
                 </BarChart>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/app/survey/components/graphs/HousingOutcomes.tsx
+++ b/app/survey/components/graphs/HousingOutcomes.tsx
@@ -61,6 +61,8 @@ export const HousingOutcomes = () => {
                         type="number"
                         tickLine={false}
                         axisLine={false}
+                        tickCount={2}
+                        tickFormatter={(value: number) => Math.round(value).toString()}
                         /> 
                     <YAxis 
                         type="category"    

--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -3,6 +3,7 @@ export const TENURE_COLORS: Record<string, string> = {
     "Shared ownership": "rgb(var(--shared-ownership-color-rgb))",
     "Private rent": "rgb(var(--private-rent-land-color-rgb))",
     "Market purchase": "rgb(var(--freehold-equity-color-rgb))",
+    "Fairhold": "rgb(var(--fairhold-equity-color-rgb))"
 };
 
 export const AGE_ORDER = [

--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -1,3 +1,10 @@
+export const TENURE_COLORS: Record<string, string> = {
+    "Social rent": "rgb(var(--social-rent-land-color-rgb))",
+    "Shared ownership": "rgb(var(--shared-ownership-color-rgb))",
+    "Private rent": "rgb(var(--private-rent-land-color-rgb))",
+    "Market purchase": "rgb(var(--freehold-equity-color-rgb))",
+};
+
 export const AGE_ORDER = [
   "0-18",
   "19-24",

--- a/app/survey/types.tsx
+++ b/app/survey/types.tsx
@@ -24,17 +24,21 @@ export type RawResults = {
     supportNewFairhold: string;
 };
 
-export type BarOrPieResults = Record<Exclude<keyof RawResults, 
-    'id' | 
-    'houseType' | 
-    'idealHouseType' | 
-    'liveWith' | 
-    'idealLiveWith' | 
-    'currentTenure' | 
-    'currentMeansTenureChoice' | 
-    'anyMeansTenureChoice'
-    >, 
-    BarOrPieResult[]>
+export type BarOrPieResults = {
+  [K in Exclude<
+    keyof RawResults,
+    | 'id'
+    | 'houseType'
+    | 'idealHouseType'
+    | 'liveWith'
+    | 'idealLiveWith'
+    | 'currentTenure'
+    | 'currentMeansTenureChoice'
+    | 'anyMeansTenureChoice'
+  >]: K extends 'housingOutcomes'
+    ? Record<string, BarOrPieResult[]>
+    : BarOrPieResult[];
+};
 
 export type BarOrPieResult = {
     answer: string | string[] | undefined;

--- a/app/survey/types.tsx
+++ b/app/survey/types.tsx
@@ -32,8 +32,7 @@ type ExcludedRawResults =
     | "liveWith"
     | "idealLiveWith"
     | "currentTenure"
-    | "currentMeansTenureChoice"
-    | "anyMeansTenureChoice";
+    | "currentMeansTenureChoice";
 
 type ResultKeys = Exclude<keyof RawResults, ExcludedRawResults>;
 
@@ -44,15 +43,14 @@ export type BarOrPieResults = {
 };
 
 export type BarOrPieResult = {
-    answer: string | string[] | undefined;
+    answer: string;
     value: number;
 }
 
 export type SankeyResults = Record<Extract<keyof RawResults, 
     'idealHouseType' | 
     'idealLiveWith' | 
-    'currentMeansTenureChoice' | 
-    'anyMeansTenureChoice'
+    'currentMeansTenureChoice'
     >, 
     SankeyResult>
 

--- a/app/survey/types.tsx
+++ b/app/survey/types.tsx
@@ -24,20 +24,23 @@ export type RawResults = {
     supportNewFairhold: string;
 };
 
+// These are excluded because they are either not relevant (eg id) or will be formatted separately to bar / pie results (eg houseType, idealHouseType)
+type ExcludedRawResults =
+    | "id"
+    | "houseType"
+    | "idealHouseType"
+    | "liveWith"
+    | "idealLiveWith"
+    | "currentTenure"
+    | "currentMeansTenureChoice"
+    | "anyMeansTenureChoice";
+
+type ResultKeys = Exclude<keyof RawResults, ExcludedRawResults>;
+
 export type BarOrPieResults = {
-  [K in Exclude<
-    keyof RawResults,
-    | 'id'
-    | 'houseType'
-    | 'idealHouseType'
-    | 'liveWith'
-    | 'idealLiveWith'
-    | 'currentTenure'
-    | 'currentMeansTenureChoice'
-    | 'anyMeansTenureChoice'
-  >]: K extends 'housingOutcomes'
-    ? Record<string, BarOrPieResult[]>
-    : BarOrPieResult[];
+    [K in ResultKeys]: K extends "housingOutcomes"
+        ? Record<string, BarOrPieResult[]>
+        : BarOrPieResult[];
 };
 
 export type BarOrPieResult = {

--- a/app/survey/utils.tsx
+++ b/app/survey/utils.tsx
@@ -181,21 +181,15 @@ return chartMax;
 const mapTenureCategory = (tenure: string): string => {
     tenure = tenure.trim();
     
-    if (tenure === "I own it outright" || tenure === "I own it with a mortgage") {
+    switch (tenure) {
+    case "I own it outright":
         return "Market purchase";
-    }
-    if (tenure === "I rent it") {
+    case "I own it with a mortgage":
+        return "Market purchase";
+    case "I rent it":
         return "Private rent";
-    }
-    if (tenure === "Part own, part rent") {
+    case "Part own, part rent":
         return "Shared ownership";
     }
-    if (
-        tenure === "I live for free in a home" ||
-        tenure === "I do not have a stable home at the moment" ||
-        tenure === "Other"
-    ) {
-        return "Other";
-    }
-    return tenure || "Other";
+    return "Other";
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.0",
         "airtable": "^0.12.2",
-        "chart.js": "^4.4.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv-cli": "^8.0.0",
@@ -39,7 +38,6 @@
         "tailwindcss-animate": "^1.0.7",
         "ts-node": "^10.9.2",
         "unist-util-visit": "^5.0.0",
-        "vaul": "^1.1.2",
         "zod": "^3.25.56"
       },
       "devDependencies": {
@@ -2878,11 +2876,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
@@ -6651,18 +6644,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
-      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -17819,19 +17800,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/vaul": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
-      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-dialog": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.0",
     "airtable": "^0.12.2",
-    "chart.js": "^4.4.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv-cli": "^8.0.0",
@@ -58,7 +57,6 @@
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.9.2",
     "unist-util-visit": "^5.0.0",
-    "vaul": "^1.1.2",
     "zod": "^3.25.56"
   },
   "devDependencies": {


### PR DESCRIPTION
- New `TenureSelector.tsx` component in `survey/`
- Updates in aggregation (in `utils.tsx` and `types.tsx`) because previous `housingOutcomes` data shape / graph showed them aggregated across tenures, rather than split by current tenure
- Updates `SurveyGraphCard` to take optional `action` prop (where `TenureSelector` can be passed)
- Styles (adds subtitle, removes x and y axis lines etc.)
- Limits results to 5

As per designs!

Before:
![image](https://github.com/user-attachments/assets/41a77cf1-a27e-4394-8c44-ab46b6f28f44)
After:
![Screenshot 2025-06-24 163152](https://github.com/user-attachments/assets/d02e8ca7-ef61-48e0-944d-10013f46a7a4)
