### PR TITLE
style: doughnut legend fixes

### DIFF
--- a/components/custom/survey/graphs/AffordFairhold.tsx
+++ b/components/custom/survey/graphs/AffordFairhold.tsx
@@ -27,9 +27,10 @@ export const AffordFairhold = () => {
                     ))}
                     </Pie>
                     <Legend 
-                        align="center" 
+                        align="left" 
+                        height={50}
                         verticalAlign="bottom" 
-                        wrapperStyle={{ fontSize: 18 }}
+                        wrapperStyle={{ fontSize: 14 }}
                         />
                 </PieChart>
             </ResponsiveContainer>

--- a/components/custom/survey/graphs/Age.tsx
+++ b/components/custom/survey/graphs/Age.tsx
@@ -10,6 +10,10 @@ export const Age = () => {
     const COLORS = [
       "rgb(var(--survey-grey-lightest))", "rgb(var(--survey-grey-light))", "rgb(var(--survey-grey-mid))", "rgb(var(--survey-grey-dark))", "rgb(var(--survey-black))"  
     ];
+
+    const renderLegendText = (value: string) => (
+        <span style={{ color: "rgb(var(--survey-grey-mid))" }}>{value}</span>
+        );
   
     return (
         <SurveyGraphCard title="How old are you?">
@@ -30,7 +34,7 @@ export const Age = () => {
                     <Legend 
                         align="center" 
                         verticalAlign="bottom" 
-                        wrapperStyle={{ fontSize: 18 }}
+                        formatter={renderLegendText}
                     />
                 </PieChart>
         </ResponsiveContainer>

--- a/components/custom/survey/graphs/Age.tsx
+++ b/components/custom/survey/graphs/Age.tsx
@@ -32,9 +32,10 @@ export const Age = () => {
                         ))}
                     </Pie>
                     <Legend 
-                        align="center" 
+                        align="left" 
                         verticalAlign="bottom" 
                         formatter={renderLegendText}
+                        wrapperStyle={{ fontSize: 14 }}
                     />
                 </PieChart>
         </ResponsiveContainer>

--- a/components/custom/survey/graphs/Country.tsx
+++ b/components/custom/survey/graphs/Country.tsx
@@ -28,9 +28,10 @@ import { BarOrPieResult } from "@/lib/survey/types";
               ))}
               </Pie>
             <Legend 
-              align="center" 
+              align="left" 
+              // height={50}
               verticalAlign="bottom" 
-              wrapperStyle={{ fontSize: 18 }}
+              wrapperStyle={{ fontSize: 14 }}
             />
             </PieChart>
         </ResponsiveContainer>

--- a/components/custom/survey/graphs/Country.tsx
+++ b/components/custom/survey/graphs/Country.tsx
@@ -29,7 +29,6 @@ import { BarOrPieResult } from "@/lib/survey/types";
               </Pie>
             <Legend 
               align="left" 
-              // height={50}
               verticalAlign="bottom" 
               wrapperStyle={{ fontSize: 14 }}
             />

--- a/components/custom/survey/graphs/SupportDevelopment.tsx
+++ b/components/custom/survey/graphs/SupportDevelopment.tsx
@@ -27,9 +27,9 @@ export const SupportDevelopment = () => {
                         ))}
                     </Pie>
                     <Legend 
-                        align="center" 
+                        align="left" 
                         verticalAlign="bottom" 
-                        wrapperStyle={{ fontSize: 18 }}
+                        wrapperStyle={{ fontSize: 14 }}
                     />
              </PieChart>
             </ResponsiveContainer>

--- a/components/custom/survey/graphs/SupportNewFairhold.tsx
+++ b/components/custom/survey/graphs/SupportNewFairhold.tsx
@@ -28,9 +28,9 @@ export const SupportNewFairhold = () => {
                         ))}
                     </Pie>
                     <Legend 
-                        align="center" 
+                        align="left" 
                         verticalAlign="bottom" 
-                        wrapperStyle={{ fontSize: 18 }}
+                        wrapperStyle={{ fontSize: 14 }}
                     />
              </PieChart>
             </ResponsiveContainer>

--- a/lib/survey/constants.tsx
+++ b/lib/survey/constants.tsx
@@ -17,8 +17,8 @@ export const AGE_ORDER = [
 
 export const AFFORD_FAIRHOLD = [
   { label: "Yes", colour: "rgb(var(--fairhold-equity-color-rgb))" },
-  { label: "Yes, but Fairhold Land Rent only, because the deposit is lower", colour: "rgb(var(--fairhold-interest-color-rgb))" },
-  { label: "No, it's still too expensive", colour: "rgb(var(--social-rent-land-color-rgb))" },
+  { label: "Yes (Fairhold Land Rent only)", colour: "rgb(var(--fairhold-interest-color-rgb))" },
+  { label: "No", colour: "rgb(var(--social-rent-land-color-rgb))" },
 ] as const;
 
 export const SUPPORT_DEVELOPMENT_ORDER = [
@@ -108,6 +108,12 @@ export const HOUSING_OUTCOMES_LABELS = {
   "None of these. My current situation is fine.": "Nothing"
 }
 
+export const AFFORD_FAIRHOLD_LABELS = {
+  "Yes": "Yes",
+  "Yes, but Fairhold Land Rent only, because the deposit is lower": "Yes (Fairhold Land Rent only)",
+  "No, it's still too expensive": "No"
+}
+
 export const SUPPORT_DEVELOPMENT_LABELS = {
   "Strongly supportive of any development": "Strongly supportive",
   "Quite supportive of most development": "Quite supportive",
@@ -117,6 +123,7 @@ export const SUPPORT_DEVELOPMENT_LABELS = {
 }
 
 export const LABEL_MAP: Record<string, { labels: Record<string, string>, defaultLabel?: string }> = {
+  affordFairhold: { labels: AFFORD_FAIRHOLD_LABELS},
   whyFairhold: { labels: WHY_FAIRHOLD_LABELS, defaultLabel: "Other;" },
   whyNotFairhold: { labels: WHY_NOT_FAIRHOLD_LABELS },
   supportDevelopment: { labels: SUPPORT_DEVELOPMENT_LABELS },


### PR DESCRIPTION
Aligns labels left as per design (I had some trouble with switching the layout to vertical, we may need a custom component here if we want to render the `Legend` outside of the chart itself--depends on how closely we want to follow the designs.) Also shortened some labels to get them to fit! 

Before:
<img width="400" alt="Screenshot 2025-08-12 114030" src="https://github.com/user-attachments/assets/ce60a34b-65ee-421b-a57e-a790db184dea" />

After:
<img width="400" alt="Screenshot 2025-08-12 114045" src="https://github.com/user-attachments/assets/c73a88e4-43b6-4b44-98f5-99ceb401f1e6" />
