### PR TITLE
feat: format sankey labels where needed

### DIFF
--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -25,6 +25,7 @@ type NodePayload = {
     y: number;
     dy: number;
     color?: string;
+    label?: string;
 }
 
 type CustomLinkProps = {

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -25,7 +25,6 @@ type NodePayload = {
     y: number;
     dy: number;
     color?: string;
-    label?: string;
 }
 
 type CustomLinkProps = {
@@ -54,7 +53,7 @@ type CustomLinkPayload = {
 }
 
 type SankeyProps = {
-    nodes: Array<{name: string}>;
+    nodes: Array<{name: string, label?: string}>;
     links: Array<{source: number, target: number, value: number}>;
     leftLabel?: string;
     rightLabel?: string;
@@ -114,7 +113,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                     fontWeight={"bold"}
                     fillOpacity={0.8}
                 > 
-                    {props.payload.label || props.payload.name} 
+                    {props.payload.label} 
                 </text> 
             </g> 
         ); 

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -13,7 +13,7 @@ type CustomNodeProps = {
 
 type NodePayload = {
     name: string;
-    label?: string;
+    label: string;
     sourceNodes: [];
     sourceLinks: [];
     targetLinks: [];
@@ -53,7 +53,7 @@ type CustomLinkPayload = {
 }
 
 type SankeyProps = {
-    nodes: Array<{name: string, label?: string}>;
+    nodes: Array<{name: string, label: string}>;
     links: Array<{source: number, target: number, value: number}>;
     leftLabel?: string;
     rightLabel?: string;

--- a/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
@@ -5,32 +5,9 @@ import { ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 import { applyNodeColors } from "@lib/survey/utils";
 
-const getLabel = (name: string) => {
-    switch (name) {
-        case "Part own, part rent":
-            return "Shared ownership";
-        case "I live for free in a home":
-            return "Free housing";
-        case "I do not have a stable home at the moment":
-            return "No stable home";
-        default:
-            return name;
-    }
-};
-
 export const CurrentMeansTenureChoice = () => {
     const { currentMeansTenureChoice } = useSurveyContext().sankey;
-    
-    // We use suffixes to distinguish between current and ideal so we don't end up with circular links (eg for Freehold -> Freehold), so we need to remove the suffixes
-    const formattedNodes = currentMeansTenureChoice.nodes.map((node) => ({
-        ...node,
-        name: node.name.replace(/_(0|1)$/, ""),
-    }));
-    const labeledNodes = formattedNodes.map((node: { name: string }) => ({
-        ...node,
-        label: getLabel(node.name),
-    }));
-    const colouredNodes = applyNodeColors(labeledNodes);
+    const colouredNodes = applyNodeColors(currentMeansTenureChoice.nodes);
 
     return (
         <SurveyGraphCard title="Which tenure would you choose?">

--- a/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/CurrentMeansTenureChoice.tsx
@@ -4,20 +4,39 @@ import { CustomSankey } from "../CustomSankey"
 import { ResponsiveContainer } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 import { applyNodeColors } from "@lib/survey/utils";
+
+const getLabel = (name: string) => {
+    switch (name) {
+        case "Part own, part rent":
+            return "Shared ownership";
+        case "I live for free in a home":
+            return "Free housing";
+        case "I do not have a stable home at the moment":
+            return "No stable home";
+        default:
+            return name;
+    }
+};
+
 export const CurrentMeansTenureChoice = () => {
     const { currentMeansTenureChoice } = useSurveyContext().sankey;
+    
     // We use suffixes to distinguish between current and ideal so we don't end up with circular links (eg for Freehold -> Freehold), so we need to remove the suffixes
-    let formattedNodes = currentMeansTenureChoice.nodes.map((node) => ({
+    const formattedNodes = currentMeansTenureChoice.nodes.map((node) => ({
         ...node,
         name: node.name.replace(/_(0|1)$/, ""),
     }));
-    formattedNodes = applyNodeColors(formattedNodes);
+    const labeledNodes = formattedNodes.map((node: { name: string }) => ({
+        ...node,
+        label: getLabel(node.name),
+    }));
+    const colouredNodes = applyNodeColors(labeledNodes);
 
     return (
         <SurveyGraphCard title="Which tenure would you choose?">
             <ResponsiveContainer width="100%" height="100%">
                 <CustomSankey
-                    nodes={formattedNodes}
+                    nodes={colouredNodes}
                     links={currentMeansTenureChoice.links}     
                     leftLabel="I live in"
                     rightLabel="I want to live in"   

--- a/components/custom/survey/graphs/IdealHouseType.tsx
+++ b/components/custom/survey/graphs/IdealHouseType.tsx
@@ -3,14 +3,30 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey";
 import { useSurveyContext } from "@context/surveyContext";
 
+const getLabel = (name: string) => {
+    switch (name) {
+        case "A flat":
+            return "Flat";
+        case "A house":
+            return "House";
+        case "A studio":
+            return "Studio";
+        default:
+            return name;
+    }
+};
 
 export const IdealHouseType = () => {
     const { idealHouseType } = useSurveyContext().sankey;
-    
+    const labeledNodes = idealHouseType.nodes.map((node: { name: string }) => ({
+        ...node,
+        label: getLabel(node.name),
+    }));
+
     return (
         <SurveyGraphCard title="What type of home do you want to live in?">
             <CustomSankey
-                nodes={idealHouseType.nodes}
+                nodes={labeledNodes}
                 links={idealHouseType.links}       
                 leftLabel="I live in"
                 rightLabel="I want to live in"

--- a/components/custom/survey/graphs/IdealHouseType.tsx
+++ b/components/custom/survey/graphs/IdealHouseType.tsx
@@ -3,30 +3,13 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey";
 import { useSurveyContext } from "@context/surveyContext";
 
-const getLabel = (name: string) => {
-    switch (name) {
-        case "A flat":
-            return "Flat";
-        case "A house":
-            return "House";
-        case "A studio":
-            return "Studio";
-        default:
-            return name;
-    }
-};
-
 export const IdealHouseType = () => {
     const { idealHouseType } = useSurveyContext().sankey;
-    const labeledNodes = idealHouseType.nodes.map((node: { name: string }) => ({
-        ...node,
-        label: getLabel(node.name),
-    }));
-
+    
     return (
         <SurveyGraphCard title="What type of home do you want to live in?">
             <CustomSankey
-                nodes={labeledNodes}
+                nodes={idealHouseType.nodes}
                 links={idealHouseType.links}       
                 leftLabel="I live in"
                 rightLabel="I want to live in"

--- a/components/custom/survey/graphs/IdealLiveWith.tsx
+++ b/components/custom/survey/graphs/IdealLiveWith.tsx
@@ -3,39 +3,15 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey"
 import { useSurveyContext } from "@context/surveyContext";
 
-const getLabel = (name: string) => {
-    switch (name) {
-        case "I live with my parents":
-            return "Parents / extended family";
-        case "I live alone":
-            return "Alone";
-        case "I live with my parents or extended family": // intentional fallthrough
-        case "With my parents or extended family":
-            return "Parents / extended family";
-        case "I live with housemates":
-        case "With friends":
-            return "Friends / housemates";
-        case "I live with my partner / family":
-        case "With partner / family": // intentional fallthrough
-            return "Partner / family";
-        default:
-            return name;
-    }
-};
-
 export const IdealLiveWith = () => {
     const { idealLiveWith } = useSurveyContext().sankey;
     const color = "rgb(var(--fairhold-equity-color-rgb))";
     const coloredNodes = idealLiveWith.nodes.map((node) => ({...node, color}));
-    const labeledNodes = coloredNodes.map((node: { name: string }) => ({
-    ...node,
-    label: getLabel(node.name),
-    }));
 
     return (
         <SurveyGraphCard title="Who do you want to live with?">
             <CustomSankey
-                nodes={labeledNodes}
+                nodes={coloredNodes}
                 links={idealLiveWith.links}     
                 leftLabel="I live with"
                 rightLabel="I want to live with" 

--- a/components/custom/survey/graphs/IdealLiveWith.tsx
+++ b/components/custom/survey/graphs/IdealLiveWith.tsx
@@ -3,15 +3,39 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { CustomSankey } from "../CustomSankey"
 import { useSurveyContext } from "@context/surveyContext";
 
+const getLabel = (name: string) => {
+    switch (name) {
+        case "I live with my parents":
+            return "Parents / extended family";
+        case "I live alone":
+            return "Alone";
+        case "I live with my parents or extended family": // intentional fallthrough
+        case "With my parents or extended family":
+            return "Parents / extended family";
+        case "I live with housemates":
+        case "With friends":
+            return "Friends / housemates";
+        case "I live with my partner / family":
+        case "With partner / family": // intentional fallthrough
+            return "Partner / family";
+        default:
+            return name;
+    }
+};
+
 export const IdealLiveWith = () => {
     const { idealLiveWith } = useSurveyContext().sankey;
     const color = "rgb(var(--fairhold-equity-color-rgb))";
     const coloredNodes = idealLiveWith.nodes.map((node) => ({...node, color}));
-    
+    const labeledNodes = coloredNodes.map((node: { name: string }) => ({
+    ...node,
+    label: getLabel(node.name),
+    }));
+
     return (
         <SurveyGraphCard title="Who do you want to live with?">
             <CustomSankey
-                nodes={coloredNodes}
+                nodes={labeledNodes}
                 links={idealLiveWith.links}     
                 leftLabel="I live with"
                 rightLabel="I want to live with" 

--- a/lib/survey/constants.tsx
+++ b/lib/survey/constants.tsx
@@ -142,3 +142,26 @@ export const TENURE_CHOICE_COLOR_MAP: Record<string, string> = {
   "Social rent": "rgb(var(--social-rent-land-color-rgb))",
   "I don't know": "rgb(var(--survey-grey-mid))"
 };
+
+export const CURRENT_MEANS_TENURE_LABELS: Record<string, string> = {
+  "Part own, part rent": "Shared ownership",
+  "I live for free in a home": "Free housing",
+  "I do not have a stable home at the moment": "No stable home"
+}
+
+export const IDEAL_HOUSE_TYPE_LABELS: Record<string, string> = {
+  "A flat": "Flat",
+  "A house": "House",
+  "A studio": "Studio"
+}
+
+export const IDEAL_LIVE_WITH_LABELS: Record<string, string> = {
+    "I live with my parents":"Parents / extended family",
+    "I live alone": "Alone",
+    "I live with my parents or extended family": "Parents / extended family",
+    "With my parents or extended family": "Parents / extended family",
+    "I live with housemates": "With friends",
+    "Friends / housemates": "With friends",
+    "I live with my partner / family": "Partner / family",
+    "With partner / family": "Partner / family"
+};

--- a/lib/survey/types.tsx
+++ b/lib/survey/types.tsx
@@ -60,6 +60,7 @@ export type SankeyResults = Record<Extract<keyof RawResults,
 export type SankeyResult = {
     nodes: {
         name: string
+        label?: string
     }[]
     links: {
         source: number;

--- a/lib/survey/types.tsx
+++ b/lib/survey/types.tsx
@@ -60,7 +60,7 @@ export type SankeyResults = Record<Extract<keyof RawResults,
 export type SankeyResult = {
     nodes: {
         name: string
-        label?: string
+        label: string
     }[]
     links: {
         source: number;

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -314,17 +314,12 @@ const aggregateOther = (arr: BarOrPieResult[]): BarOrPieResult[] => {
     return notOthers;
 };
 
-export const applyNodeColors = <T extends { name: string }>(nodes: T[]) => {return nodes.map(node => {
-    const hasLabel = (n: typeof node): n is typeof node & { label: string } =>
-        typeof (n as { label?: unknown }).label === "string" && !!(n as { label?: unknown }).label;
-
-    const baseName = hasLabel(node)
-        ? node.label
-        : node.name.replace(/ \((current|ideal)\)$/i, "");
-
+export const applyNodeColors = (nodes: { name: string; label?: string }[]) => {
+  return nodes.map(node => {
+    const baseName = node.label ?? node.name.replace(/ \((current|ideal)\)$/i, "");
     return {
-        ...node,
-        color: TENURE_CHOICE_COLOR_MAP[baseName] || "rgb(var(--survey-grey-mid))"
+      ...node,
+      color: TENURE_CHOICE_COLOR_MAP[baseName] || "rgb(var(--survey-grey-mid))"
     };
 });
 }

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -141,14 +141,14 @@ const updateSankeyNodesAndLinks = (
     let sourceIndex = nodes.findIndex((node) => node.name === fromValue);
     if (sourceIndex === -1) {
         sourceIndex = nodes.length;
-        nodes.push({ name: fromValue });
+        nodes.push({ name: fromValue, label: "" });
     }
 
     // Find or add the target node
     let targetIndex = nodes.findIndex((node) => node.name === toValue);
     if (targetIndex === -1) {
         targetIndex = nodes.length;
-        nodes.push({ name: toValue });
+        nodes.push({ name: toValue, label: "" });
     }
 
     // Find or add the link
@@ -318,7 +318,7 @@ const aggregateOther = (arr: BarOrPieResult[]): BarOrPieResult[] => {
     return notOthers;
 };
 
-export const applyNodeColors = (nodes: { name: string; label?: string }[]) => {
+export const applyNodeColors = (nodes: { name: string; label: string }[]) => {
   return nodes.map(node => {
     const baseName = node.label ?? node.name.replace(/ \((current|ideal)\)$/i, ""); // we want to use the label if it exists, if it doesn't then we just use the name (but removing the suffixes created for unique node names)
     return {

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -2,11 +2,14 @@ import { RawResults, BarOrPieResults, BarOrPieResult, SankeyResults, SankeyResul
 import {
     AFFORD_FAIRHOLD,
     AGE_ORDER,
+    CURRENT_MEANS_TENURE_LABELS,
     HOUSING_OUTCOMES_LABELS,
+    IDEAL_HOUSE_TYPE_LABELS,
+    IDEAL_LIVE_WITH_LABELS,
     LABEL_MAP,
     SUPPORT_DEVELOPMENT_ORDER,
     SUPPORT_FAIRHOLD_ORDER,
-  TENURE_CHOICE_COLOR_MAP,
+    TENURE_CHOICE_COLOR_MAP,
 } from "./constants";
 
 const SANKEY_MAPPINGS = [
@@ -36,7 +39,8 @@ export const aggregateResults = (rawResults: RawResults[]) => {
     const sortedBarOrPie = sortResults(shortenedBarOrPie);
     const slicedBarOrPie = sliceResults(sortedBarOrPie);
     
-    return { numberResponses, barOrPie: slicedBarOrPie, sankey };
+    const labelledSankey = applySankeyNodeLabels(sankey);
+    return { numberResponses, barOrPie: slicedBarOrPie, sankey: labelledSankey };
 }
 
 const initializeBarOrPieResultsObject = (): BarOrPieResults => {
@@ -245,7 +249,7 @@ const sortByValueDesc = (arr: BarOrPieResult[]) => {
     arr.sort((a, b) => b.value - a.value);
 };
 
-const sortResults = (results: BarOrPieResults) => {
+const sortResults = (results: BarOrPieResults): BarOrPieResults => {
     // We handle housingOutcomes separately (because it's a nested object)
     Object.values(results.housingOutcomes).forEach((arr) => {
         sortByValueDesc(arr);
@@ -351,4 +355,18 @@ export const getMaxWhyFairholdValue = (surveyResults: SurveyResults) => {
     getMaxValue(whyNotFairholdResults)
   );
   return maxWhyFairholdValue;
+}
+
+const applySankeyNodeLabels = (sankeyResults: SankeyResults) => {
+  sankeyResults.currentMeansTenureChoice.nodes.forEach(node => {
+    const baseName = node.name.replace(/_(0|1)$/, "");
+    node.label = CURRENT_MEANS_TENURE_LABELS[baseName] || baseName;
+  });
+  sankeyResults.idealHouseType.nodes.forEach(node => {
+    node.label = IDEAL_HOUSE_TYPE_LABELS[node.name] || node.name;
+  });
+  sankeyResults.idealLiveWith.nodes.forEach(node => {
+    node.label = IDEAL_LIVE_WITH_LABELS[node.name] || node.name;
+  });
+  return sankeyResults;
 }

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -316,7 +316,7 @@ const aggregateOther = (arr: BarOrPieResult[]): BarOrPieResult[] => {
 
 export const applyNodeColors = (nodes: { name: string; label?: string }[]) => {
   return nodes.map(node => {
-    const baseName = node.label ?? node.name.replace(/ \((current|ideal)\)$/i, "");
+    const baseName = node.label ?? node.name.replace(/ \((current|ideal)\)$/i, ""); // we want to use the label if it exists, if it doesn't then we just use the name (but removing the suffixes created for unique node names)
     return {
       ...node,
       color: TENURE_CHOICE_COLOR_MAP[baseName] || "rgb(var(--survey-grey-mid))"

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -314,15 +314,19 @@ const aggregateOther = (arr: BarOrPieResult[]): BarOrPieResult[] => {
     return notOthers;
 };
 
-export const applyNodeColors = (nodes: {name: string }[]) => {
-    return nodes.map(node => {
-        // Remove suffix for color lookup if present
-        const baseName = node.name.replace(/ \((current|ideal)\)$/i, "");
-        return {
-            ...node,
-            color: TENURE_CHOICE_COLOR_MAP[baseName] || "rgb(var(--survey-grey-mid))"
-        };
-    });
+export const applyNodeColors = <T extends { name: string }>(nodes: T[]) => {return nodes.map(node => {
+    const hasLabel = (n: typeof node): n is typeof node & { label: string } =>
+        typeof (n as { label?: unknown }).label === "string" && !!(n as { label?: unknown }).label;
+
+    const baseName = hasLabel(node)
+        ? node.label
+        : node.name.replace(/ \((current|ideal)\)$/i, "");
+
+    return {
+        ...node,
+        color: TENURE_CHOICE_COLOR_MAP[baseName] || "rgb(var(--survey-grey-mid))"
+    };
+});
 }
 
 const padAndSortHousingOutcomes = (housingOutcomes: Record<string, BarOrPieResult[]>) => {


### PR DESCRIPTION
Updated to maintain separation of concerns / handle all data management in backend and only visualisation in frontend. 

- Creates label mapping objects in `constants.tsx`
- Adds new `label` prop to `SankeyResult` and `applySankeyNodeLabels()` utility function
- Runs `applySankeyNodeLabels()` in `aggregateResults()`, returning labeled nodes to frontend

While doing this I realised the same pattern should be applied to the node colour handling too, so have branched off and opened #648 too (separated them as they're different concerns!) 

Before:
<img width="300" alt="Screenshot 2025-08-26 112250" src="https://github.com/user-attachments/assets/83bcddf1-75fd-4d27-bdf1-4381ee3ebc91" />

After:
<img width="300" alt="Screenshot 2025-08-26 112210" src="https://github.com/user-attachments/assets/b5f5979c-581a-4583-a0b2-698eecce7ff1" />
