### PR TITLE
style: justify sankey labels to nodes

### DIFF
--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -14,6 +14,7 @@ type CustomNodeProps = {
 
 type NodePayload = {
     name: string;
+    label?: string;
     sourceNodes: [];
     sourceLinks: [];
     targetLinks: [];
@@ -69,8 +70,8 @@ export const CustomSankey: React.FC<SankeyProps> = ({
     // Custom Node Component with Label 
     const CustomNode = (props: CustomNodeProps) => { 
         const isLeft = props.payload.depth === 0;
-        const adjustmentFactor = 80;
-        return ( 
+        const adjustmentFactor = 10;
+            return ( 
             <g> 
                 <Rectangle 
                     {...props} 
@@ -79,18 +80,18 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                 <text 
                     x={isLeft ? props.x - adjustmentFactor : props.x + props.width + adjustmentFactor}
                     y={props.y + props.height / 2} 
-                    textAnchor={isLeft ? "start" : "end"}
+                    textAnchor={isLeft ? "end" : "start"}
                     dominantBaseline="middle" 
                     fill={props.payload.color} 
                     fontSize={14}
                     fontWeight={"bold"}
                     fillOpacity={0.8}
                 > 
-                    {props.payload.name} 
+                    {props.payload.label || props.payload.name} 
                 </text> 
             </g> 
         ); 
-    }; 
+    };
 
     // Custom Link Component with Label 
     const CustomLink = (props: CustomLinkProps) => { 

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -180,7 +180,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                         nodePadding={50}
                         margin={{
                             left: 150,
-                            right: 100,
+                            right: 150,
                             top: 50,
                             bottom: 50,
                         }}


### PR DESCRIPTION
Swaps text anchor (start and end) and adjusts sankey margin.

Before:
<img width="500" alt="Screenshot 2025-08-13 102207" src="https://github.com/user-attachments/assets/78bd4c69-687c-4110-aa37-e71a937230f8" />

After:
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/c7d47b45-afb8-49ff-acc8-77b1e0b515fa" />

