### PR TITLE
feat: new route for calculator results

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,13 @@
+"use client";
+import React, { useState } from "react";
 import CalculatorInput from "@components/custom/ui/CalculatorInput";
 import { ClipLoader } from "react-spinners";
 import { Suspense } from "react";
 import { Inter } from "next/font/google";
 import { Footer } from "@components/custom/ui/Footer";
 import { Header } from "@components/custom/ui/Header";
+import { FormFrontend } from "@/schemas/formSchema";
+import { useRouter } from "next/navigation";
 
 const inter = Inter({
   weight: ["500", "600", "700", "800"],
@@ -11,12 +15,45 @@ const inter = Inter({
 });
 
 export default function Home() {
+    const router = useRouter();
+    const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleSubmit = async (formData: FormFrontend) => {
+      try {
+        setError(null);
+        setIsSubmitting(true);
+
+        const stringParams: Record<string, string> = {
+          housePostcode: formData.housePostcode,
+          houseAge: formData.houseAge.toString(),
+          houseBedrooms: formData.houseBedrooms.toString(),
+          houseType: formData.houseType,
+          maintenanceLevel: formData.maintenanceLevel,
+          ...(formData.houseSize && { houseSize: formData.houseSize.toString() })
+        };
+
+        const params = new URLSearchParams(stringParams).toString();
+          router.push(`/results?${params}`);
+      } catch (err) {
+          console.error('Navigation error:', err);
+          setError('Unable to navigate to results. Please try again.');
+        } finally {
+          setIsSubmitting(false);
+      };
+    };
+
   return (
     <>
     <Header />
     <main className={inter.className}>
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4 mx-4">
+          {error}
+          </div>
+      )}
       <Suspense fallback={<ClipLoader />}>
-        <CalculatorInput />
+        <CalculatorInput onSubmit={handleSubmit} isLoading={isSubmitting} />
       </Suspense>
     </main>
     <Footer/>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, Suspense } from "react";
 import Dashboard from "@components/custom/ui/Dashboard";
 import { Header } from "@components/custom/ui/Header";
 import { Footer } from "@components/custom/ui/Footer";
@@ -13,7 +13,7 @@ import { Household } from "@models/Household";
 
 type View = "loading" | "dashboard";
 
-const ResultsPage = () => {
+const ResultsPageContent = () => {
     const [view, setView] = useState<View>("loading");
     const [data, setData] = useState<Household | null>(null);
 
@@ -55,8 +55,6 @@ const ResultsPage = () => {
     }, [params.toString()]); // re-run if params change
 
 return (
-    <>
-        <Header />
         <main>
             <div className="min-h-[70vh] flex items-center justify-center">
                 {view === "loading" && (
@@ -67,9 +65,17 @@ return (
                 )}
             </div>
         </main>
+    );
+};
+
+const ResultsPage = () => (
+    <>
+        <Header />
+        <Suspense fallback={<ClipLoader color="black" size={50} />}>
+            <ResultsPageContent />
+        </Suspense>
         <Footer />
     </>
-    );
-}
+);
 
 export default ResultsPage;

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import Dashboard from "@components/custom/ui/Dashboard";
+import { Header } from "@components/custom/ui/Header";
+import { Footer } from "@components/custom/ui/Footer";
+import ClipLoader from "react-spinners/ClipLoader"; 
+import { useSearchParams } from "next/navigation";
+import { FormFrontend } from "@schemas/formSchema";
+import { MaintenanceLevel } from "@models/constants";
+import { HouseType } from "@models/Property";
+import { useRouter } from "next/navigation";
+import { Household } from "@models/Household";
+
+type View = "loading" | "dashboard";
+
+const ResultsPage = () => {
+    const [view, setView] = useState<View>("loading");
+    const [data, setData] = useState<Household | null>(null);
+
+    const router = useRouter();
+    const params = useSearchParams();
+
+    const formObj: FormFrontend = {
+        housePostcode: (params.get("housePostcode") || ""),
+        houseAge: Number(params.get("houseAge") || 0),
+        houseBedrooms: Number(params.get("houseBedrooms") || 2),
+        houseType: (params.get("houseType") as HouseType || ""),
+        maintenanceLevel: params.get("maintenanceLevel") as MaintenanceLevel,
+        houseSize: params.get("houseSize") ? Number(params.get("houseSize")) : undefined,
+        };
+    if (formObj.housePostcode === "") { router.push("/") }
+
+    useEffect(() => {
+        if (!formObj.housePostcode) {
+            router.push("/");
+            return;
+        }
+        const fetchData = async () => {
+            setView("loading");
+            const response = await fetch("/api", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(formObj),
+            });
+            if (!response.ok) {
+                router.push("/");
+                return;
+            }
+            const processedData = await response.json();
+            setData(processedData);
+            setView("dashboard");
+        };
+        fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [params.toString()]); // re-run if params change
+
+return (
+    <>
+        <Header />
+        <main>
+            <div className="min-h-[70vh] flex items-center justify-center">
+                {view === "loading" && (
+                    <ClipLoader color="black" size={50} />
+                )}
+                {view === "dashboard" && data && (
+                    <Dashboard processedData={data} />
+                )}
+            </div>
+        </main>
+        <Footer />
+    </>
+    );
+}
+
+export default ResultsPage;

