### PR TITLE
feat: animate on view, not load

### DIFF
--- a/components/custom/survey/SurveyGraphCard.tsx
+++ b/components/custom/survey/SurveyGraphCard.tsx
@@ -1,18 +1,22 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import React from "react";
+import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
-type Props = React.PropsWithChildren<{
+type Props = {
   title: string;
   subtitle?: React.ReactNode;
   action?: React.ReactNode;
   loading?: boolean;
-}>;
+  children?: (animate: boolean) => React.ReactNode;
+};
 
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children, loading }) => {
+  const { ref, animate } = useAnimateOnView();
+
   return (
-    <div className="flex flex-1 flex-col justify-center h-full w-full bg-white p-4">
+    <div ref={ref} className="flex flex-1 flex-col justify-center h-full w-full bg-white p-4">
         <h3 className={`text-xl md:text-lg sm:text-md font-bold text-black mt-0`}>{title}</h3>
-                {(subtitle || action) && (
+        {(subtitle || action) && (
           <div className="flex items-center gap-4 mt-2">
             {subtitle && (
               <p className="text-md font-normal" style={{ color: "rgba(var(--survey-grey-mid))" }}>
@@ -30,8 +34,7 @@ const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children, l
                 <Skeleton className="h-6 w-1/2 rounded-xl bg-gray-200" /> 
               </div>
             </div>
-          ) : children
-        }
+          ) : (typeof children === "function" ? children(animate) : children)}
         </div>
       </div>
   );

--- a/components/custom/survey/SurveyGraphCard.tsx
+++ b/components/custom/survey/SurveyGraphCard.tsx
@@ -7,7 +7,7 @@ type Props = {
   subtitle?: React.ReactNode;
   action?: React.ReactNode;
   loading?: boolean;
-  children?: (animate: boolean) => React.ReactNode;
+  children?: React.ReactNode | ((animate: boolean) => React.ReactNode);
 };
 
 const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children, loading }) => {

--- a/components/custom/survey/graphs/AffordFairhold.tsx
+++ b/components/custom/survey/graphs/AffordFairhold.tsx
@@ -2,8 +2,6 @@ import React from "react"
 import SurveyGraphCard from "@components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
-import { useAnimateOnView } from "@hooks/UseAnimateOnView";
-
 export const AffordFairhold: React.FC = () => {
     const { affordFairhold } = useSurveyContext().surveyResults.barOrPie;
     const { loading } = useSurveyContext(); 
@@ -12,35 +10,35 @@ export const AffordFairhold: React.FC = () => {
       "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--social-rent-land-color-rgb))" 
     ];
 
-    const { ref, animate } = useAnimateOnView();
-
     return (
         <SurveyGraphCard title="Could you afford to buy a Fairhold home in your area?" loading={loading}>
-            <div ref={ref} style={{ width: "100%", height: "100%" }}>
-            <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                    <Pie 
-                        data={affordFairhold} 
-                        dataKey="value" 
-                        nameKey="answer" 
-                        fill="rgb(var(--survey-placeholder))" 
-                        innerRadius="60%"
-                        outerRadius="80%"
-                        isAnimationActive={animate}
-                        >
-                    {affordFairhold.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={COLORS[index]} />
-                    ))}
-                    </Pie>
-                    <Legend 
-                        align="left" 
-                        height={50}
-                        verticalAlign="bottom" 
-                        wrapperStyle={{ fontSize: 14 }}
-                        />
-                </PieChart>
-            </ResponsiveContainer>
-            </div>
+            {(animate) => (
+                <div style={{ width: "100%", height: "100%" }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                        <PieChart>
+                            <Pie 
+                                data={affordFairhold} 
+                                dataKey="value" 
+                                nameKey="answer" 
+                                fill="rgb(var(--survey-placeholder))" 
+                                innerRadius="60%"
+                                outerRadius="80%"
+                                isAnimationActive={animate}
+                                >
+                            {affordFairhold.map((entry, index) => (
+                                <Cell key={`cell-${index}`} fill={COLORS[index]} />
+                            ))}
+                            </Pie>
+                            <Legend 
+                                align="left" 
+                                height={50}
+                                verticalAlign="bottom" 
+                                wrapperStyle={{ fontSize: 14 }}
+                            />
+                        </PieChart>
+                    </ResponsiveContainer>
+                </div>
+            )}
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/AffordFairhold.tsx
+++ b/components/custom/survey/graphs/AffordFairhold.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import SurveyGraphCard from "@components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
+import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const AffordFairhold: React.FC = () => {
     const { affordFairhold } = useSurveyContext().surveyResults.barOrPie;
@@ -11,8 +12,11 @@ export const AffordFairhold: React.FC = () => {
       "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--social-rent-land-color-rgb))" 
     ];
 
+    const { ref, animate } = useAnimateOnView();
+
     return (
         <SurveyGraphCard title="Could you afford to buy a Fairhold home in your area?" loading={loading}>
+            <div ref={ref} style={{ width: "100%", height: "100%" }}>
             <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                     <Pie 
@@ -22,6 +26,7 @@ export const AffordFairhold: React.FC = () => {
                         fill="rgb(var(--survey-placeholder))" 
                         innerRadius="60%"
                         outerRadius="80%"
+                        isAnimationActive={animate}
                         >
                     {affordFairhold.map((entry, index) => (
                         <Cell key={`cell-${index}`} fill={COLORS[index]} />
@@ -35,6 +40,7 @@ export const AffordFairhold: React.FC = () => {
                         />
                 </PieChart>
             </ResponsiveContainer>
+            </div>
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/Age.tsx
+++ b/components/custom/survey/graphs/Age.tsx
@@ -3,7 +3,6 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 import { BarOrPieResult } from "@/lib/survey/types";
-import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const Age: React.FC = () => {
     const { ageGroup } = useSurveyContext().surveyResults.barOrPie as { ageGroup: BarOrPieResult[] };
@@ -16,13 +15,11 @@ export const Age: React.FC = () => {
     const renderLegendText = (value: string) => (
         <span style={{ color: "rgb(var(--survey-grey-mid))" }}>{value}</span>
         );
-  
-  
-    const { ref, animate } = useAnimateOnView();
 
     return (
         <SurveyGraphCard title="How old are you?" loading={loading}>
-            <div ref={ref} style={{ width: "100%", height: "100%" }}>
+        {(animate) => (
+            <div style={{ width: "100%", height: "100%" }}>
                 <ResponsiveContainer width="100%" height="100%">
                     <PieChart>
                         <Pie 
@@ -42,11 +39,12 @@ export const Age: React.FC = () => {
                             align="left" 
                             verticalAlign="bottom" 
                             formatter={renderLegendText}
-                        wrapperStyle={{ fontSize: 14 }}
+                            wrapperStyle={{ fontSize: 14 }}
                         />
                     </PieChart>
                 </ResponsiveContainer>
             </div>
+        )}
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/Age.tsx
+++ b/components/custom/survey/graphs/Age.tsx
@@ -3,6 +3,7 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 import { BarOrPieResult } from "@/lib/survey/types";
+import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const Age: React.FC = () => {
     const { ageGroup } = useSurveyContext().surveyResults.barOrPie as { ageGroup: BarOrPieResult[] };
@@ -16,30 +17,36 @@ export const Age: React.FC = () => {
         <span style={{ color: "rgb(var(--survey-grey-mid))" }}>{value}</span>
         );
   
+  
+    const { ref, animate } = useAnimateOnView();
+
     return (
         <SurveyGraphCard title="How old are you?" loading={loading}>
-            <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                    <Pie 
-                        data={ageGroup} 
-                        dataKey="value" 
-                        nameKey="answer" 
-                        fill="rgb(var(--survey-placeholder))" 
-                        innerRadius="60%"
-                        outerRadius="80%"
-                        >
-                        {ageGroup.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                        ))}
-                    </Pie>
-                    <Legend 
-                        align="left" 
-                        verticalAlign="bottom" 
-                        formatter={renderLegendText}
+            <div ref={ref} style={{ width: "100%", height: "100%" }}>
+                <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                        <Pie 
+                            data={ageGroup} 
+                            dataKey="value" 
+                            nameKey="answer" 
+                            fill="rgb(var(--survey-placeholder))" 
+                            innerRadius="60%"
+                            outerRadius="80%"
+                            isAnimationActive={animate}
+                            >
+                            {ageGroup.map((entry, index) => (
+                                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                            ))}
+                        </Pie>
+                        <Legend 
+                            align="left" 
+                            verticalAlign="bottom" 
+                            formatter={renderLegendText}
                         wrapperStyle={{ fontSize: 14 }}
-                    />
-                </PieChart>
-        </ResponsiveContainer>
+                        />
+                    </PieChart>
+                </ResponsiveContainer>
+            </div>
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/AnyMeansTenureChoice.tsx
+++ b/components/custom/survey/graphs/AnyMeansTenureChoice.tsx
@@ -50,55 +50,62 @@ export const AnyMeansTenureChoice: React.FC = () => {
             title="Rank the tenures by preference"
             subtitle="If you could afford (and were eligible for) any type of home, which would you prefer?"
             loading={loading}
-            >
-          <ResponsiveContainer height={150}>
-          <BarChart
-              data={anyMeansTenureChoice}
-              barSize={20}
-              barGap={0}
-              layout="vertical"
-          >
-              <XAxis 
-                  type="number"
-                  height={20}
-                  fontSize={10}
-                  interval={10}
-                  axisLine={false}
-                  tickLine={false}
-                  tick={false}
-                  /> 
-              <YAxis 
-                  type="category"    
-                  dataKey="answer" 
-                  width={150} 
-                  fontSize={10}
-                  interval={0}
-                  tickLine={false}
-                  axisLine={false}
-                  tick={(props) => (
-                    <ColoredYAxisTick 
-                    {...props}
-                    />
-                )}
-                  /> 
-              <Bar dataKey="value">
-                {
-                    anyMeansTenureChoice.map(({ answer }, index) => (
-                        <Cell
-                            key={`cell-${index}`}
-                            fill={TENURE_COLORS[answer] || "rgb(var(--text-inaccessible-rgb))"}
+        >
+            {(animate) => (
+                <div style={{ width: "100%", height: "100%" }}>
+                    <ResponsiveContainer height={150}>
+                        <BarChart
+                            data={anyMeansTenureChoice}
+                            barSize={20}
+                    barGap={0}
+                    layout="vertical"
+                >
+                    <XAxis 
+                        type="number"
+                        height={20}
+                        fontSize={10}
+                        interval={10}
+                        axisLine={false}
+                        tickLine={false}
+                        tick={false}
+                        /> 
+                    <YAxis 
+                        type="category"    
+                        dataKey="answer" 
+                        width={150} 
+                        fontSize={10}
+                        interval={0}
+                        tickLine={false}
+                        axisLine={false}
+                        tick={(props) => (
+                            <ColoredYAxisTick 
+                            {...props}
+                            />
+                        )}
+                        /> 
+                    <Bar 
+                        dataKey="value"
+                        isAnimationActive={animate}
+                    >
+                        {
+                            anyMeansTenureChoice.map(({ answer }, index) => (
+                                <Cell
+                                    key={`cell-${index}`}
+                                    fill={TENURE_COLORS[answer] || "rgb(var(--text-inaccessible-rgb))"}
+                                />
+                            ))
+                        }
+                        <LabelList 
+                            dataKey="value"
+                            position="insideStart"
+                            fill="white"    
+                            content={RankLabel}
                         />
-                    ))
-                }
-                <LabelList 
-                    dataKey="value"
-                    position="insideStart"
-                    fill="white"    
-                    content={RankLabel}
-                />
-                </Bar>  
-          </BarChart>
-          </ResponsiveContainer>
+                        </Bar>  
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
+            )}
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/Country.tsx
+++ b/components/custom/survey/graphs/Country.tsx
@@ -3,6 +3,7 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 import { BarOrPieResult } from "@/lib/survey/types";
+import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const Country: React.FC = () => {
   const { uk } = useSurveyContext().surveyResults.barOrPie as { uk: BarOrPieResult[] };
@@ -11,30 +12,35 @@ export const Country: React.FC = () => {
   const COLORS = [
     "rgb(var(--survey-blue))", "rgb(var(--survey-blue-light))"
   ];
+
+    const { ref, animate } = useAnimateOnView();
   
   return (
     <SurveyGraphCard title="Where do you live?" loading={loading}>
-      <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-          <Pie 
-            data={uk} 
-            dataKey="value" 
-            nameKey="answer" 
-            fill="rgb(var(--survey-placeholder))" 
-            innerRadius="60%"
-            outerRadius="80%"
-            >
-            {uk.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-            ))}
-            </Pie>
-          <Legend 
-            align="left" 
-            verticalAlign="bottom" 
-            wrapperStyle={{ fontSize: 14 }}
-          />
-          </PieChart>
-      </ResponsiveContainer>
+        <div ref={ref} style={{ width: "100%", height: "100%" }}>
+        <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+            <Pie 
+              data={uk} 
+              dataKey="value" 
+              nameKey="answer" 
+              fill="rgb(var(--survey-placeholder))" 
+              innerRadius="60%"
+              outerRadius="80%"
+                isAnimationActive={animate}
+              >
+              {uk.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+              </Pie>
+            <Legend 
+              align="left" 
+              verticalAlign="bottom" 
+              wrapperStyle={{ fontSize: 14 }}
+            />
+            </PieChart>
+        </ResponsiveContainer>
+        </div>
     </SurveyGraphCard>
   );
   };

--- a/components/custom/survey/graphs/Country.tsx
+++ b/components/custom/survey/graphs/Country.tsx
@@ -3,7 +3,6 @@ import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
 import { BarOrPieResult } from "@/lib/survey/types";
-import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const Country: React.FC = () => {
   const { uk } = useSurveyContext().surveyResults.barOrPie as { uk: BarOrPieResult[] };
@@ -12,35 +11,35 @@ export const Country: React.FC = () => {
   const COLORS = [
     "rgb(var(--survey-blue))", "rgb(var(--survey-blue-light))"
   ];
-
-    const { ref, animate } = useAnimateOnView();
   
   return (
     <SurveyGraphCard title="Where do you live?" loading={loading}>
-        <div ref={ref} style={{ width: "100%", height: "100%" }}>
-        <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-            <Pie 
-              data={uk} 
-              dataKey="value" 
-              nameKey="answer" 
-              fill="rgb(var(--survey-placeholder))" 
-              innerRadius="60%"
-              outerRadius="80%"
-                isAnimationActive={animate}
-              >
-              {uk.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-              ))}
-              </Pie>
-            <Legend 
-              align="left" 
-              verticalAlign="bottom" 
-              wrapperStyle={{ fontSize: 14 }}
-            />
-            </PieChart>
-        </ResponsiveContainer>
+      {(animate) => (
+        <div style={{ width: "100%", height: "100%" }}>
+          <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie 
+                  data={uk} 
+                  dataKey="value" 
+                  nameKey="answer" 
+                  fill="rgb(var(--survey-placeholder))" 
+                  innerRadius="60%"
+                  outerRadius="80%"
+                  isAnimationActive={animate}
+                  >
+                  {uk.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                  </Pie>
+                <Legend 
+                  align="left" 
+                  verticalAlign="bottom" 
+                  wrapperStyle={{ fontSize: 14 }}
+                />
+              </PieChart>
+          </ResponsiveContainer>
         </div>
+      )}
     </SurveyGraphCard>
   );
   };

--- a/components/custom/survey/graphs/HousingOutcomes.tsx
+++ b/components/custom/survey/graphs/HousingOutcomes.tsx
@@ -44,33 +44,38 @@ export const HousingOutcomes: React.FC = () => {
             />
             }  
             >
-
-            <ResponsiveContainer width="100%" height="100%">
-                <BarChart
-                    data={housingOutcomes[selectedTenure]}
-                    barSize={20}
-                    layout="vertical"
-                >
-                    <XAxis 
-                        type="number"
-                        tickLine={false}
-                        axisLine={false}
-                        tickCount={2}
-                        tickFormatter={(value: number) => Math.round(value).toString()}
-                        domain={[0, maxX]}
+                {(animate) => (
+                    <ResponsiveContainer width="100%" height="100%">
+                        <BarChart
+                            data={housingOutcomes[selectedTenure]}
+                            barSize={20}
+                            layout="vertical"
+                        >
+                            <XAxis 
+                                type="number"
+                                tickLine={false}
+                                axisLine={false}
+                                tickCount={2}
+                                tickFormatter={(value: number) => Math.round(value).toString()}
+                                domain={[0, maxX]}
                         /> 
-                    <YAxis 
-                        type="category"    
-                        dataKey="answer" 
-                        width={160} 
-                        interval={0}
-                        tick={(props) => <CustomTick {...props} />}
-                        tickLine={false}
-                        axisLine={false}
-                        /> 
-                    <Bar dataKey="value" fill={color} /> 
-                </BarChart>
-            </ResponsiveContainer>
+                            <YAxis 
+                                type="category"    
+                                dataKey="answer" 
+                                width={160} 
+                                interval={0}
+                                tick={(props) => <CustomTick {...props} />}
+                                tickLine={false}
+                                axisLine={false}
+                                /> 
+                            <Bar 
+                                dataKey="value" 
+                                fill={color} 
+                                isAnimationActive={animate}
+                            /> 
+                        </BarChart>
+                    </ResponsiveContainer>
+                )}
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/SupportDevelopment.tsx
+++ b/components/custom/survey/graphs/SupportDevelopment.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
+import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const SupportDevelopment: React.FC = () => {
     const { supportDevelopment } = useSurveyContext().surveyResults.barOrPie;
@@ -11,29 +12,34 @@ export const SupportDevelopment: React.FC = () => {
       "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--survey-orange))", "rgb(var(--survey-pink))", "rgb(var(--social-rent-land-color-rgb))", "rgb(var(--survey-grey-light))"
     ];
 
+    const { ref, animate } = useAnimateOnView();
+
     return (
         <SurveyGraphCard title="In general, do you support the development of new homes in your area?" loading={loading}>
-             <ResponsiveContainer height={300}>
-                <PieChart>
-                    <Pie 
-                        data={supportDevelopment} 
-                        dataKey="value" 
-                        nameKey="answer" 
-                        fill="rgb(var(--survey-placeholder))"
-                        innerRadius="60%"
-                        outerRadius="80%"
+            <div ref={ref} style={{ width: "100%", height: "100%" }}>
+                <ResponsiveContainer height={300}>
+                    <PieChart>
+                        <Pie 
+                            data={supportDevelopment} 
+                            dataKey="value" 
+                            nameKey="answer" 
+                            fill="rgb(var(--survey-placeholder))"
+                            innerRadius="60%"
+                            outerRadius="80%"
+                            isAnimationActive={animate}
                         >
                         {supportDevelopment.map((entry, index) => (
                             <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                         ))}
                     </Pie>
                     <Legend 
-                        align="left" 
+                        align="center" 
                         verticalAlign="bottom" 
-                        wrapperStyle={{ fontSize: 14 }}
+                        wrapperStyle={{ fontSize: 18 }}
                     />
              </PieChart>
             </ResponsiveContainer>
+        </div>
         </SurveyGraphCard>
     )
-}
+};

--- a/components/custom/survey/graphs/SupportDevelopmentFactors.tsx
+++ b/components/custom/survey/graphs/SupportDevelopmentFactors.tsx
@@ -10,31 +10,38 @@ export const SupportDevelopmentFactors: React.FC = () => {
 
   return (
     <SurveyGraphCard title="Which of these factors would make you more likely to support new homes being created near where you live?" loading={loading}>
-      <ResponsiveContainer height={480} width="100%">
-            <BarChart
-                data={supportDevelopmentFactors}
-                barSize={20}
-                layout="vertical"
-            >
-                <XAxis 
-                  type="number" 
-                  tick={false}
-                  tickLine={false}
-                  axisLine={false}                  
-                /> 
-                <YAxis 
-                    type="category"    
-                    dataKey="answer" 
-                    width={180} 
-                    interval={0}
-                    tick={(props) => <CustomTick {...props} />}
-                    axisLine={false}
-                    tickLine={false}
-                    /> 
-                    
-                <Bar dataKey="value" fill="rgb(var(--fairhold-equity-color-rgb))" /> 
-            </BarChart>
-            </ResponsiveContainer>
+            {(animate) => (
+                <div style={{ width: "100%", height: "100%" }}>
+              <ResponsiveContainer height={480} width="100%">
+                        <BarChart
+                            data={supportDevelopmentFactors}
+                            barSize={20}
+                            layout="vertical"
+                        >
+                            <XAxis 
+                                type="number" 
+                                tick={false}
+                                tickLine={false}
+                                axisLine={false}                  
+                            /> 
+                            <YAxis 
+                                type="category"    
+                                dataKey="answer" 
+                                width={180} 
+                                interval={0}
+                                tick={(props) => <CustomTick {...props} />}
+                                axisLine={false}
+                                tickLine={false}
+                            /> 
+                            <Bar 
+                            dataKey="value" 
+                            fill="rgb(var(--fairhold-equity-color-rgb))" 
+                            isAnimationActive={animate}
+                            /> 
+                        </BarChart>
+                    </ResponsiveContainer>
+                </div>
+            )}
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/SupportNewFairhold.tsx
+++ b/components/custom/survey/graphs/SupportNewFairhold.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
-import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const SupportNewFairhold: React.FC = () => {
     const { supportNewFairhold } = useSurveyContext().surveyResults.barOrPie;
@@ -11,35 +10,35 @@ export const SupportNewFairhold: React.FC = () => {
     const COLORS = [
       "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--survey-orange))", "rgb(var(--survey-pink))", "rgb(var(--social-rent-land-color-rgb))", "rgb(var(--survey-grey-light))"
     ];
-    
-    const { ref, animate } = useAnimateOnView();
-    
+        
     return (
         <SurveyGraphCard title="Would you support the creation of new Fairhold homes (or plots) in your area?" loading={loading}>
-            <div ref={ref} style={{ width: "100%", height: "100%" }}>
-                <ResponsiveContainer height={300}>
-                    <PieChart>
-                        <Pie 
-                            data={supportNewFairhold} 
-                            dataKey="value" 
-                            nameKey="answer" 
-                            fill="rgb(var(--survey-placeholder))" 
-                            innerRadius="60%"
-                            outerRadius="80%"
-                            isAnimationActive={animate}
-                            >
-                            {supportNewFairhold.map((entry, index) => (
-                                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                            ))}
-                        </Pie>
-                        <Legend 
-                            align="left" 
-                            verticalAlign="bottom" 
-                            wrapperStyle={{ fontSize: 14 }}
-                        />
-                </PieChart>
-                </ResponsiveContainer>
-            </div>
+            {(animate) => (
+                <div style={{ width: "100%", height: "100%" }}>
+                    <ResponsiveContainer height={300}>
+                        <PieChart>
+                            <Pie 
+                                data={supportNewFairhold} 
+                                dataKey="value" 
+                                nameKey="answer" 
+                                fill="rgb(var(--survey-placeholder))" 
+                                innerRadius="60%"
+                                outerRadius="80%"
+                                isAnimationActive={animate}
+                                >
+                                {supportNewFairhold.map((entry, index) => (
+                                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                                ))}
+                            </Pie>
+                            <Legend 
+                                align="left" 
+                                verticalAlign="bottom" 
+                                wrapperStyle={{ fontSize: 14 }}
+                            />
+                        </PieChart>
+                    </ResponsiveContainer>
+                </div>
+            )}
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/SupportNewFairhold.tsx
+++ b/components/custom/survey/graphs/SupportNewFairhold.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import SurveyGraphCard from "@/components/custom/survey/SurveyGraphCard";
 import { PieChart, Pie, Legend, ResponsiveContainer, Cell } from "recharts";
 import { useSurveyContext } from "@context/surveyContext";
-
+import { useAnimateOnView } from "@hooks/UseAnimateOnView";
 
 export const SupportNewFairhold: React.FC = () => {
     const { supportNewFairhold } = useSurveyContext().surveyResults.barOrPie;
@@ -12,29 +12,34 @@ export const SupportNewFairhold: React.FC = () => {
       "rgb(var(--fairhold-equity-color-rgb))", "rgb(var(--fairhold-interest-color-rgb))", "rgb(var(--survey-orange))", "rgb(var(--survey-pink))", "rgb(var(--social-rent-land-color-rgb))", "rgb(var(--survey-grey-light))"
     ];
     
+    const { ref, animate } = useAnimateOnView();
+    
     return (
         <SurveyGraphCard title="Would you support the creation of new Fairhold homes (or plots) in your area?" loading={loading}>
-             <ResponsiveContainer height={300}>
-                <PieChart>
-                    <Pie 
-                        data={supportNewFairhold} 
-                        dataKey="value" 
-                        nameKey="answer" 
-                        fill="rgb(var(--survey-placeholder))" 
-                        innerRadius="60%"
-                        outerRadius="80%"
-                        >
-                        {supportNewFairhold.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                        ))}
-                    </Pie>
-                    <Legend 
-                        align="left" 
-                        verticalAlign="bottom" 
-                        wrapperStyle={{ fontSize: 14 }}
-                    />
-             </PieChart>
-            </ResponsiveContainer>
+            <div ref={ref} style={{ width: "100%", height: "100%" }}>
+                <ResponsiveContainer height={300}>
+                    <PieChart>
+                        <Pie 
+                            data={supportNewFairhold} 
+                            dataKey="value" 
+                            nameKey="answer" 
+                            fill="rgb(var(--survey-placeholder))" 
+                            innerRadius="60%"
+                            outerRadius="80%"
+                            isAnimationActive={animate}
+                            >
+                            {supportNewFairhold.map((entry, index) => (
+                                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                            ))}
+                        </Pie>
+                        <Legend 
+                            align="left" 
+                            verticalAlign="bottom" 
+                            wrapperStyle={{ fontSize: 14 }}
+                        />
+                </PieChart>
+                </ResponsiveContainer>
+            </div>
         </SurveyGraphCard>
     )
 }

--- a/components/custom/survey/graphs/WhyFairhold.tsx
+++ b/components/custom/survey/graphs/WhyFairhold.tsx
@@ -10,6 +10,7 @@ export const WhyFairhold: React.FC<{ maxX: number }> = ({ maxX }) => {
   
   return (
       <SurveyGraphCard title="Why would you choose Fairhold?" loading={loading} >
+        {(animate) => (  
           <ResponsiveContainer height={150}>
           <BarChart
               data={whyFairhold}
@@ -38,9 +39,14 @@ export const WhyFairhold: React.FC<{ maxX: number }> = ({ maxX }) => {
                     />
                     }                        
                   /> 
-              <Bar dataKey="value" fill="rgb(var(--fairhold-equity-color-rgb))" /> 
+              <Bar 
+                dataKey="value" 
+                fill="rgb(var(--fairhold-equity-color-rgb))" 
+                isAnimationActive={animate}
+                /> 
           </BarChart>
           </ResponsiveContainer>
+        )}
       </SurveyGraphCard>
   )
 }

--- a/components/custom/survey/graphs/WhyNotFairhold.tsx
+++ b/components/custom/survey/graphs/WhyNotFairhold.tsx
@@ -10,31 +10,37 @@ export const WhyNotFairhold: React.FC<{ maxX: number }> = ({ maxX }) => {
   
   return (
       <SurveyGraphCard title="Why wouldn't you choose Fairhold?" loading={loading}>
-          <ResponsiveContainer height={150}>
-          <BarChart
-              data={whyNotFairhold}
-              barSize={20}
-              layout="vertical"
-          >
-              <XAxis 
-                  type="number" 
-                  tickLine={false}
-                  axisLine={false}
-                  tickCount={2}
-                  domain={[0, maxX]}
+          {(animate) => (
+            <ResponsiveContainer height={150}>
+            <BarChart
+                data={whyNotFairhold}
+                barSize={20}
+                layout="vertical"
+            >
+                <XAxis 
+                    type="number" 
+                    tickLine={false}
+                    axisLine={false}
+                    tickCount={2}
+                    domain={[0, maxX]}
                   /> 
-              <YAxis 
-                  type="category"    
-                  dataKey="answer" 
-                  width={150} 
-                  interval={0}
-                  tickLine={false}
-                  axisLine={false}
-                  tick={(props) => <CustomTick {...props} />}
-                /> 
-              <Bar dataKey="value" fill="rgb(var(--survey-placeholder))" /> 
-          </BarChart>
-          </ResponsiveContainer>
+                <YAxis 
+                    type="category"    
+                    dataKey="answer" 
+                    width={150} 
+                    interval={0}
+                    tickLine={false}
+                    axisLine={false}
+                    tick={(props) => <CustomTick {...props} />}
+                    /> 
+                <Bar 
+                    dataKey="value" 
+                    fill="rgb(var(--survey-placeholder))"
+                    isAnimationActive={animate}
+                    /> 
+            </BarChart>
+            </ResponsiveContainer>
+          )}
       </SurveyGraphCard>
   )
 }

--- a/hooks/UseAnimateOnView.tsx
+++ b/hooks/UseAnimateOnView.tsx
@@ -1,0 +1,12 @@
+import { useInView } from "react-intersection-observer";
+
+/**
+ * Returns boolean indicating if element is in view.
+ */
+export function useAnimateOnView(threshold = 0.01) {
+  const { ref, inView } = useInView({
+    triggerOnce: true,
+    threshold,
+  });
+  return { ref, animate: inView };
+}

--- a/hooks/UseAnimateOnView.tsx
+++ b/hooks/UseAnimateOnView.tsx
@@ -3,10 +3,11 @@ import { useInView } from "react-intersection-observer";
 /**
  * Returns boolean indicating if element is in view.
  */
-export function useAnimateOnView(threshold = 0.01) {
+export function useAnimateOnView(threshold = 0.01, delay = 0.5) {
   const { ref, inView } = useInView({
     triggerOnce: true,
     threshold,
+    delay
   });
   return { ref, animate: inView };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.62.0",
+        "react-intersection-observer": "^9.16.0",
         "react-markdown": "^10.1.0",
         "react-spinners": "^0.17.0",
         "recharts": "^2.15.4",
@@ -15861,6 +15862,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.62.0",
+    "react-intersection-observer": "^9.16.0",
     "react-markdown": "^10.1.0",
     "react-spinners": "^0.17.0",
     "recharts": "^2.15.4",


### PR DESCRIPTION
# What does this PR do?
- Installs `react-intersection-observer` dependency
- Creates new `useAnimateOnView` hook using `useInView`
- Uses hook in all survey results doughnut graphs

# Why?
To animate on view and not on load, for a slightly nicer UX / fancy touch ✨ 

Closes #617