### PR TITLE
style: add colours and labels to sankeys

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,13 +22,15 @@
   --fairhold-equity-color-rgb: 74 179 91;
   --fairhold-interest-color-rgb: 159 211 166;
   --fairhold-detail-color-rgb: 207 227 209;
-  --private-rent-land-color-rgb: 45 155 240;
+  --leasehold-color-rgb: 29, 112, 184, 0.8; /* some colours / tenures are only used in the survey results, not the calculator results--so we only have one version of them */
+  --private-rent-land-color-rgb: 45 155 240; 
   --private-rent-house-color-rgb: 119 188 242;
   --private-rent-detail-color-rgb: 203 225 242;
   --shared-ownership-color-rgb: 149, 151, 202;
   --social-rent-land-color-rgb: 255 97 118;
   --social-rent-house-color-rgb: 242 160 171;
   --social-rent-detail-color-rgb: 242 196 202;
+  --affordable-rent-color-rgb: 255, 97, 118, 0.8;
   --error-text-rgb: 181 31 20;
   --not-viable-light-color-rgb: 251 164 164;
   --not-viable-dark-color-rgb: 255 0 0;

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -92,7 +92,7 @@ export default function SurveyPage() {
                         <HousingOutcomes />
                         <AffordFairhold />
                       </div>
-                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
+                      <div className="flex flex-col md:flex-row md:h-[50rem] p-4">
                         <CurrentMeansTenureChoice />
                       </div>
                       <div className="flex flex-col md:flex-row md:h-[30rem] p-4">

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -84,7 +84,7 @@ export default function SurveyPage() {
 
                     <div className="flex flex-col">
                       <h3 className="text-xl font-medium">Housing preferences</h3>
-                      <div className="flex flex-col md:flex-row w-full md:h-[30rem] p-4">
+                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
                         <IdealHouseType />
                         <IdealLiveWith />
                       </div>

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -9,6 +9,7 @@ type CustomNodeProps = {
     height: number;
     index: number;
     payload: NodePayload;
+    color?: string;
 }
 
 type NodePayload = {
@@ -77,13 +78,15 @@ type SankeyProps = {
     links: Array<{source: number, target: number, value: number}>;
     leftLabel?: string;
     rightLabel?: string;
+    color?: string;
 };
 
 export const CustomSankey: React.FC<SankeyProps> = ({ 
     nodes, 
     links,
     leftLabel,
-    rightLabel
+    rightLabel,
+    color
 }) => {
 
     // Custom Node Component with Label 
@@ -93,7 +96,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
             <g> 
                 <Rectangle 
                     {...props} 
-                    fill={"rgb(var(--fairhold-equity-color-rgb))"} 
+                    fill={color || "rgb(var(--fairhold-equity-color-rgb))"} 
                 /> 
                 <text 
                     x={isLeft ? props.x - 80 : props.x + props.width + 80}
@@ -122,7 +125,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                 <path 
                     d={`M${sourceX},${sourceY}C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`} 
                     fill="none" 
-                    stroke={"rgb(var(--fairhold-equity-color-rgb))"} 
+                    stroke={color || "rgb(var(--fairhold-equity-color-rgb))"} 
                     strokeOpacity={0.5} 
                     strokeWidth={linkWidth} 
                 /> 

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -24,6 +24,7 @@ type NodePayload = {
     dx: number;
     y: number;
     dy: number;
+    color?: string;
 }
 
 type CustomLinkProps = {
@@ -41,52 +42,28 @@ type CustomLinkProps = {
 }
 
 type CustomLinkPayload = {
-    source: {
-        name: string;
-        sourceNodes: [];
-        sourceLinks: [];
-        targetLinks: [];
-        targetNodes: [];
-        value: number;
-        depth: number;
-        x: number;
-        dx: number;
-        y: number;
-        dy: number;
-    },
-    target: {
-        name: string;
-        sourceNodes: [];
-        sourceLinks: [];
-        targetLinks: [];
-        targetNodes: [];
-        value: number;
-        depth: number;
-        x: number;
-        dx: number;
-        y: number;
-        dy: number;
-    },
+    source: NodePayload & { color?: string };
+    target: NodePayload & { color?: string };
     value: number;
     dy: number;
     sy: number;
     ty: number;
+    sourceColor?: string;
+    targetColor?: string;
 }
 
 type SankeyProps = {
-    nodes: Array<{name: string}>;
+    nodes: Array<{name: string, color?: string}>;
     links: Array<{source: number, target: number, value: number}>;
     leftLabel?: string;
     rightLabel?: string;
-    color?: string;
 };
 
 export const CustomSankey: React.FC<SankeyProps> = ({ 
     nodes, 
     links,
     leftLabel,
-    rightLabel,
-    color
+    rightLabel
 }) => {
 
     // Custom Node Component with Label 
@@ -96,7 +73,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
             <g> 
                 <Rectangle 
                     {...props} 
-                    fill={color || "rgb(var(--fairhold-equity-color-rgb))"} 
+                    fill={props.payload.color || "rgb(var(--fairhold-equity-color-rgb))"} 
                 /> 
                 <text 
                     x={isLeft ? props.x - 80 : props.x + props.width + 80}
@@ -114,7 +91,22 @@ export const CustomSankey: React.FC<SankeyProps> = ({
 
     // Custom Link Component with Label 
     const CustomLink = (props: CustomLinkProps) => { 
-        const { sourceX, targetX, sourceY, targetY, sourceControlX, targetControlX, linkWidth, payload } = props; 
+        const { 
+            sourceX, 
+            targetX, 
+            sourceY, 
+            targetY, 
+            sourceControlX, 
+            targetControlX, 
+            linkWidth, 
+            payload 
+        } = props; 
+        const sourceColor = payload.source.color || "rgb(var(--survey-grey-mid))";
+        const targetColor = payload.target.color || "rgb(var(--survey-grey-mid))";
+
+        const sourceLabel = payload.source.name.replace(/\s+/g, "-");
+        const targetLabel = payload.target.name.replace(/\s+/g, "-");
+        const gradientId = `link-gradient-${sourceLabel}-to-${targetLabel}`;
 
         // Calculate a midpoint for the label 
         const midX = (sourceX + targetX) / 2; 
@@ -122,10 +114,17 @@ export const CustomSankey: React.FC<SankeyProps> = ({
 
         return ( 
             <g> 
+                <defs>
+                    <linearGradient id={gradientId} gradientUnits="userSpaceOnUse"
+                        x1={sourceX} y1={sourceY} x2={targetX} y2={targetY}>
+                        <stop offset="0%" stopColor={sourceColor} />
+                        <stop offset="100%" stopColor={targetColor} />
+                    </linearGradient>
+                </defs>
                 <path 
                     d={`M${sourceX},${sourceY}C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`} 
                     fill="none" 
-                    stroke={color || "rgb(var(--fairhold-equity-color-rgb))"} 
+                    stroke={`url(#${gradientId})`}
                     strokeOpacity={0.5} 
                     strokeWidth={linkWidth} 
                 /> 

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -73,7 +73,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
             <g> 
                 <Rectangle 
                     {...props} 
-                    fill={props.payload.color || "rgb(var(--fairhold-equity-color-rgb))"} 
+                    fill={props.payload.color || "rgb(var(--survey-grey-mid))"} 
                 /> 
                 <text 
                     x={isLeft ? props.x - 80 : props.x + props.width + 80}

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -104,8 +104,9 @@ export const CustomSankey: React.FC<SankeyProps> = ({
         const sourceColor = payload.source.color || "rgb(var(--survey-grey-mid))";
         const targetColor = payload.target.color || "rgb(var(--survey-grey-mid))";
 
-        const sourceLabel = payload.source.name.replace(/\s+/g, "-");
-        const targetLabel = payload.target.name.replace(/\s+/g, "-");
+        const sanitize = (str: string) => str.replace(/[^a-zA-Z0-9-_]/g, "");
+        const sourceLabel = sanitize(payload.source.name.replace(/\s+/g, "-"));
+        const targetLabel = sanitize(payload.target.name.replace(/\s+/g, "-"));
         const gradientId = `link-gradient-${sourceLabel}-to-${targetLabel}`;
 
         // Calculate a midpoint for the label 
@@ -126,7 +127,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                     fill="none" 
                     stroke={`url(#${gradientId})`}
                     strokeOpacity={0.5} 
-                    strokeWidth={linkWidth} 
+                    strokeWidth={linkWidth}
                 /> 
                 {linkWidth > 5 && ( // Only show labels if link is wide enough 
                     <text 

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -75,12 +75,20 @@ type CustomLinkPayload = {
 type SankeyProps = {
     nodes: Array<{name: string}>;
     links: Array<{source: number, target: number, value: number}>;
+    leftLabel?: string;
+    rightLabel?: string;
 };
 
-export const CustomSankey: React.FC<SankeyProps> = ({ nodes, links }) => {
+export const CustomSankey: React.FC<SankeyProps> = ({ 
+    nodes, 
+    links,
+    leftLabel,
+    rightLabel
+}) => {
 
     // Custom Node Component with Label 
     const CustomNode = (props: CustomNodeProps) => { 
+        const isLeft = props.payload.depth === 0;
         return ( 
             <g> 
                 <Rectangle 
@@ -88,9 +96,9 @@ export const CustomSankey: React.FC<SankeyProps> = ({ nodes, links }) => {
                     fill={"rgb(var(--fairhold-equity-color-rgb))"} 
                 /> 
                 <text 
-                    x={props.x + props.width / 2} 
+                    x={isLeft ? props.x - 80 : props.x + props.width + 80}
                     y={props.y + props.height / 2} 
-                    textAnchor="middle" 
+                    textAnchor={props.payload.depth === 0 ? "start" : "end"}
                     dominantBaseline="middle" 
                     fill="rgb(var(--text-default-rgb))" 
                     fontSize={12} 
@@ -136,24 +144,45 @@ export const CustomSankey: React.FC<SankeyProps> = ({ nodes, links }) => {
     }; 
 
     return (
-        <ResponsiveContainer width="100%" height="100%">
-        <Sankey
-            data={{
-                nodes: nodes,
-                links: links
-            }}
-            node={CustomNode}
-            link={CustomLink}
-            nodePadding={50}
-            margin={{
-                left: 60,
-                right: 6e0,
-                top: 50,
-                bottom: 50,
-            }}
-        >
-            <Tooltip />
-        </Sankey>
-        </ResponsiveContainer> 
+        <div style={{ width: "100%", height: "100%", position: "relative" }}>
+            <div style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                width: "100%",
+                padding: "0 2rem 0 2rem",
+                position: "absolute",
+                top: 0,
+                left: 0,
+                pointerEvents: "none",
+                zIndex: 1,
+                height: 40
+            }}>
+                <span>{leftLabel}</span>
+                <span>{rightLabel}</span>
+            </div>
+            {/* Sankey chart below labels */}
+            <div style={{ width: "100%", height: "calc(100% - 40px)", marginTop: 40 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                    <Sankey
+                        data={{
+                            nodes: nodes,
+                            links: links
+                        }}
+                        node={CustomNode}
+                        link={CustomLink}
+                        nodePadding={50}
+                        margin={{
+                            left: 150,
+                            right: 100,
+                            top: 50,
+                            bottom: 50,
+                        }}
+                    >
+                        <Tooltip />
+                    </Sankey>
+                </ResponsiveContainer>
+            </div>
+        </div>
     )
 }

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -79,7 +79,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                 <text 
                     x={isLeft ? props.x - adjustmentFactor : props.x + props.width + adjustmentFactor}
                     y={props.y + props.height / 2} 
-                    textAnchor={props.payload.depth === 0 ? "start" : "end"}
+                    textAnchor={isLeft ? "start" : "end"}
                     dominantBaseline="middle" 
                     fill="rgb(var(--text-default-rgb))" 
                     fontSize={12} 

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -53,7 +53,7 @@ type CustomLinkPayload = {
 }
 
 type SankeyProps = {
-    nodes: Array<{name: string, color?: string}>;
+    nodes: Array<{name: string}>;
     links: Array<{source: number, target: number, value: number}>;
     leftLabel?: string;
     rightLabel?: string;
@@ -69,6 +69,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
     // Custom Node Component with Label 
     const CustomNode = (props: CustomNodeProps) => { 
         const isLeft = props.payload.depth === 0;
+        const adjustmentFactor = 80;
         return ( 
             <g> 
                 <Rectangle 
@@ -76,7 +77,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                     fill={props.payload.color || "rgb(var(--survey-grey-mid))"} 
                 /> 
                 <text 
-                    x={isLeft ? props.x - 80 : props.x + props.width + 80}
+                    x={isLeft ? props.x - adjustmentFactor : props.x + props.width + adjustmentFactor}
                     y={props.y + props.height / 2} 
                     textAnchor={props.payload.depth === 0 ? "start" : "end"}
                     dominantBaseline="middle" 
@@ -104,10 +105,10 @@ export const CustomSankey: React.FC<SankeyProps> = ({
         const sourceColor = payload.source.color || "rgb(var(--survey-grey-mid))";
         const targetColor = payload.target.color || "rgb(var(--survey-grey-mid))";
 
-        const sanitize = (str: string) => str.replace(/[^a-zA-Z0-9-_]/g, "");
+        const sanitize = (str: string) => str.replace(/[^a-zA-Z0-9-_]/g, ""); // handle special characters (eg for tenure like "I don't know")
         const sourceLabel = sanitize(payload.source.name.replace(/\s+/g, "-"));
         const targetLabel = sanitize(payload.target.name.replace(/\s+/g, "-"));
-        const gradientId = `link-gradient-${sourceLabel}-to-${targetLabel}`;
+        const gradientId = `link-gradient-${sourceLabel}-to-${targetLabel}`; // we need a unique ID
 
         // Calculate a midpoint for the label 
         const midX = (sourceX + targetX) / 2; 
@@ -164,7 +165,6 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                 <span>{leftLabel}</span>
                 <span>{rightLabel}</span>
             </div>
-            {/* Sankey chart below labels */}
             <div style={{ width: "100%", height: "calc(100% - 40px)", marginTop: 40 }}>
                 <ResponsiveContainer width="100%" height="100%">
                     <Sankey

--- a/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
@@ -5,14 +5,19 @@ import { ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 import { applyNodeColors } from "@lib/survey/utils";
 export const CurrentMeansTenureChoice = () => {
-    const currentMeansTenureChoice = useSurveyContext().sankey.currentMeansTenureChoice;
-    
-    const coloredNodes = applyNodeColors(currentMeansTenureChoice.nodes);
+    const { currentMeansTenureChoice } = useSurveyContext().sankey;
+    // We use suffixes to distinguish between current and ideal so we don't end up with circular links (eg for Freehold -> Freehold), so we need to remove the suffixes
+    let formattedNodes = currentMeansTenureChoice.nodes.map((node) => ({
+        ...node,
+        name: node.name.replace(/_(0|1)$/, ""),
+    }));
+    formattedNodes = applyNodeColors(formattedNodes);
+
     return (
         <SurveyGraphCard title="Which tenure would you choose?">
             <ResponsiveContainer width="100%" height="100%">
                 <CustomSankey
-                    nodes={coloredNodes}
+                    nodes={formattedNodes}
                     links={currentMeansTenureChoice.links}     
                     leftLabel="Current situation"
                     rightLabel="Ideal, with current means"   

--- a/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
@@ -12,7 +12,10 @@ export const CurrentMeansTenureChoice = () => {
             <ResponsiveContainer width="100%" height="100%">
                 <CustomSankey
                     nodes={currentMeansTenureChoice.nodes}
-                    links={currentMeansTenureChoice.links}            >
+                    links={currentMeansTenureChoice.links}     
+                    leftLabel="Current situation"
+                    rightLabel="Ideal, with current means"   
+                   >
                 </CustomSankey>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
@@ -3,15 +3,16 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey"
 import { ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
-
+import { applyNodeColors } from "@lib/survey/utils";
 export const CurrentMeansTenureChoice = () => {
     const currentMeansTenureChoice = useSurveyContext().sankey.currentMeansTenureChoice;
     
+    const coloredNodes = applyNodeColors(currentMeansTenureChoice.nodes);
     return (
         <SurveyGraphCard title="Could you afford a Fairhold home in your area?">
             <ResponsiveContainer width="100%" height="100%">
                 <CustomSankey
-                    nodes={currentMeansTenureChoice.nodes}
+                    nodes={coloredNodes}
                     links={currentMeansTenureChoice.links}     
                     leftLabel="Current situation"
                     rightLabel="Ideal, with current means"   

--- a/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
@@ -19,8 +19,8 @@ export const CurrentMeansTenureChoice = () => {
                 <CustomSankey
                     nodes={formattedNodes}
                     links={currentMeansTenureChoice.links}     
-                    leftLabel="Current situation"
-                    rightLabel="Ideal, with current means"   
+                    leftLabel="I live in"
+                    rightLabel="I want to live in"   
                    >
                 </CustomSankey>
             </ResponsiveContainer>

--- a/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
@@ -9,7 +9,7 @@ export const CurrentMeansTenureChoice = () => {
     
     const coloredNodes = applyNodeColors(currentMeansTenureChoice.nodes);
     return (
-        <SurveyGraphCard title="Could you afford a Fairhold home in your area?">
+        <SurveyGraphCard title="Which tenure would you choose?">
             <ResponsiveContainer width="100%" height="100%">
                 <CustomSankey
                     nodes={coloredNodes}

--- a/components/custom/survey/graphs/IdealHouseType.tsx
+++ b/components/custom/survey/graphs/IdealHouseType.tsx
@@ -12,8 +12,8 @@ export const IdealHouseType = () => {
             <CustomSankey
                 nodes={idealHouseType.nodes}
                 links={idealHouseType.links}       
-                leftLabel="Current"
-                rightLabel="Ideal"
+                leftLabel="I live in"
+                rightLabel="I want to live in"
                 >
             </CustomSankey>
         </SurveyGraphCard>

--- a/components/custom/survey/graphs/IdealHouseType.tsx
+++ b/components/custom/survey/graphs/IdealHouseType.tsx
@@ -16,7 +16,6 @@ export const IdealHouseType = () => {
                     links={idealHouseType.links}       
                     leftLabel="Current"
                     rightLabel="Ideal"
-                    color="rgb(var(--survey-grey-mid))"
                     >
                 </CustomSankey>
             </ResponsiveContainer>

--- a/components/custom/survey/graphs/IdealHouseType.tsx
+++ b/components/custom/survey/graphs/IdealHouseType.tsx
@@ -13,7 +13,10 @@ export const IdealHouseType = () => {
             <ResponsiveContainer>
                 <CustomSankey
                     nodes={idealHouseType.nodes}
-                    links={idealHouseType.links}            >
+                    links={idealHouseType.links}       
+                    leftLabel="Current"
+                    rightLabel="Ideal"
+                    >
                 </CustomSankey>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/components/custom/survey/graphs/IdealHouseType.tsx
+++ b/components/custom/survey/graphs/IdealHouseType.tsx
@@ -1,24 +1,21 @@
 import React from "react"
 import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey";
-import { ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 
 
 export const IdealHouseType = () => {
-    const idealHouseType = useSurveyContext().sankey.idealHouseType;
+    const { idealHouseType } = useSurveyContext().sankey;
     
     return (
         <SurveyGraphCard title="What type of home do you want to live in?">
-            <ResponsiveContainer>
-                <CustomSankey
-                    nodes={idealHouseType.nodes}
-                    links={idealHouseType.links}       
-                    leftLabel="Current"
-                    rightLabel="Ideal"
-                    >
-                </CustomSankey>
-            </ResponsiveContainer>
+            <CustomSankey
+                nodes={idealHouseType.nodes}
+                links={idealHouseType.links}       
+                leftLabel="Current"
+                rightLabel="Ideal"
+                >
+            </CustomSankey>
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/IdealHouseType.tsx
+++ b/components/custom/survey/graphs/IdealHouseType.tsx
@@ -16,6 +16,7 @@ export const IdealHouseType = () => {
                     links={idealHouseType.links}       
                     leftLabel="Current"
                     rightLabel="Ideal"
+                    color="rgb(var(--survey-grey-mid))"
                     >
                 </CustomSankey>
             </ResponsiveContainer>

--- a/components/custom/survey/graphs/IdealLiveWith.tsx
+++ b/components/custom/survey/graphs/IdealLiveWith.tsx
@@ -1,25 +1,22 @@
 import React from "react"
 import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey"
-import { ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 
 export const IdealLiveWith = () => {
-    const idealLiveWith = useSurveyContext().sankey.idealLiveWith;
+    const { idealLiveWith } = useSurveyContext().sankey;
     const color = "rgb(var(--fairhold-equity-color-rgb))";
     const coloredNodes = idealLiveWith.nodes.map((node) => ({...node, color}));
     
     return (
         <SurveyGraphCard title="Who do you want to live with?">
-            <ResponsiveContainer width="100%" height="100%">
-                <CustomSankey
-                    nodes={coloredNodes}
-                    links={idealLiveWith.links}     
-                    leftLabel="Current"
-                    rightLabel="Ideal" 
-                   >
-                </CustomSankey>
-            </ResponsiveContainer>
+            <CustomSankey
+                nodes={coloredNodes}
+                links={idealLiveWith.links}     
+                leftLabel="Current"
+                rightLabel="Ideal" 
+                >
+            </CustomSankey>
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/IdealLiveWith.tsx
+++ b/components/custom/survey/graphs/IdealLiveWith.tsx
@@ -13,8 +13,8 @@ export const IdealLiveWith = () => {
             <CustomSankey
                 nodes={coloredNodes}
                 links={idealLiveWith.links}     
-                leftLabel="Current"
-                rightLabel="Ideal" 
+                leftLabel="I live with"
+                rightLabel="I want to live with" 
                 >
             </CustomSankey>
         </SurveyGraphCard>

--- a/components/custom/survey/graphs/IdealLiveWith.tsx
+++ b/components/custom/survey/graphs/IdealLiveWith.tsx
@@ -6,12 +6,14 @@ import { useSurveyContext } from "@context/surveyContext";
 
 export const IdealLiveWith = () => {
     const idealLiveWith = useSurveyContext().sankey.idealLiveWith;
+    const color = "rgb(var(--fairhold-equity-color-rgb))";
+    const coloredNodes = idealLiveWith.nodes.map((node) => ({...node, color}));
     
     return (
         <SurveyGraphCard title="Who do you want to live with?">
             <ResponsiveContainer width="100%" height="100%">
                 <CustomSankey
-                    nodes={idealLiveWith.nodes}
+                    nodes={coloredNodes}
                     links={idealLiveWith.links}     
                     leftLabel="Current"
                     rightLabel="Ideal" 

--- a/components/custom/survey/graphs/IdealLiveWith.tsx
+++ b/components/custom/survey/graphs/IdealLiveWith.tsx
@@ -12,7 +12,10 @@ export const IdealLiveWith = () => {
             <ResponsiveContainer width="100%" height="100%">
                 <CustomSankey
                     nodes={idealLiveWith.nodes}
-                    links={idealLiveWith.links}            >
+                    links={idealLiveWith.links}     
+                    leftLabel="Current"
+                    rightLabel="Ideal" 
+                   >
                 </CustomSankey>
             </ResponsiveContainer>
         </SurveyGraphCard>

--- a/lib/survey/constants.tsx
+++ b/lib/survey/constants.tsx
@@ -113,3 +113,16 @@ export const LABEL_MAP: Record<string, { labels: Record<string, string>, default
   whyNotFairhold: { labels: WHY_NOT_FAIRHOLD_LABELS },
   supportDevelopmentFactors: { labels: SUPPORT_DEVELOPMENT_LABELS }
 };
+
+
+export const TENURE_CHOICE_COLOR_MAP: Record<string, string> = {
+  "Freehold": "rgb(var(--freehold-equity-color-rgb))",
+  "Leasehold": "rgb(var(--leasehold-color-rgb)))",
+  "Shared ownership": "rgb(var(--shared-ownership-color-rgb))",
+  "Affordable ownership": "rgb(var(--affordable-rent-color-rgb))",
+  "Market rent": "rgb(var(--private-rent-land-color-rgb))",
+  "Affordable rent": "rgb(var(--affordable-rent-color-rgb))",
+  "Fairhold": "rgb(var(--fairhold-land-rent-color-rgb))",
+  "Social rent": "rgb(var(--social-rent-land-color-rgb))",
+  "I don't know": "rgb(var(--survey-grey-mid))"
+};

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -314,14 +314,3 @@ export const applyNodeColors = (nodes: {name: string }[]) => {
         };
     });
 }
-
-export const applyLinkColors = (
-  links: { source: number; target: number; value: number }[],
-  nodes: { name: string; color?: string }[]
-) => {
-  return links.map(link => ({
-    ...link,
-    sourceColor: nodes[link.source]?.color || "rgb(var(--survey-grey-mid))",
-    targetColor: nodes[link.target]?.color || "rgb(var(--survey-grey-mid))"
-  }));
-};

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -111,10 +111,17 @@ const addSankeyResult = (results: SankeyResults, rawResult: RawResults) => {
 
         const sankeyResult = results[newKey as keyof SankeyResults];
 
-        if (isArray && Array.isArray(toValue) && toValue.length > 0) {
-            updateSankeyNodesAndLinks(sankeyResult, fromValue, toValue[0]);
+        // For currentMeansTenureChoice, distinguish left/right nodes
+        if (newKey === "currentMeansTenureChoice") {
+            const fromNode = fromValue + "_0";
+            const toNode = (toValue as string) + "_1";
+            updateSankeyNodesAndLinks(sankeyResult, fromNode, toNode);
         } else {
-            updateSankeyNodesAndLinks(sankeyResult, fromValue, toValue as string);
+            if (isArray && Array.isArray(toValue) && toValue.length > 0) {
+                updateSankeyNodesAndLinks(sankeyResult, fromValue, toValue[0]);
+            } else {
+                updateSankeyNodesAndLinks(sankeyResult, fromValue, toValue as string);
+            }
         }
     });
 };
@@ -298,10 +305,14 @@ const aggregateOther = (arr: BarOrPieResult[]): BarOrPieResult[] => {
 };
 
 export const applyNodeColors = (nodes: {name: string }[]) => {
-    return nodes.map(node => ({
-        ...node,
-        color: TENURE_CHOICE_COLOR_MAP[node.name] || "rgb(var(--survey-grey-mid))"
-    }))
+    return nodes.map(node => {
+        // Remove suffix for color lookup if present
+        const baseName = node.name.replace(/ \((current|ideal)\)$/i, "");
+        return {
+            ...node,
+            color: TENURE_CHOICE_COLOR_MAP[baseName] || "rgb(var(--survey-grey-mid))"
+        };
+    });
 }
 
 export const applyLinkColors = (

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -100,7 +100,7 @@ const addSankeyResult = (results: SankeyResults, rawResult: RawResults) => {
 
         // We want to show a more granular version of current tenure for this graph, so 'from' value should be either ownershipModel or rentalModel
         if (newKey === "currentMeansTenureChoice") {
-            fromValue = rawResult.ownershipModel ?? rawResult.rentalModel;
+           fromValue = rawResult.ownershipModel ?? rawResult.rentalModel ?? rawResult.currentTenure;
         } else {
             fromValue = rawResult[fromKey as keyof RawResults] as string;
         }


### PR DESCRIPTION
# What does this PR do?
- Adds colours for all tenure options to `globals.css`
- Enable color props in `CustomSankey` nodes and links
- Add left and right labels to `SankeyProps`
- Adjusts data aggregation for `currentMeansTenureChoice`
    - Accesses optional properties `rentalModel` and `ownershipModel` for granular tenure options (decided in roadmap that we wanted to show eg freehold or leasehold, not just ownership)
    - Adds suffixes here for current and ideal (`_0` and `_1` respectively, to avoid circular loop in case of Freehold -> Freehold)
    - New `applyNodeColors` util function for mapping tenures to colors
- Replace suffixes in `CurrentMeansTenureChoice` labels
- Some minor style adjustments & tidying up

# Why?
As per designs!

Now we have:
<img width="2111" height="816" alt="Screenshot 2025-07-15 153651" src="https://github.com/user-attachments/assets/203ee58b-8c5e-4d16-97ff-f7e37455eb48" />
<img width="2132" height="1205" alt="Screenshot 2025-07-15 153705" src="https://github.com/user-attachments/assets/ed2390fb-e1f2-4417-85c9-2758595417a3" />

Closes #555 and #556