--- a/components/custom/ui/CalculatorInput.tsx
+++ b/components/custom/ui/CalculatorInput.tsx
@@ -1,9 +1,7 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Household } from "@/models/Household";
-import Dashboard from "./Dashboard";
 import { formSchema, FormFrontend } from "@/schemas/formSchema";
 import { useSearchParams } from "next/navigation";
 import {
@@ -15,7 +13,6 @@ import {
 import { MaintenanceLevel } from "@models/constants";
 
 import { RadioGroup, RadioGroupItem } from "@/components/radio-group";
-import { ClipLoader } from "react-spinners";
 import {
   Form,
   FormField,
@@ -27,18 +24,17 @@ import {
 import { Button } from "@/components/button";
 import { Input } from "@/components/input";
 import { Label } from "@/components/label";
-import { APIError } from "@/lib/calculator/exceptions";
 import { BackgroundAssumptions } from "./BackgroundAssumptions";
 import { MaintenanceExplainerDrawer } from "./MaintenanceExplainerDrawer";
 import InputDropdown from "./InputDropdown";
 import InputField from "./InputField";
 import { Separator } from "@/components/separator"
 
-type View = "form" | "loading" | "dashboard";
-
-const CalculatorInput = () => {
-  const [view, setView] = useState<View>("form");
-  const [data, setData] = useState<Household | null>(null);
+type CalculatorInputProps = {
+  onSubmit: (data: FormFrontend) => void;
+  isLoading?: boolean;
+};
+const CalculatorInput: React.FC<CalculatorInputProps> = ({ onSubmit, isLoading }) => {
 
   const searchParams = useSearchParams();
   const urlPostcode = searchParams.get("postcode");
@@ -83,39 +79,7 @@ const CalculatorInput = () => {
     },
   });
 
-  const onSubmit = async (data: FormFrontend) => {
-    setView("loading");
-    const response = await fetch("/api", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
-    });
-    const processedData = await response.json();
-    if (!response.ok) return handleErrors(processedData.error);
-
-    setData(processedData);
-    setView("dashboard");
-  };
-
-  const handleErrors = (error: APIError) => {
-    switch (error.code) {
-      case "ITL3_NOT_FOUND":
-      case "INSUFFICIENT_PRICES_PAID_DATA":
-        form.setError("housePostcode", {
-          message:
-            "Insufficient data for this postcode. Please try again with a different postcode.",
-        });
-        break;
-      case "UNHANDLED_EXCEPTION":
-      default:
-        console.error(error);
-    }
-
-    setView("form");
-  };
-
-  if (view === "form") {
-    return (
+  return(
       <div className="flex flex-col justify-center w-full md:w-2/3 mx-auto px-10">
         <div className="h1-style text-lg md:text-xl lg:text-2xl">
           Calculate how much a Fairhold home might cost you
@@ -408,6 +372,7 @@ const CalculatorInput = () => {
             <Button
               type="submit"
               className="calculate-button-style px-10 md:px-20"
+              disabled={isLoading}
             >
               Calculate
             </Button>
@@ -418,19 +383,5 @@ const CalculatorInput = () => {
       </div>
     );
   }
-
-  if (view === "loading") { // TODO: should this conditional logic actually live in page.tsx and CalculatorInput.tsx is just the form UI?
-    return (
-      <div className="flex items-center justify-center h-screen text-black mt-5">
-        <ClipLoader color="black" size={50} />
-      </div>
-    );
-  }
-
-  if (view === "dashboard" && data) {
-    const formValues = form.getValues();
-    return <Dashboard processedData={data} inputData={formValues} />;
-  }
-};
 
 export default CalculatorInput;


### PR DESCRIPTION
This is a new version of #508 (closed because of messy rebase and to improve separation of concerns). 

# What does this PR do?
Creates a new route at /results for survey dashboard
Moves conditional rendering to /results/page.tsx (it probably shouldn't have been in CalculatorInput.tsx anyway!)

# Why?
We decided to create a new route for results so that if people hit 'back' to change any of their form inputs, they wouldn't get redirected to their previous non-Fairhold page / referrer.

# Questions
I was thinking about [Daf's comment here](https://github.com/theopensystemslab/fairhold-dashboard/pull/508#discussion_r2177813846) and wondered if maybe we would want to route people to `/results?housePostcode=abc123`--eg I want to share with my flatmates / partner what our home would cost if it was Fairhold, or similar. Thoughts? 

Closes #502 