### PR TITLE
style: make bar graph spacing consistent

### DIFF
--- a/components/custom/survey/graphs/AnyMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/AnyMeansTenureChoice.tsx
@@ -48,7 +48,7 @@ export const AnyMeansTenureChoice = () => {
             title="Rank the tenures by preference"
             subtitle="If you could afford (and were eligible for) any type of home, which would you prefer?"
             >
-          <ResponsiveContainer height={anyMeansTenureChoice.length * 30}>
+          <ResponsiveContainer height={150}>
           <BarChart
               data={anyMeansTenureChoice}
               barSize={20}

--- a/components/custom/survey/graphs/SupportDevelopmentFactors.tsx
+++ b/components/custom/survey/graphs/SupportDevelopmentFactors.tsx
@@ -28,11 +28,10 @@ export const SupportDevelopmentFactors = () => {
     
     return (
         <SurveyGraphCard title="Which of these factors would make you more likely to support new homes being created near where you live?">
-            <ResponsiveContainer height="100%" width="100%">
+            <ResponsiveContainer height={480} width="100%">
             <BarChart
                 data={supportDevelopmentFactors}
                 barSize={20}
-                height={480}
                 layout="vertical"
             >
                 <XAxis 

--- a/components/custom/survey/graphs/WhyFairhold.tsx
+++ b/components/custom/survey/graphs/WhyFairhold.tsx
@@ -28,7 +28,7 @@ export const WhyFairhold = () => {
   
   return (
       <SurveyGraphCard title="Why would you choose Fairhold?">
-          <ResponsiveContainer>
+          <ResponsiveContainer height={150}>
           <BarChart
               data={whyFairhold}
               barSize={20}

--- a/components/custom/survey/graphs/WhyNotFairhold.tsx
+++ b/components/custom/survey/graphs/WhyNotFairhold.tsx
@@ -28,7 +28,7 @@ export const WhyNotFairhold = () => {
   
   return (
       <SurveyGraphCard title="Why wouldn't you choose Fairhold?">
-          <ResponsiveContainer>
+          <ResponsiveContainer height={150}>
           <BarChart
               data={whyNotFairhold}
               barSize={20}

--- a/lib/survey/utils.tsx
+++ b/lib/survey/utils.tsx
@@ -160,11 +160,18 @@ const updateSankeyNodesAndLinks = (
 
 const sliceResults = (barOrPieResults: BarOrPieResults) => {
     for (const key in barOrPieResults) {
-        if (key === "whyFairhold" || key === "whyNotFairhold") {
-            barOrPieResults[key] = barOrPieResults[key].slice(0,5);
-        }
-        else if (key === "housingOutcomes") { // We have to slice this one per-tenure, but also pad out the number of answers if less than 10
-            padAndSortHousingOutcomes(barOrPieResults[key])
+        switch (key) {
+            case "whyFairhold":
+            case "whyNotFairhold":
+                barOrPieResults[key] = barOrPieResults[key].slice(0, 5);
+                break;
+            case "housingOutcomes":
+                // We have to slice this one per-tenure, but also pad out the number of answers if less than 10
+                padAndSortHousingOutcomes(barOrPieResults[key]);
+                break;
+            default:
+                // No action for other keys
+                break;
         }
     }
     return barOrPieResults;


### PR DESCRIPTION
This makes the spacing between bars consistent by
1. adjusting the height of `ResponsiveContainer` (defining a `barGap` leads to auto `barSIze` and vice versa, so that wasn't an option since we wanted sizes and gaps to be consistent)
2. ensuring that all tenures have the same number of bars in `housingOutcomes` by padding out the number of answers listed and sorting / slicing (in new helper function `padAndSortHousingOutcomes()`)

Before:
<img width="400" alt="Screenshot 2025-08-06 163018" src="https://github.com/user-attachments/assets/e97014c4-381b-45b4-a2cc-cf1bf58e0997" />
<img  width="400" alt="Screenshot 2025-08-06 163024" src="https://github.com/user-attachments/assets/85f3f0a8-9fc8-4c0b-887e-8b0f2bf045fc" />

After:
<img width="400" alt="Screenshot 2025-08-06 162945" src="https://github.com/user-attachments/assets/dc94e254-2227-4b9f-b415-d27d565f24d7" />
<img width="400" alt="Screenshot 2025-08-06 162953" src="https://github.com/user-attachments/assets/5ac7f8d9-10ca-4c3d-b664-69951936722c" />
