### PR TITLE
feat: new route for calculator results v3

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,53 @@
+"use client";
+import React, { useState } from "react";
 import CalculatorInput from "../components/custom/ui/CalculatorInput";
 import { ClipLoader } from "react-spinners";
 import { Suspense } from "react";
 import { Footer } from "../components/custom/ui/Footer";
 import { Header } from "../components/custom/ui/Header";
+import { FormFrontend } from "@/schemas/formSchema";
+import { useRouter } from "next/navigation";
 
 export default function Home() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (formData: FormFrontend) => {
+    try {
+      setError(null);
+      setIsSubmitting(true);
+
+      const stringParams: Record<string, string> = {
+        housePostcode: formData.housePostcode,
+        houseAge: formData.houseAge.toString(),
+        houseBedrooms: formData.houseBedrooms.toString(),
+        houseType: formData.houseType,
+        maintenanceLevel: formData.maintenanceLevel,
+        ...(formData.houseSize && { houseSize: formData.houseSize.toString() })
+      };
+
+      const params = new URLSearchParams(stringParams).toString();
+        router.push(`/results?${params}`);
+    } catch (err) {
+        console.error('Navigation error:', err);
+        setError('Unable to navigate to results. Please try again.');
+      } finally {
+        setIsSubmitting(false);
+    };
+  };
+
   return (
     <>
     <Header />
     <main className="main-content">
+            {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4 mx-4">
+          {error}
+          </div>
+      )}
       <Suspense fallback={<ClipLoader />}>
-        <CalculatorInput />
+        <CalculatorInput onSubmit={handleSubmit} isLoading={isSubmitting} />
       </Suspense>
     </main>
     <Footer/>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+import React, { useEffect, useState, Suspense } from "react";
+import Dashboard from "@components/custom/ui/Dashboard";
+import { Header } from "@components/custom/ui/Header";
+import { Footer } from "@components/custom/ui/Footer";
+import ClipLoader from "react-spinners/ClipLoader"; 
+import { useSearchParams } from "next/navigation";
+import { FormFrontend } from "@schemas/formSchema";
+import { MaintenanceLevel } from "@models/constants";
+import { HouseType } from "@models/Property";
+import { useRouter } from "next/navigation";
+import { Household } from "@models/Household";
+
+type View = "loading" | "dashboard";
+
+const ResultsPageContent = () => {
+    const [view, setView] = useState<View>("loading");
+    const [data, setData] = useState<Household | null>(null);
+
+    const router = useRouter();
+    const params = useSearchParams();
+
+    const formObj: FormFrontend = {
+        housePostcode: (params.get("housePostcode") || ""),
+        houseAge: Number(params.get("houseAge") || 0),
+        houseBedrooms: Number(params.get("houseBedrooms") || 2),
+        houseType: (params.get("houseType") as HouseType || ""),
+        maintenanceLevel: params.get("maintenanceLevel") as MaintenanceLevel,
+        houseSize: params.get("houseSize") ? Number(params.get("houseSize")) : undefined,
+        };
+    if (formObj.housePostcode === "") { router.push("/") }
+
+    useEffect(() => {
+        if (!formObj.housePostcode) {
+            router.push("/");
+            return;
+        }
+        const fetchData = async () => {
+            setView("loading");
+            const response = await fetch("/api", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(formObj),
+            });
+            if (!response.ok) {
+                router.push("/");
+                return;
+            }
+            const processedData = await response.json();
+            setData(processedData);
+            setView("dashboard");
+        };
+        fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [params.toString()]); // re-run if params change
+
+return (
+        <main>
+            <div className="min-h-[70vh] flex items-center justify-center">
+                {view === "loading" && (
+                    <ClipLoader color="black" size={50} />
+                )}
+                {view === "dashboard" && data && (
+                    <Dashboard processedData={data} />
+                )}
+            </div>
+        </main>
+    );
+};
+
+const ResultsPage = () => (
+    <>
+        <Header />
+        <Suspense fallback={<ClipLoader color="black" size={50} />}>
+            <ResultsPageContent />
+        </Suspense>
+        <Footer />
+    </>
+);
+
+export default ResultsPage;

--- a/schemas/formSchema.ts
+++ b/schemas/formSchema.ts
@@ -23,12 +23,9 @@ export const formSchema = z.object({
     .refine((value) => value === undefined || (!isNaN(value) && value > 0), {
       message: "Enter a positive house size.",
     }),
-  houseAge: z
-    .number()
-    .min(0, { message: "Enter a valid estimated build year." })
-    .or(z.undefined())
-    .refine((value) => value !== undefined, {
-      message: "Enter an estimated build year.",
+houseAge: z.coerce
+  .number({
+      message: "Enter an estimated build year."
     }),
   houseBedrooms: z.coerce
     .number({


### PR DESCRIPTION
This is a new version of #508 (closed because of messy rebase and to improve separation of concerns) _and_ #580 (because rebasing got too messy). 

# What does this PR do?
Creates a new route at /results for survey dashboard
Moves conditional rendering to /results/page.tsx (it probably shouldn't have been in CalculatorInput.tsx anyway!)

# Why?
We decided to create a new route for results so that if people hit 'back' to change any of their form inputs, they wouldn't get redirected to their previous non-Fairhold page / referrer.

# Questions
I was thinking about [Daf's comment here](https://github.com/theopensystemslab/fairhold-dashboard/pull/508#discussion_r2177813846) and wondered if maybe we would want to route people to `/results?housePostcode=abc123`--eg I want to share with my flatmates / partner what our home would cost if it was Fairhold, or similar. Thoughts? 

Closes #502 