### PR TITLE
style: missing survey results graph styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,7 @@
   --private-rent-land-color-rgb: 45 155 240;
   --private-rent-house-color-rgb: 119 188 242;
   --private-rent-detail-color-rgb: 203 225 242;
+  --shared-ownership-color-rgb: 149, 151, 202;
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
   --social-rent-detail-color-rgb: 242 196 202;

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -8,7 +8,7 @@ type Props = React.PropsWithChildren<{
 
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children }) => {
   return (
-    <div className="justify-center w-full bg-white m-4 p-4">
+    <div className="flex flex-1 flex-col justify-center h-full w-full bg-white m-4 p-4">
         <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`}>{title}</h3>
                 {(subtitle || action) && (
           <div className="flex items-center gap-4 mt-2">
@@ -16,7 +16,7 @@ const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children })
             {action}
           </div>
         )}      
-        {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
+        {children && <div className="mt-4 flex-1">{children}</div>}
     </div>
   );
 };

--- a/app/survey/components/SurveyGraphCard.tsx
+++ b/app/survey/components/SurveyGraphCard.tsx
@@ -3,14 +3,20 @@ import React from "react";
 type Props = React.PropsWithChildren<{
   title: string;
   subtitle?: React.ReactNode;
+  action?: React.ReactNode;
 }>;
 
-const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, children }) => {
+const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children }) => {
   return (
     <div className="justify-center w-full bg-white m-4 p-4">
         <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`}>{title}</h3>
-        {subtitle && <p className={`text-md md:text-lg text-gray-600 mt-2 font-normal`}>{subtitle}</p>}
-      {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
+                {(subtitle || action) && (
+          <div className="flex items-center gap-4 mt-2">
+            {subtitle && <p className="text-md text-gray-600 font-normal">{subtitle}</p>}
+            {action}
+          </div>
+        )}      
+        {children && <div className="mt-4 h-[calc(60vh-16rem)]">{children}</div>}
     </div>
   );
 };

--- a/app/survey/components/SurveyTenureSelector.tsx
+++ b/app/survey/components/SurveyTenureSelector.tsx
@@ -1,0 +1,29 @@
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+
+interface SurveyTenureSelectorProps {
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+  color: string;
+}
+
+const SurveyTenureSelector: React.FC<SurveyTenureSelectorProps> = ({ options, value, onChange, color }) => (
+  <div>
+    <label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-[180px]" style={{ color, border: 'none' }}>
+          <SelectValue placeholder="Select tenure" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map(option => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </label>
+  </div>
+);
+
+export default SurveyTenureSelector;

--- a/app/survey/components/graphs/AnyMeansTenureChoice.tsx
+++ b/app/survey/components/graphs/AnyMeansTenureChoice.tsx
@@ -1,20 +1,107 @@
 import React from "react"
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
-import { CustomSankey } from "../CustomSankey";
-import { ResponsiveContainer } from "recharts";
+import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer, Cell, LabelList } from "recharts";
 import { useSurveyContext } from "../../context";
