### PR TITLE
fix: CostOverTime width

### DIFF
--- a/app/components/Dashboard/Cards/CostOverTime.tsx
+++ b/app/components/Dashboard/Cards/CostOverTime.tsx
@@ -75,7 +75,7 @@ export const CostOverTime: React.FC<DashboardProps> = ({ processedData }) => {
         </span>
       }
       >
-      <div className="flex flex-col h-full w-full md:w-3/4 justify-between">
+      <div className="flex flex-col h-full w-full justify-between">
         <div className="flex gap-2 mb-4">
             <div className="block md:hidden w-full">
               <TenureSelectorMobile


### PR DESCRIPTION
Small fix--`CostOverTime` was `md:w-3/4` when all the other graphs were full width! 

Closes #577 