### PR TITLE
style: SurveyTenureSelector dropdown focus

### DIFF
--- a/components/custom/survey/SurveyTenureSelector.tsx
+++ b/components/custom/survey/SurveyTenureSelector.tsx
@@ -16,7 +16,10 @@ const SurveyTenureSelector: React.FC<SurveyTenureSelectorProps> = ({ options, va
         </SelectTrigger>
         <SelectContent>
           {options.map(option => (
-            <SelectItem key={option} value={option}>
+            <SelectItem 
+              key={option} 
+              value={option}
+              className="text-xs focus:bg-gray-200"              >
               {option}
             </SelectItem>
           ))}

--- a/components/custom/survey/SurveyTenureSelector.tsx
+++ b/components/custom/survey/SurveyTenureSelector.tsx
@@ -11,7 +11,7 @@ const SurveyTenureSelector: React.FC<SurveyTenureSelectorProps> = ({ options, va
   <div>
     <label>
       <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="w-[180px]" style={{ color, border: 'none' }}>
+        <SelectTrigger className="w-[180px]" style={{ color, border: `1px solid ${color}` }}>
           <SelectValue placeholder="Select tenure" />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
Following on from #597, forgot there was another dropdown in the survey results that would also need focus! While I was here added a thin border for visibility. 

Before:
<img width="150" alt="Screenshot 2025-07-22 151228" src="https://github.com/user-attachments/assets/6a74b57b-e5f4-478d-879b-2a5e0fc6db88" />

After:

<img width="150" alt="Screenshot 2025-07-22 151820" src="https://github.com/user-attachments/assets/c0ed3631-579c-452f-9745-6bed57dccefe" />