+import { TENURE_COLORS } from "../../constants"
+import { CustomLabelListContentProps } from "@/app/components/graphs/shared";
+
+export interface CustomYTickProps {
+  x: number;
+  y: number;
+  payload: { value: string };
+  index?: number;
+}
+
+const RankLabel: React.FC<CustomLabelListContentProps> = ({ index, x, y }) => {
+    const rank = typeof index === "number" ? index + 1 : "";
+    return (
+        <text
+            x={Number(x) + 5}
+            y={Number(y) + 15}
+            fill="white"
+            fontSize={12}
+        >
+            {rank}
+        </text>
+    );
+};
+
+const ColoredYAxisTick: React.FC<CustomYTickProps> = ({ x, y, payload: { value: label }  }) => {
+    const answerStr = Array.isArray(label) ? label[0] : label;
+    return (
+        <text
+            x={x}
+            y={y + 5}
+            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+            fontSize={10}
+            textAnchor="end"
+        >
+            {answerStr}
+        </text>
+    );
+};
 
 export const AnyMeansTenureChoice = () => {
-    const anyMeansTenureChoice = useSurveyContext().sankey.anyMeansTenureChoice;
-    
+    const { anyMeansTenureChoice } = useSurveyContext().barOrPie;
     return (
-        <SurveyGraphCard title="What tenure would you choose?">
-            <ResponsiveContainer width="100%" height="100%">
-                <CustomSankey
-                    nodes={anyMeansTenureChoice.nodes}
-                    links={anyMeansTenureChoice.links}            >
-                </CustomSankey>
-            </ResponsiveContainer>
+        <SurveyGraphCard 
+            title="Rank the tenures by preference"
+            subtitle="If you could afford (and were eligible for) any type of home, which would you prefer?"
+            >
+          <ResponsiveContainer height={anyMeansTenureChoice.length * 30}>
+          <BarChart
+              data={anyMeansTenureChoice}
+              barSize={20}
+              barGap={0}
+              layout="vertical"
+          >
+              <XAxis 
+                  type="number"
+                  height={20}
+                  fontSize={10}
+                  interval={10}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={false}
+                  /> 
+              <YAxis 
+                  type="category"    
+                  dataKey="answer" 
+                  width={350} 
+                  fontSize={10}
+                  interval={0}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={(props) => (
+                    <ColoredYAxisTick 
+                    {...props}
+                    />
+                )}
+                  /> 
+              <Bar dataKey="value">
+                {anyMeansTenureChoice.map((entry, index) => {
+                    let answerStr = "";
+                    if (Array.isArray(entry.answer)) {
+                        answerStr = entry.answer[0] ?? "";
+                    } else if (typeof entry.answer === "string") {
+                        answerStr = entry.answer;
+                    }
+                    return (
+                        <Cell
+                            key={`cell-${index}`}
+                            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+                        />
+                    );
+                })}
+                <LabelList 
+                    dataKey="value"
+                    position="insideStart"
+                    fill="white"    
+                    content={RankLabel}
+                />
+                </Bar>  
+          </BarChart>
+          </ResponsiveContainer>
         </SurveyGraphCard>
     )
 }

--- a/app/survey/components/graphs/AnyMeansTenureChoice.tsx
+++ b/app/survey/components/graphs/AnyMeansTenureChoice.tsx
@@ -27,16 +27,15 @@ const RankLabel: React.FC<CustomLabelListContentProps> = ({ index, x, y }) => {
 };
 
 const ColoredYAxisTick: React.FC<CustomYTickProps> = ({ x, y, payload: { value: label }  }) => {
-    const answerStr = Array.isArray(label) ? label[0] : label;
     return (
         <text
             x={x}
             y={y + 5}
-            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+            fill={TENURE_COLORS[label] || "rgb(var(--text-inaccessible-rgb))"}
             fontSize={10}
             textAnchor="end"
         >
-            {answerStr}
+            {label}
         </text>
     );
 };
@@ -79,20 +78,14 @@ export const AnyMeansTenureChoice = () => {
                 )}
                   /> 
               <Bar dataKey="value">
-                {anyMeansTenureChoice.map((entry, index) => {
-                    let answerStr = "";
-                    if (Array.isArray(entry.answer)) {
-                        answerStr = entry.answer[0] ?? "";
-                    } else if (typeof entry.answer === "string") {
-                        answerStr = entry.answer;
-                    }
-                    return (
+                {
+                    anyMeansTenureChoice.map(({ answer }, index) => (
                         <Cell
                             key={`cell-${index}`}
-                            fill={TENURE_COLORS[answerStr] || "rgb(var(--text-inaccessible-rgb))"}
+                            fill={TENURE_COLORS[answer] || "rgb(var(--text-inaccessible-rgb))"}
                         />
-                    );
-                })}
+                    ))
+                }
                 <LabelList 
                     dataKey="value"
                     position="insideStart"

--- a/app/survey/components/graphs/HousingOutcomes.tsx
+++ b/app/survey/components/graphs/HousingOutcomes.tsx
@@ -1,11 +1,24 @@
-import React from "react"
+import React, { useState } from "react"
 import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
