### PR TITLE
style: fix survey label and card alignment

### DIFF
--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -75,7 +75,7 @@ export default function SurveyPage() {
                     <p className="text-lg md:text-xl">So far, <Highlight>{surveyResults.numberResponses}</Highlight> people have responded.</p>
                     
                     <div className="flex flex-col py-4">
-                      <h2 className="text-xl font-bold">Who has responded?</h2>
+                      <h2 className="text-xl font-bold my-8">Who has responded?</h2>
                       <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
                         <Country />
                         <Age />
@@ -84,7 +84,7 @@ export default function SurveyPage() {
                     </div>
 
                     <div className="flex flex-col">
-                      <h2 className="text-xl font-bold">Housing preferences</h2>
+                      <h2 className="text-xl font-bold my-8">Housing preferences</h2>
                       <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
                         <IdealHouseType />
                         <IdealLiveWith />
@@ -100,7 +100,7 @@ export default function SurveyPage() {
                         <WhyFairhold />
                         <WhyNotFairhold />
                       </div>
-                      <div className="flex flex-col md:flex-row  md:h-[30rem] p-4">
+                      <div className="flex flex-col md:flex-row  md:h-[30rem] p-4 mb-4">
                         <div className="md:w-1/2 w-full mr-4">
                           <AnyMeansTenureChoice />
                         </div>
@@ -109,7 +109,7 @@ export default function SurveyPage() {
                     </div>
 
                     <div className="flex flex-col">
-                      <h2 className="text-xl font-bold">Attitudes towards development</h2>
+                      <h2 className="text-xl font-bold my-8">Attitudes towards development</h2>
                       <div className="flex flex-col md:flex-row w-full md:gap-8 p-4">
                         <div className="flex flex-col md:w-1/2 w-full md:h-[60rem]">
                           <div className="flex-1 flex flex-col"> 

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -76,31 +76,31 @@ export default function SurveyPage() {
                     
                     <div className="flex flex-col py-4">
                       <h2 className="text-xl font-bold my-8">Who has responded?</h2>
-                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
+                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
                         <Country />
                         <Age />
                         {/* <Postcode {...results} /> */}
                       </div>
                     </div>
 
-                    <div className="flex flex-col">
+                    <div className="flex flex-col gap-8 ">
                       <h2 className="text-xl font-bold my-8">Housing preferences</h2>
-                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
+                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
                         <IdealHouseType />
                         <IdealLiveWith />
                       </div>
-                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
+                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
                         <HousingOutcomes />
                         <AffordFairhold />
                       </div>
-                      <div className="flex flex-col md:flex-row md:h-[50rem] p-4">
+                      <div className="flex flex-col md:flex-row md:h-[50rem]">
                         <CurrentMeansTenureChoice />
                       </div>
-                      <div className="flex flex-col md:flex-row md:h-[30rem] p-4">
+                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
                         <WhyFairhold />
                         <WhyNotFairhold />
                       </div>
-                      <div className="flex flex-col md:flex-row  md:h-[30rem] p-4 mb-4">
+                      <div className="flex flex-col md:flex-row  md:h-[30rem] mb-4">
                         <div className="md:w-1/2 w-full mr-4">
                           <AnyMeansTenureChoice />
                         </div>
@@ -108,10 +108,10 @@ export default function SurveyPage() {
                       </div>
                     </div>
 
-                    <div className="flex flex-col">
+                    <div className="flex flex-col pb-8">
                       <h2 className="text-xl font-bold my-8">Attitudes towards development</h2>
-                      <div className="flex flex-col md:flex-row w-full md:gap-8 p-4">
-                        <div className="flex flex-col md:w-1/2 w-full md:h-[60rem]">
+                      <div className="flex flex-col md:flex-row w-full md:gap-8">
+                        <div className="flex flex-col md:w-1/2 w-full gap-8 md:h-[60rem]">
                           <div className="flex-1 flex flex-col"> 
                             <SupportDevelopment />
                           </div>

--- a/components/custom/survey/SurveyGraphCard.tsx
+++ b/components/custom/survey/SurveyGraphCard.tsx
@@ -8,7 +8,7 @@ type Props = React.PropsWithChildren<{
 
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children }) => {
   return (
-    <div className="flex flex-1 flex-col justify-center h-full w-full bg-white m-4 p-4">
+    <div className="flex flex-1 flex-col justify-center h-full w-full bg-white p-4">
         <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black mt-0`}>{title}</h3>
                 {(subtitle || action) && (
           <div className="flex items-center gap-4 mt-2">

--- a/components/custom/survey/SurveyGraphCard.tsx
+++ b/components/custom/survey/SurveyGraphCard.tsx
@@ -9,7 +9,7 @@ type Props = React.PropsWithChildren<{
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children }) => {
   return (
     <div className="flex flex-1 flex-col justify-center h-full w-full bg-white m-4 p-4">
-        <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black`}>{title}</h3>
+        <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black mt-0`}>{title}</h3>
                 {(subtitle || action) && (
           <div className="flex items-center gap-4 mt-2">
             {subtitle && (


### PR DESCRIPTION
Aligns `h2` vertically in between `SurveyGraphCard`, aligns leftmost `SurveyGraphCard` left with `h2`, makes the padding around `SurveyGraphCard` titles consistent / even. 

Before: 
<img width="500" alt="Screenshot 2025-08-12 124040" src="https://github.com/user-attachments/assets/36b1fd75-53d4-4e51-a85d-50c78169c0d4" />

After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/17ec85e5-203a-432b-8ebc-c124130353e0" />
