### PR TITLE
feat: shortenStrings for bar labels

### DIFF
--- a/components/custom/survey/graphs/AnyMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/AnyMeansTenureChoice.tsx
@@ -67,7 +67,7 @@ export const AnyMeansTenureChoice = () => {
               <YAxis 
                   type="category"    
                   dataKey="answer" 
-                  width={350} 
+                  width={150} 
                   fontSize={10}
                   interval={0}
                   tickLine={false}

--- a/components/custom/survey/graphs/HousingOutcomes.tsx
+++ b/components/custom/survey/graphs/HousingOutcomes.tsx
@@ -67,7 +67,7 @@ export const HousingOutcomes = () => {
                     <YAxis 
                         type="category"    
                         dataKey="answer" 
-                        width={350} 
+                        width={150} 
                         fontSize={10}
                         interval={0}
                         tick={Tick}

--- a/components/custom/survey/graphs/SupportDevelopmentFactors.tsx
+++ b/components/custom/survey/graphs/SupportDevelopmentFactors.tsx
@@ -44,7 +44,7 @@ export const SupportDevelopmentFactors = () => {
                 <YAxis 
                     type="category"    
                     dataKey="answer" 
-                    width={350} 
+                    width={150} 
                     fontSize={10}
                     interval={0}
                     tick={Tick}

--- a/components/custom/survey/graphs/WhyFairhold.tsx
+++ b/components/custom/survey/graphs/WhyFairhold.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { TickProps, BarOrPieResult } from "@lib/survey/types";
+import { TickProps } from "@lib/survey/types";
 import SurveyGraphCard from "@components/custom/survey/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";

--- a/components/custom/survey/graphs/WhyFairhold.tsx
+++ b/components/custom/survey/graphs/WhyFairhold.tsx
@@ -43,7 +43,7 @@ export const WhyFairhold = () => {
               <YAxis 
                   type="category"    
                   dataKey="answer" 
-                  width={350} 
+                  width={150} 
                   fontSize={10}
                   interval={0}
                   tickLine={false}

--- a/components/custom/survey/graphs/WhyNotFairhold.tsx
+++ b/components/custom/survey/graphs/WhyNotFairhold.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { TickProps, BarOrPieResult } from "@lib/survey/types";
+import { TickProps } from "@lib/survey/types";
 import SurveyGraphCard from "@components/custom/survey/SurveyGraphCard";
 import { Bar, BarChart, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";

--- a/components/custom/survey/graphs/WhyNotFairhold.tsx
+++ b/components/custom/survey/graphs/WhyNotFairhold.tsx
@@ -43,7 +43,7 @@ export const WhyNotFairhold = () => {
               <YAxis 
                   type="category"    
                   dataKey="answer" 
-                  width={350} 
+                  width={150} 
                   fontSize={10}
                   interval={0}
                   tickLine={false}

--- a/lib/survey/constants.tsx
+++ b/lib/survey/constants.tsx
@@ -107,3 +107,9 @@ export const HOUSING_OUTCOMES_LABELS = {
   "Freedom from a bad relationship": "Freedom from bad relationship",
   "None of these. My current situation is fine.": "Nothing"
 }
+
+export const LABEL_MAP: Record<string, { labels: Record<string, string>, defaultLabel?: string }> = {
+  whyFairhold: { labels: WHY_FAIRHOLD_LABELS, defaultLabel: "Other;" },
+  whyNotFairhold: { labels: WHY_NOT_FAIRHOLD_LABELS },
+  supportDevelopmentFactors: { labels: SUPPORT_DEVELOPMENT_LABELS }
+};

--- a/lib/survey/constants.tsx
+++ b/lib/survey/constants.tsx
@@ -61,7 +61,7 @@ export const WHY_NOT_FAIRHOLD_LABELS = {
 
 export const SUPPORT_DEVELOPMENT_LABELS = {
   "Homes that are affordable to keyworkers": "Prioritise keyworkers",
-  "Homes that are affordable to low-income families": "Prioritise low-income families",
+  "Homes that are affordable to low-income families": "Prioritise low-income",
   "Homes that are affordable to me": "Affordable to me",
   "Priority given to local residents and their families (to allow downsizing, for example)": "Prioritise locals",
   "Community-led or self-build development (designed for people, not profit)": "Community-led or self-build",

--- a/lib/survey/constants.tsx
+++ b/lib/survey/constants.tsx
@@ -38,3 +38,72 @@ export const SUPPORT_FAIRHOLD_ORDER = [
     "Strongly oppose",
     "Other",
 ]
+
+export const WHY_FAIRHOLD_LABELS = {
+  "To own a home": "Home ownership",
+  "To spend less money on housing": "Affordability",
+  "To get a better home": "Quality home",
+  "I want to build my own home": "Self-build",
+  "To live in a better location": "Location",
+  "Environmental sustainability is important to me": "Environmental sustainability",
+  "I want to see a fairer society": "Fairness"
+}
+
+export const WHY_NOT_FAIRHOLD_LABELS = {
+  "It's too expensive for me": "Too expensive",
+  "I don't want the responsibility of maintaining a home": "Maintenance burden",
+  "I want my home to appreciate in value as an investment asset": "Want investment gains",
+  "I want to be able to make money from letting my home out": "Want rental income", 
+  "I'd be worried about moving house in future": "Moving concerns",
+  "It feels too complicated": "Too complicated",
+  "I don't know enough about it yet": "Not enough information"
+}
+
+export const SUPPORT_DEVELOPMENT_LABELS = {
+  "Homes that are affordable to keyworkers": "Prioritise keyworkers",
+  "Homes that are affordable to low-income families": "Prioritise low-income families",
+  "Homes that are affordable to me": "Affordable to me",
+  "Priority given to local residents and their families (to allow downsizing, for example)": "Prioritise locals",
+  "Community-led or self-build development (designed for people, not profit)": "Community-led or self-build",
+  "Council or social housing provider led (designed for people, not profit)": "Social housing",
+  "Beautiful design that improves the local character": "Beautiful design",
+  "Traditional design, with a heritage character": "Traditional design",
+  "Supported by new infrastructure (eg. public transport, cycle lanes, schools, GPs, parks)": "New infrastructure", 
+  "Walkable streets with trees and green spaces": "Pedestrianisation",
+  "Includes shops, cafés and community facilities": "Local amenities",
+  "Small-scale development spread across the area": "Small-scale development",
+  "Infill development on gap sites, increasing the density of existing neighbourhoods instead of developing greenfield land": "Infill development",
+  "Only build new neighbourhoods on sites away from existing homes": "Away from existing homes",
+  "Environmentally sustainable, zero-carbon homes": "Environmentally sustainable",
+  "Development that protects and enhances biodiversity": "Biodiversity gain",
+  "Built by local companies, supporting local jobs": "Local jobs",
+  "Includes a financial return for me and my family": "Financial return",
+  "Includes a financial return for the local community": "Community financial return",
+  "No new build. We should only convert existing buildings or bring empty homes back into use": "No new builds",
+  "None of these, there shouldn't be any new homes": "No new homes",
+}
+
+export const HOUSING_OUTCOMES_LABELS = {
+  "Security from being evicted": "No eviction",
+  "Lower cost": "Lower cost",
+  "Proximity to work": "Close to work",
+  "Proximity to friends and family": "Close to friends & family",
+  "Proximity to good schools": "Good schools",
+  "To get my money back when I sell": "Money back on sale",
+  "To retire with low outgoings": "Low retirement costs",
+  "Lower energy bills": "Lower energy bills",
+  "Freedom to improve or repair my home myself": "Freedom to improve",
+  "Home kept in good state of repair by others": "Repair by others",
+  "Quality of space": "Quality of space",
+  "More space": "More space",
+  "Sense of community / shared spaces within the neighbourhood": "Sense of community",
+  "Better public transport connections": "Public transport",
+  "Walkable neighbourhood": "Walkable neighbourhood",
+  "Lower crime / antisocial behaviour": "Safer neighbourhood",
+  "Being able to easily move home whenever I want to": "Easy to move",
+  "My home to increase in value as an investment": "Investment value",
+  "Rent as a source of income": "Rental income",
+  "Freedom from stress or exploitation (for example, debt, bills, bad landlords or exploitative management companies)": "Freedom from stress",
+  "Freedom from a bad relationship": "Freedom from bad relationship",
+  "None of these. My current situation is fine.": "Nothing"
+}

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -2,12 +2,10 @@ import { RawResults, BarOrPieResults, BarOrPieResult, SankeyResults, SankeyResul
 import {
   AFFORD_FAIRHOLD,
   AGE_ORDER,
+  HOUSING_OUTCOMES_LABELS,
   SUPPORT_DEVELOPMENT_ORDER,
   SUPPORT_FAIRHOLD_ORDER,
-  HOUSING_OUTCOMES_LABELS,
-  WHY_FAIRHOLD_LABELS,
-  WHY_NOT_FAIRHOLD_LABELS,
-  SUPPORT_DEVELOPMENT_LABELS
+  LABEL_MAP
 } from "./constants";
 
 const SANKEY_MAPPINGS = [
@@ -236,48 +234,26 @@ const sortResults = (results: BarOrPieResults) => {
 }
 
 const shortenStrings = (results: BarOrPieResults) => {
-    Object.entries(results).forEach(([key, arr]) => {
-        if (key === "whyFairhold") {
-            (arr as BarOrPieResult[]).forEach(item => {
-                const label = WHY_FAIRHOLD_LABELS[item.answer as keyof typeof WHY_FAIRHOLD_LABELS];
-                if (label) {
-                    item.answer = label;
-                } else {
-                    item.answer = "Other;"
-                }
-            });
-        }
-        else if (key === "whyNotFairhold") {
-            (arr as BarOrPieResult[]).forEach(item => {
-                const label = WHY_NOT_FAIRHOLD_LABELS[item.answer as keyof typeof WHY_NOT_FAIRHOLD_LABELS];
-                if (label) {
-                    item.answer = label;
-                } else {
-                    item.answer = "Other";
-                }
-            });
-        }
-        else if (key === "supportDevelopmentFactors") {
-            (arr as BarOrPieResult[]).forEach(item => {
-                const label = SUPPORT_DEVELOPMENT_LABELS[item.answer as keyof typeof SUPPORT_DEVELOPMENT_LABELS];
-                if (label) {
-                    item.answer = label;
-                } else {
-                    item.answer = "Other";
-                }
-            })
-        }
-        else if (key === "housingOutcomes") {
-    const outcomesRecord = arr as Record<string, BarOrPieResult[]>;
-    Object.values(outcomesRecord).forEach((outcomeArr) => {
-        outcomeArr.forEach((item) => {
-            const label = HOUSING_OUTCOMES_LABELS[item.answer as keyof typeof HOUSING_OUTCOMES_LABELS];
-            if (label) {
-                item.answer = label;
-            }
-        });
-    });
-}
-    })
-    return results;
-}
+  Object.entries(results).forEach(([key, arr]) => {
+    if (LABEL_MAP[key]) {
+      mapAnswersWithLabels(arr as BarOrPieResult[], LABEL_MAP[key].labels, LABEL_MAP[key].defaultLabel);
+    } else if (key === "housingOutcomes") {
+      const outcomesRecord = arr as Record<string, BarOrPieResult[]>;
+      Object.values(outcomesRecord).forEach((outcomeArr) => {
+        mapAnswersWithLabels(outcomeArr, HOUSING_OUTCOMES_LABELS);
+      });
+    }
+  });
+  return results;
+};
+
+const mapAnswersWithLabels = (
+  arr: BarOrPieResult[],
+  labels: Record<string, string>,
+  defaultLabel = "Other"
+) => {
+  arr.forEach(item => {
+    const label = labels[item.answer as keyof typeof labels];
+    item.answer = label || defaultLabel;
+  });
+};

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -4,6 +4,10 @@ import {
   AGE_ORDER,
   SUPPORT_DEVELOPMENT_ORDER,
   SUPPORT_FAIRHOLD_ORDER,
+  HOUSING_OUTCOMES_LABELS,
+  WHY_FAIRHOLD_LABELS,
+  WHY_NOT_FAIRHOLD_LABELS,
+  SUPPORT_DEVELOPMENT_LABELS
 } from "./constants";
 
 const SANKEY_MAPPINGS = [
@@ -29,11 +33,12 @@ export const aggregateResults = (rawResults: RawResults[]) => {
         addBarOrPieResult(barOrPie, rawResult);
         addSankeyResult(sankey, rawResult);
     }
-
+    // const shortenedBarOrPie = shortenStrings(barOrPie);
     const sortedBarOrPie = sortResults(barOrPie);
     const slicedBarOrPie = getTopFive(sortedBarOrPie);
-
-    return { numberResponses, barOrPie: slicedBarOrPie, sankey };
+    const shortenedBarOrPie = shortenStrings(slicedBarOrPie);
+    
+    return { numberResponses, barOrPie: shortenedBarOrPie, sankey };
 }
 
 const initializeBarOrPieResultsObject = (): BarOrPieResults => {
@@ -218,7 +223,7 @@ const sortResults = (results: BarOrPieResults) => {
                 );
             }
         }
-        if (["whyFairhold", "whyNotFairhold", "supportDevelopmentFactors"].includes(key)) {
+        if (["anyMeansTenureChoice", "whyFairhold", "whyNotFairhold", "supportDevelopmentFactors"].includes(key)) {
             (arr as BarOrPieResult[]).sort((a, b) => b.value - a.value);
         }
     });
@@ -227,5 +232,52 @@ const sortResults = (results: BarOrPieResults) => {
         arr.sort((a, b) => b.value - a.value);
     });
 
+    return results;
+}
+
+const shortenStrings = (results: BarOrPieResults) => {
+    Object.entries(results).forEach(([key, arr]) => {
+        if (key === "whyFairhold") {
+            (arr as BarOrPieResult[]).forEach(item => {
+                const label = WHY_FAIRHOLD_LABELS[item.answer as keyof typeof WHY_FAIRHOLD_LABELS];
+                if (label) {
+                    item.answer = label;
+                } else {
+                    item.answer = "Other;"
+                }
+            });
+        }
+        else if (key === "whyNotFairhold") {
+            (arr as BarOrPieResult[]).forEach(item => {
+                const label = WHY_NOT_FAIRHOLD_LABELS[item.answer as keyof typeof WHY_NOT_FAIRHOLD_LABELS];
+                if (label) {
+                    item.answer = label;
+                } else {
+                    item.answer = "Other";
+                }
+            });
+        }
+        else if (key === "supportDevelopmentFactors") {
+            (arr as BarOrPieResult[]).forEach(item => {
+                const label = SUPPORT_DEVELOPMENT_LABELS[item.answer as keyof typeof SUPPORT_DEVELOPMENT_LABELS];
+                if (label) {
+                    item.answer = label;
+                } else {
+                    item.answer = "Other";
+                }
+            })
+        }
+        else if (key === "housingOutcomes") {
+    const outcomesRecord = arr as Record<string, BarOrPieResult[]>;
+    Object.values(outcomesRecord).forEach((outcomeArr) => {
+        outcomeArr.forEach((item) => {
+            const label = HOUSING_OUTCOMES_LABELS[item.answer as keyof typeof HOUSING_OUTCOMES_LABELS];
+            if (label) {
+                item.answer = label;
+            }
+        });
+    });
+}
+    })
     return results;
 }

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -218,8 +218,11 @@ const sortResults = (results: BarOrPieResults) => {
                 );
             }
         }
+        if (["whyFairhold", "whyNotFairhold", "supportDevelopmentFactors"].includes(key)) {
+            (arr as BarOrPieResult[]).sort((a, b) => b.value - a.value);
+        }
     });
-
+    // Descending sort for housing outcomes is separate because it's grouped by tenure and thus a nested object
     Object.values(results.housingOutcomes).forEach((arr) => {
         arr.sort((a, b) => b.value - a.value);
     });

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -1,11 +1,11 @@
 import { RawResults, BarOrPieResults, BarOrPieResult, SankeyResults, SankeyResult } from "./types"
 import {
-  AFFORD_FAIRHOLD,
-  AGE_ORDER,
-  HOUSING_OUTCOMES_LABELS,
-  SUPPORT_DEVELOPMENT_ORDER,
-  SUPPORT_FAIRHOLD_ORDER,
-  LABEL_MAP
+    AFFORD_FAIRHOLD,
+    AGE_ORDER,
+    HOUSING_OUTCOMES_LABELS,
+    LABEL_MAP,
+    SUPPORT_DEVELOPMENT_ORDER,
+    SUPPORT_FAIRHOLD_ORDER,
 } from "./constants";
 
 const SANKEY_MAPPINGS = [


### PR DESCRIPTION
# What does this PR do?
- Creates new `shortenStrings()` function to shorten labels
    - User input strings (eg if they selected 'Other') will be returned as `Other` by `shortenStrings()` (eg in case of typos, malicious entries, and because it would just be messy). New `aggregateOther()` function will combine different instances of answer `Other` into one
- Creates new objects for mapping full to shortened label, nesting them within `LABEL_MAP`
- Shortens labels before sorting and slicing

# Why?
As discussed with Alastair, survey answers can be too long for concise graphs. 

Before:
<img width="400" alt="Screenshot 2025-07-22 150315" src="https://github.com/user-attachments/assets/53139def-d3b5-4626-b9a1-ece855c1ce18" />

Afte
<img width="400" alt="Screenshot 2025-07-22 150327" src="https://github.com/user-attachments/assets/c28fdb92-5055-4d42-9067-0df262dbbbd6" />
r: