### PR TITLE
style: fix footer margin

### DIFF
--- a/app/components/ui/Footer.tsx
+++ b/app/components/ui/Footer.tsx
@@ -3,7 +3,7 @@ import "./../../webflow.css";
 import Image from "next/image";
 
 export const Footer: React.FC = () => (
-  <footer className="footer mt-5">
+  <footer className="footer">
     <div className="w-layout-blockcontainer container w-container">
       <div className="columns w-row">
         <div className="column-6 w-col w-col-3"><a href="#" className="footer-link-block w-inline-block">

--- a/app/globals.css
+++ b/app/globals.css
@@ -177,6 +177,10 @@ main {
   background: #f2f2f0;
 }
 
+.main-content {
+  padding-bottom: 2rem;
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .scrollbar-hide::-webkit-scrollbar {
   display: none;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
   return (
     <>
     <Header />
-    <main className={inter.className}>
+    <main className={`${inter.className} main-content`}>
       <Suspense fallback={<ClipLoader />}>
         <CalculatorInput />
       </Suspense>

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -65,7 +65,7 @@ export default function SurveyPage() {
     <ErrorBoundary>
       <Header />
         <SurveyContext.Provider value={surveyResults}>
-          <main className={`${inter.className} min-h-screen w-full bg-[rgb(var(--background-end-rgb))]`}>
+          <main className={`${inter.className} main-content min-h-screen w-full bg-[rgb(var(--background-end-rgb))]`}>
             <div className="flex flex-row">
               <div className="hidden md:block w-1/4"></div>
 


### PR DESCRIPTION
Footer had a `mt-4` that was causing a band of white in between main and footer. Removes that and adds padding to a new `main-content` class. 

Before:
<img width="2811" height="1233" alt="Screenshot 2025-07-11 143745" src="https://github.com/user-attachments/assets/6ad31b53-5f06-42c0-b725-da75014733c7" />

After:
<img width="2791" height="912" alt="Screenshot 2025-07-11 143800" src="https://github.com/user-attachments/assets/12b9e5ad-1f7a-42b2-87cc-2b1e47ccb2e6" />

<img width="2802" height="806" alt="Screenshot 2025-07-11 143852" src="https://github.com/user-attachments/assets/a2c91360-c782-476f-8bf4-8296f29c44ab" />