+import SurveyTenureSelector from "../SurveyTenureSelector";
+import { TENURE_COLORS } from "../../constants";
+import { getTopFive } from "../../utils";
 
 export const HousingOutcomes = () => {
     const housingOutcomes = useSurveyContext().barOrPie.housingOutcomes;
+    
+    // Get available tenure keys (we might not have all of them, eg if no shared ownership residents fill out the survey)
+    const tenureOptions = Object.keys(housingOutcomes);
+
+    const [selectedTenure, setSelectedTenure] = useState(
+        tenureOptions.length > 0 ? tenureOptions[0] : ""
+    );
+    const housingOutcomesTopFive = getTopFive(housingOutcomes[selectedTenure] || []);
+
+    const color = TENURE_COLORS[selectedTenure] || "rgb(var(--text-default-rgb))";
 
     const Tick = (props: TickProps) => {
         const { x, y, payload } = props;
@@ -16,7 +29,7 @@ export const HousingOutcomes = () => {
                 y={0} 
                 dy={4} 
                 textAnchor="end" 
-                fill="#333" 
+                fill={color} 
                 fontSize={10}
                 width={240}
             >
@@ -27,22 +40,43 @@ export const HousingOutcomes = () => {
     }
 
     return (
-        <SurveyGraphCard title="What do you most want from housing that you don't currently get?">
+        <SurveyGraphCard 
+            title="What do you most want from housing that you don't currently get?" 
+            subtitle="Showing top 10 responses for"
+            action={
+            <SurveyTenureSelector
+                options={tenureOptions}
+                value={selectedTenure}
+                onChange={setSelectedTenure}
+                color={color}
+            />
+            }  
+            >
+
             <ResponsiveContainer width="100%" height="100%">
                 <BarChart
-                    data={housingOutcomes}
+                    data={housingOutcomesTopFive}
                     barSize={20}
                     layout="vertical"
                 >
-                    <XAxis type="number" /> 
+                    <XAxis 
+                        type="number"
+                        tickLine={false}
+                        axisLine={false}
+                        tickCount={2}
+                        tickFormatter={(value: number) => Math.round(value).toString()}
+                        /> 
                     <YAxis 
                         type="category"    
                         dataKey="answer" 
                         width={350} 
                         fontSize={10}
                         interval={0}
-                        tick={Tick}/> 
-                    <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+                        tick={Tick}
+                        tickLine={false}
+                        axisLine={false}
+                        /> 
+                    <Bar dataKey="value" fill={color} /> 
                 </BarChart>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/app/survey/components/graphs/SupportDevelopmentFactors.tsx
+++ b/app/survey/components/graphs/SupportDevelopmentFactors.tsx
@@ -35,14 +35,23 @@ export const SupportDevelopmentFactors = () => {
                 height={480}
                 layout="vertical"
             >
-                <XAxis type="number" /> 
+                <XAxis 
+                  type="number" 
+                  tick={false}
+                  tickLine={false}
+                  axisLine={false}                  
+                /> 
                 <YAxis 
                     type="category"    
                     dataKey="answer" 
                     width={350} 
                     fontSize={10}
                     interval={0}
-                    tick={Tick}/> 
+                    tick={Tick}
+                    axisLine={false}
+                    tickLine={false}
+                    /> 
+                    
                 <Bar dataKey="value" fill="rgb(var(--fairhold-equity-color-rgb))" /> 
             </BarChart>
             </ResponsiveContainer>

--- a/app/survey/components/graphs/SupportDevelopmentFactors.tsx
+++ b/app/survey/components/graphs/SupportDevelopmentFactors.tsx
@@ -43,7 +43,7 @@ export const SupportDevelopmentFactors = () => {
                     fontSize={10}
                     interval={0}
                     tick={Tick}/> 
-                <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+                <Bar dataKey="value" fill="rgb(var(--fairhold-equity-color-rgb))" /> 
             </BarChart>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/app/survey/components/graphs/WhyFairhold.tsx
+++ b/app/survey/components/graphs/WhyFairhold.tsx
@@ -3,9 +3,12 @@ import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
+import { getTopFive } from "@/app/survey/utils";
 
 export const WhyFairhold = () => {
   const whyFairhold = useSurveyContext().barOrPie.whyFairhold;
+  const whyFairholdTopFive = getTopFive(whyFairhold);
+
   const Tick = (props: TickProps) => {
       const { x, y, payload } = props;
       return (
@@ -29,13 +32,15 @@ export const WhyFairhold = () => {
       <SurveyGraphCard title="Why would you choose Fairhold?">
           <ResponsiveContainer>
           <BarChart
-              data={whyFairhold}
+              data={whyFairholdTopFive}
               barSize={20}
               layout="vertical"
           >
               <XAxis 
                   type="number"
-                  hide={true}
+                  tickLine={false}
+                  axisLine={false}
+                  tickCount={2}
                   /> 
               <YAxis 
                   type="category"    
@@ -43,8 +48,10 @@ export const WhyFairhold = () => {
                   width={350} 
                   fontSize={10}
                   interval={0}
+                  tickLine={false}
+                  axisLine={false}
                   tick={Tick}/> 
-              <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
+              <Bar dataKey="value" fill="rgb(var(--fairhold-equity-color-rgb))" /> 
           </BarChart>
           </ResponsiveContainer>
       </SurveyGraphCard>

--- a/app/survey/components/graphs/WhyNotFairhold.tsx
+++ b/app/survey/components/graphs/WhyNotFairhold.tsx
@@ -3,9 +3,11 @@ import { TickProps } from "@/app/survey/types";
 import SurveyGraphCard from "@/app/survey/components/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "../../context";
+import { getTopFive } from "@/app/survey/utils";
 
 export const WhyNotFairhold = () => {
   const whyNotFairhold = useSurveyContext().barOrPie.whyNotFairhold;
+  const whyNotFairholdTopFive = getTopFive(whyNotFairhold);
 
   const Tick = (props: TickProps) => {
       const { x, y, payload } = props;
@@ -30,13 +32,15 @@ export const WhyNotFairhold = () => {
       <SurveyGraphCard title="Why wouldn't you choose Fairhold?">
           <ResponsiveContainer>
           <BarChart
-              data={whyNotFairhold}
+              data={whyNotFairholdTopFive}
               barSize={20}
               layout="vertical"
           >
               <XAxis 
                   type="number" 
-                  hide={true}
+                  tickLine={false}
+                  axisLine={false}
+                  tickCount={2}
                   /> 
               <YAxis 
                   type="category"    
@@ -44,6 +48,8 @@ export const WhyNotFairhold = () => {
                   width={350} 
                   fontSize={10}
                   interval={0}
+                  tickLine={false}
+                  axisLine={false}
                   tick={Tick}/> 
               <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
           </BarChart>

--- a/app/survey/constants.tsx
+++ b/app/survey/constants.tsx
@@ -1,3 +1,11 @@
+export const TENURE_COLORS: Record<string, string> = {
+    "Social rent": "rgb(var(--social-rent-land-color-rgb))",
+    "Shared ownership": "rgb(var(--shared-ownership-color-rgb))",
+    "Private rent": "rgb(var(--private-rent-land-color-rgb))",
+    "Market purchase": "rgb(var(--freehold-equity-color-rgb))",
+    "Fairhold": "rgb(var(--fairhold-equity-color-rgb))"
+};
+
 export const AGE_ORDER = [
   "0-18",
   "19-24",

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -81,7 +81,7 @@ export default function SurveyPage() {
                     
                     <div className="flex flex-col py-4">
                       <h3 className="text-xl font-medium">Who has responded?</h3>
-                      <div className="flex flex-col md:flex-row h-240 p-4">
+                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
                         <Country />
                         <Age />
                         {/* <Postcode {...results} /> */}
@@ -90,22 +90,22 @@ export default function SurveyPage() {
 
                     <div className="flex flex-col">
                       <h3 className="text-xl font-medium">Housing preferences</h3>
-                      <div className="flex flex-col md:flex-row w-full h-240 p-4">
+                      <div className="flex flex-col md:flex-row w-full md:h-[30rem] p-4">
                         <IdealHouseType />
                         <IdealLiveWith />
                       </div>
-                      <div className="flex flex-col md:flex-row h-240 p-4">
+                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
                         <HousingOutcomes />
                         <AffordFairhold />
                       </div>
-                      <div className="flex flex-col md:flex-row h-240 p-4">
+                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
                         <CurrentMeansTenureChoice />
                       </div>
-                      <div className="flex flex-col md:flex-row h-240 p-4">
+                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
                         <WhyFairhold />
                         <WhyNotFairhold />
                       </div>
-                      <div className="flex flex-col md:flex-row  h-240 p-4">
+                      <div className="flex flex-col md:flex-row  md:h-[30rem] p-4">
                         <div className="md:w-1/2 w-full mr-4">
                           <AnyMeansTenureChoice />
                         </div>
@@ -116,11 +116,15 @@ export default function SurveyPage() {
                     <div className="flex flex-col">
                       <h3 className="text-xl font-medium">Attitudes towards development</h3>
                       <div className="flex flex-col md:flex-row w-full md:gap-8 p-4">
-                        <div className="flex flex-col md:w-1/2 w-full h-480">
-                          <SupportDevelopment />
-                          <SupportNewFairhold />
+                        <div className="flex flex-col md:w-1/2 w-full md:h-[60rem]">
+                          <div className="flex-1 flex flex-col"> 
+                            <SupportDevelopment />
+                          </div>
+                          <div className="flex-1 flex flex-col">
+                            <SupportNewFairhold />
+                          </div>
                         </div>
-                        <div className="flex flex-col md:flex-row md:w-1/2 w-full h-480">
+                        <div className="flex flex-col md:flex-row md:w-1/2 w-full md:h-[60rem]">
                           <SupportDevelopmentFactors />
                         </div>
                       </div>

--- a/app/survey/types.tsx
+++ b/app/survey/types.tsx
@@ -36,10 +36,13 @@ type ExcludedRawResults =
 
 type ResultKeys = Exclude<keyof RawResults, ExcludedRawResults>;
 
+export type ResultGroupedByTenure = Record<string, BarOrPieResult[]>
+
+// Mapped type to link input key without output shape
 export type BarOrPieResults = {
-    [K in ResultKeys]: K extends "housingOutcomes"
-        ? Record<string, BarOrPieResult[]>
-        : BarOrPieResult[];
+    [K in ResultKeys]:
+        K extends "housingOutcomes" ? ResultGroupedByTenure :
+        BarOrPieResult[];
 };
 
 export type BarOrPieResult = {

--- a/app/survey/types.tsx
+++ b/app/survey/types.tsx
@@ -24,28 +24,33 @@ export type RawResults = {
     supportNewFairhold: string;
 };
 
-export type BarOrPieResults = Record<Exclude<keyof RawResults, 
-    'id' | 
-    'houseType' | 
-    'idealHouseType' | 
-    'liveWith' | 
-    'idealLiveWith' | 
-    'currentTenure' | 
-    'currentMeansTenureChoice' | 
-    'anyMeansTenureChoice'
-    >, 
-    BarOrPieResult[]>
+// These are excluded because they are either not relevant (eg id) or will be formatted separately to bar / pie results (eg houseType, idealHouseType)
+type ExcludedRawResults =
+    | "id"
+    | "houseType"
+    | "idealHouseType"
+    | "liveWith"
+    | "idealLiveWith"
+    | "currentTenure"
+    | "currentMeansTenureChoice";
+
+type ResultKeys = Exclude<keyof RawResults, ExcludedRawResults>;
+
+export type BarOrPieResults = {
+    [K in ResultKeys]: K extends "housingOutcomes"
+        ? Record<string, BarOrPieResult[]>
+        : BarOrPieResult[];
+};
 
 export type BarOrPieResult = {
-    answer: string | string[] | undefined;
+    answer: string;
     value: number;
 }
 
 export type SankeyResults = Record<Extract<keyof RawResults, 
     'idealHouseType' | 
     'idealLiveWith' | 
-    'currentMeansTenureChoice' | 
-    'anyMeansTenureChoice'
+    'currentMeansTenureChoice'
     >, 
     SankeyResult>
 

--- a/app/survey/utils.tsx
+++ b/app/survey/utils.tsx
@@ -90,7 +90,7 @@ const addBarOrPieResult = (results: BarOrPieResults, rawResult: RawResults) => {
 
         // We handle anyMeansTenureChoice differently because it's ranked choice, and each rank has a points-based weight
         if (validKey === "anyMeansTenureChoice") { 
-            handleAnyMeansTenureChoice(results, value);
+            handleAnyMeansTenureChoice(results, value as string[]);
             return;
         }
 
@@ -209,15 +209,13 @@ const addResultItem = (arr: BarOrPieResult[], item: string, weight: number = 1) 
         : arr.push({ answer: item, value: 1 });
 };
 
-const handleAnyMeansTenureChoice = (results: BarOrPieResults, value: unknown) => {
-    if (Array.isArray(value)) {
-        value.forEach((item, idx) => {
-            // Tidying the string
-            let shortAnswer = item.split("––")[0].trim();
-            shortAnswer = shortAnswer.replace("Freehold", "Market purchase");
-            // For now: 5 weight for position 1, 4 for position 2, etc.
-            const weight = Math.max(5 - idx, 1);
-            addResultItem(results.anyMeansTenureChoice, shortAnswer, weight);
-        });
-    }
+const handleAnyMeansTenureChoice = (results: BarOrPieResults, value: string[]) => {
+    value.forEach((item, idx) => {
+        // Tidying the string
+        let shortAnswer = item.split("––")[0].trim();
+        shortAnswer = shortAnswer.replace("Freehold", "Market purchase");
+        // For now: 5 weight for position 1, 4 for position 2, etc.
+        const weight = Math.max(5 - idx, 1);
+        addResultItem(results.anyMeansTenureChoice, shortAnswer, weight);
+    });
 };

--- a/app/survey/utils.tsx
+++ b/app/survey/utils.tsx
@@ -1,4 +1,4 @@
-import { RawResults, BarOrPieResults, SankeyResults, SankeyResult } from "./types"
+import { RawResults, BarOrPieResults, BarOrPieResult, SankeyResults, SankeyResult } from "./types"
 import {
   AFFORD_FAIRHOLD,
   AGE_ORDER,
@@ -10,7 +10,6 @@ const SANKEY_MAPPINGS = [
   { fromKey: 'houseType', toKey: 'idealHouseType', newKey: 'idealHouseType', isArray: false },
   { fromKey: 'liveWith', toKey: 'idealLiveWith', newKey: 'idealLiveWith', isArray: false },
   { fromKey: 'currentTenure', toKey: 'currentMeansTenureChoice', newKey: 'currentMeansTenureChoice', isArray: false },
-  { fromKey: 'currentTenure', toKey: 'anyMeansTenureChoice', newKey: 'anyMeansTenureChoice', isArray: true }
 ];
 
 const CUSTOM_ORDERS: Record<string, string[]> = {
@@ -45,6 +44,11 @@ export const aggregateResults = (rawResults: RawResults[]) => {
             }
         }
     });
+
+    Object.values(barOrPie.housingOutcomes).forEach((arr) => {
+        arr.sort((a, b) => b.value - a.value);
+    });
+
     return { numberResponses, barOrPie, sankey };
 }
 
@@ -54,10 +58,11 @@ const initializeBarOrPieResultsObject = (): BarOrPieResults => {
         nonUk: [],
         postcode: [],
         ageGroup: [],
+        anyMeansTenureChoice: [],
         ownershipModel: [],
         rentalModel: [],
         secondHomes: [],
-        housingOutcomes: [],
+        housingOutcomes: {},
         fairholdCalculator: [],
         affordFairhold: [],
         whyFairhold: [],
@@ -72,32 +77,35 @@ const initializeSankeyResultsObject = (): SankeyResults => {
     return {
         idealHouseType: { nodes: [], links: [] },
         idealLiveWith: { nodes: [], links: [] },
-        currentMeansTenureChoice: { nodes: [], links: [] },
-        anyMeansTenureChoice: { nodes: [], links: [] },
+        currentMeansTenureChoice: { nodes: [], links: [] }
     } as SankeyResults;
 };
 
 const addBarOrPieResult = (results: BarOrPieResults, rawResult: RawResults) => {
-    const getExistingResult = (key: keyof BarOrPieResults, answer: string) => 
-        results[key].find(result => result.answer === answer);
-
-    const addResultItem = (key: keyof BarOrPieResults, item: string) => {
-        const existingResult = getExistingResult(key, item);
-        existingResult
-            ? existingResult.value++
-            : results[key].push({ answer: item, value: 1 });
-    };
 
     Object.entries(rawResult).forEach(([key, value]) => {
         if (key === "id" || !(key in results)) return;
 
         const validKey = key as keyof BarOrPieResults;
-        
-        const isMultipleChoiceAnswer = Array.isArray(value);
-        
-        isMultipleChoiceAnswer
-            ? value.forEach(item => addResultItem(validKey, item))
-            : addResultItem(validKey, value);
+
+        // We handle anyMeansTenureChoice differently because it's ranked choice, and each rank has a points-based weight
+        if (validKey === "anyMeansTenureChoice") { 
+            handleAnyMeansTenureChoice(results, value);
+            return;
+        }
+
+        if (validKey === "housingOutcomes") {
+            handleHousingOutcomes(results, value, rawResult.currentTenure);
+            return;
+        }
+
+        if (Array.isArray(results[validKey])) {
+            const arr = results[validKey] as BarOrPieResult[];
+            const isMultipleChoiceAnswer = Array.isArray(value);
+            isMultipleChoiceAnswer
+                ? value.forEach(item => addResultItem(arr, item))
+                : addResultItem(arr, value);
+        }
     });
 };
 
@@ -147,5 +155,69 @@ const updateSankeyNodesAndLinks = (
         existingLink.value++;
     } else {
         links.push({ source: sourceIndex, target: targetIndex, value: 1 });
+    }
+};
+
+export const getTopFive = (data: BarOrPieResult[]) => data.slice(0,5);
+
+export const calculateChartMaximum = (data: BarOrPieResult[]) => {
+    const maxValue = data[0]?.value ?? 0;
+    const maxResponses = Math.ceil(maxValue / 10) * 10;
+    const chartMax = maxResponses < 10 ? 10 : maxResponses;
+    return chartMax;
+}
+
+const mapTenureCategory = (tenure: string): string => {
+    tenure = tenure.trim();
+
+    switch (tenure) {
+    case "I own it outright":
+        return "Market purchase";
+    case "I own it with a mortgage":
+        return "Market purchase";
+    case "I rent it":
+        return "Private rent";
+    case "Part own, part rent":
+        return "Shared ownership";
+    }
+    return "Other";
+};
+
+const handleHousingOutcomes = (
+    results: BarOrPieResults,
+    value: unknown,
+    currentTenure: string
+) => {
+    const tenure = mapTenureCategory(currentTenure || "Unknown");
+    if (!results.housingOutcomes[tenure]) {
+        results.housingOutcomes[tenure] = [];
+    }
+    if (Array.isArray(value)) {
+        value.forEach(item =>
+            addResultItem(results.housingOutcomes[tenure], item)
+        );
+    }
+};
+
+const getExistingResult = (arr: BarOrPieResult[], answer: string) =>
+    arr.find((result) => result.answer === answer);
+
+const addResultItem = (arr: BarOrPieResult[], item: string, weight: number = 1) => {
+    const existingResult = getExistingResult(arr, item);
+    existingResult
+        ? existingResult.value += weight
+        : arr.push({ answer: item, value: 1 });
+};
+
+const handleAnyMeansTenureChoice = (results: BarOrPieResults, value: unknown) => {
+    if (Array.isArray(value)) {
+        value.forEach((item, idx) => {
+            // Tidying the string
+            let shortAnswer = item.split("––")[0].trim();
+            shortAnswer = shortAnswer.replace("Freehold", "Market purchase");
+            // For now: 5 weight for position 1, 4 for position 2, etc.
+            const weight = Math.max(5 - idx, 1);
+            addResultItem(results.anyMeansTenureChoice, shortAnswer, weight);
+        });
     }
 };


### PR DESCRIPTION
I'm not sure how but when merging #545, #544, #543, #542 and #541 last week somehow a bunch of changes didn't make it in.  Adding the styles back in here! 

# What does this PR do?
Changes to:
**Housing outcomes**
- New `SurveyTenureSelector` component
- Passes optional `action` to `SurveyGraphCard` for `SurveyTenureSelector`
- Updates type and `handleHousingOutcomes` to aggregate results by current tenure
- Coloured styling

**Why Fairhold / Why Not Fairhold**
- Axes and colour styling
- `getTopFive` util function to show top five results each 

**Ranked tenure choice**
- Bar not sankey
- Aggregation through weight 
- Custom colours and label 

**Support development factors**
- Axes, colour & height styling 