### PR TITLE
feat: show survey results skeleton while loading

### DIFF
--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -59,9 +59,7 @@ export default function SurveyPage() {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen w-full bg-gray-50">
-      <Header />
-      <div className="hidden md:block top-spacer"/>
+      <SurveyLayout>
         <SurveyContext.Provider value={surveyResults}>
         <main className="flex justify-center main-content">
           <section className="w-full max-w-[960px] flex flex-row py-8">
@@ -133,17 +131,14 @@ export default function SurveyPage() {
             </section>
           </main>
         </SurveyContext.Provider>
-      <Footer />
-      </div>
+      </SurveyLayout>
     </ErrorBoundary>
   );
 }
 
 const SurveySkeleton: React.FC<React.PropsWithChildren> = () => (
   <ErrorBoundary>
-    <div role ="status" className="min-h-screen w-full bg-gray-50">
-      <Header />
-      <div className="hidden md:block top-spacer"/>
+        <SurveyLayout>
           <main className="flex justify-center main-content">
             <section className="w-full max-w-[960px] flex flex-row py-8">
               <div className="flex flex-row">
@@ -207,6 +202,15 @@ const SurveySkeleton: React.FC<React.PropsWithChildren> = () => (
                 </div>
           </section>
         </main>
-      </div>
+        </SurveyLayout>
     </ErrorBoundary>
   )
+
+const SurveyLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="min-h-screen w-full bg-gray-50">
+    <Header />
+    <div className="hidden md:block top-spacer"/>
+    {children}
+    <Footer />
+  </div>
+);

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -53,84 +53,82 @@ export default function SurveyPage() {
     fetchSurveyData();
   }, []);
 
-  if (loading) return <SurveySkeleton />;
-  if (error) return <div>Error: {error}</div>;
-  if (!surveyResults) return <div>No survey data available.</div>;
-
   return (
     <ErrorBoundary>
       <SurveyLayout>
+        {loading ? (
+          <SurveySkeleton />
+        ) : error ? (
+          <div>Error: {error}</div>
+        ) : !surveyResults ? (
+          <div>No survey data available.</div>
+        ) : (
         <SurveyContext.Provider value={surveyResults}>
-        <main className="flex justify-center main-content">
-          <section className="w-full max-w-[960px] flex flex-row py-8">
-            <div className="flex flex-row">
-                <div className="w-full flex flex-col p-4">
-                  <h1 className="h1-style text-2xl md:text-4xl">Fairhold survey results</h1>
-                    <div className="flex flex-col gap-4 mt-6">
-                    {surveyResults.numberResponses === 0 ? (
-                  <p>No survey responses found.</p>
-                ) : (
-                  <>
-                    <p className="text-lg md:text-xl">So far, <Highlight>{surveyResults.numberResponses}</Highlight> people have responded.</p>
-                    
-                    <div className="flex flex-col py-4">
-                      <h2 className="text-xl font-bold my-8">Who has responded?</h2>
-                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
-                        <Country />
-                        <Age />
-                        {/* <Postcode {...results} /> */}
+          <main className="flex justify-center main-content">
+            <section className="w-full max-w-[960px] flex flex-row py-8">
+              <div className="flex flex-row">
+                  <div className="w-full flex flex-col p-4">
+                    <h1 className="h1-style text-2xl md:text-4xl">Fairhold survey results</h1>
+                      <div className="flex flex-col gap-4 mt-6">
+                      <p className="text-lg md:text-xl">So far, <Highlight>{surveyResults.numberResponses}</Highlight> people have responded.</p>
+                      
+                      <div className="flex flex-col py-4">
+                        <h2 className="text-xl font-bold my-8">Who has responded?</h2>
+                        <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
+                          <Country />
+                          <Age />
+                          {/* <Postcode {...results} /> */}
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="flex flex-col gap-8 ">
-                      <h2 className="text-xl font-bold my-8">Housing preferences</h2>
-                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
-                        <IdealHouseType />
-                        <IdealLiveWith />
-                      </div>
-                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
-                        <HousingOutcomes />
-                        <AffordFairhold />
-                      </div>
-                      <div className="flex flex-col md:flex-row md:h-[50rem]">
-                        <CurrentMeansTenureChoice />
-                      </div>
-                      <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
-                        <WhyFairhold />
-                        <WhyNotFairhold />
-                      </div>
-                      <div className="flex flex-col md:flex-row  md:h-[30rem] mb-4">
-                        <div className="md:w-1/2 w-full mr-4">
-                          <AnyMeansTenureChoice />
+                      <div className="flex flex-col gap-8 ">
+                        <h2 className="text-xl font-bold my-8">Housing preferences</h2>
+                        <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
+                          <IdealHouseType />
+                          <IdealLiveWith />
                         </div>
-                        <div className="md:w-1/2 md:mr-4 hidden"></div>
+                        <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
+                          <HousingOutcomes />
+                          <AffordFairhold />
+                        </div>
+                        <div className="flex flex-col md:flex-row md:h-[50rem]">
+                          <CurrentMeansTenureChoice />
+                        </div>
+                        <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
+                          <WhyFairhold />
+                          <WhyNotFairhold />
+                        </div>
+                        <div className="flex flex-col md:flex-row  md:h-[30rem] mb-4">
+                          <div className="md:w-1/2 w-full mr-4">
+                            <AnyMeansTenureChoice />
+                          </div>
+                          <div className="md:w-1/2 md:mr-4 hidden"></div>
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="flex flex-col pb-8">
-                      <h2 className="text-xl font-bold my-8">Attitudes towards development</h2>
-                      <div className="flex flex-col md:flex-row w-full md:gap-8">
-                        <div className="flex flex-col md:w-1/2 w-full gap-8 md:h-[60rem]">
-                          <div className="flex-1 flex flex-col"> 
-                            <SupportDevelopment />
+                      <div className="flex flex-col pb-8">
+                        <h2 className="text-xl font-bold my-8">Attitudes towards development</h2>
+                        <div className="flex flex-col md:flex-row w-full md:gap-8">
+                          <div className="flex flex-col md:w-1/2 w-full gap-8 md:h-[60rem]">
+                            <div className="flex-1 flex flex-col"> 
+                              <SupportDevelopment />
+                            </div>
+                            <div className="flex-1 flex flex-col">
+                              <SupportNewFairhold />
+                            </div>
                           </div>
-                          <div className="flex-1 flex flex-col">
-                            <SupportNewFairhold />
+                          <div className="flex flex-col md:flex-row md:w-1/2 w-full md:h-[60rem]">
+                            <SupportDevelopmentFactors />
                           </div>
-                        </div>
-                        <div className="flex flex-col md:flex-row md:w-1/2 w-full md:h-[60rem]">
-                          <SupportDevelopmentFactors />
                         </div>
                       </div>
                     </div>
-                  </>
-                )}
                   </div>
-                </div>
-            </div>
+              </div>
             </section>
           </main>
         </SurveyContext.Provider>
+        )}
       </SurveyLayout>
     </ErrorBoundary>
   );
@@ -138,71 +136,69 @@ export default function SurveyPage() {
 
 const SurveySkeleton: React.FC<React.PropsWithChildren> = () => (
   <ErrorBoundary>
-        <SurveyLayout>
-          <main className="flex justify-center main-content">
-            <section className="w-full max-w-[960px] flex flex-row py-8">
-              <div className="flex flex-row">
-                  <div className="w-full flex flex-col p-4">
-                    <h1 className="h1-style text-2xl md:text-4xl">Fairhold survey results</h1>
-                    <div className="flex flex-col gap-4 mt-6">
-                        <p className="text-lg md:text-xl">So far, <Highlight>...</Highlight> people have responded.</p>
+    <main className="flex justify-center main-content">
+      <section className="w-full max-w-[960px] flex flex-row py-8">
+        <div className="flex flex-row">
+            <div className="w-full flex flex-col p-4">
+              <h1 className="h1-style text-2xl md:text-4xl">Fairhold survey results</h1>
+              <div className="flex flex-col gap-4 mt-6">
+                  <p className="text-lg md:text-xl">So far, <Highlight>...</Highlight> people have responded.</p>
 
-                        <div className="flex flex-col py-4">
-                          <h2 className="text-xl font-bold my-8">Who has responded?</h2>
-                          <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
-                            <SurveyGraphCard title="Where do you live?" />
-                            <SurveyGraphCard title="How old are you?" />
-                          </div>
-                        </div>
-
-                        <div className="flex flex-col gap-8">
-                          <h2 className="text-xl font-bold my-8">Housing preferences</h2>
-                          <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
-                            <SurveyGraphCard title="What type of home do you want to live in?" />
-                            <SurveyGraphCard title="Who do you want to live with?" />
-                          </div>
-                          <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
-                            <SurveyGraphCard title="What do you most want from housing that you don't currently get?" />
-                            <SurveyGraphCard title="Could you afford to buy a Fairhold home in your area?" />
-                          </div>
-                          <div className="flex flex-col md:flex-row md:h-[50rem]">
-                            <SurveyGraphCard title="Which tenure would you choose?" />
-                          </div>
-                          <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
-                            <SurveyGraphCard title="Why would you choose Fairhold?" />
-                            <SurveyGraphCard title="Why wouldn't you choose Fairhold?" />
-                          </div>
-                          <div className="flex flex-col md:flex-row  md:h-[30rem]">
-                            <div className="md:w-1/2 w-full mr-4">
-                              <SurveyGraphCard title="Rank the tenures by preference" />
-                            </div>
-                            <div className="md:w-1/2 md:mr-4 hidden"></div>
-                          </div>
-                        </div>
-
-                     <div className="flex flex-col pb-8">
-                       <h2 className="text-xl font-bold my-8">Attitudes towards development</h2>
-                       <div className="flex flex-col md:flex-row w-full md:gap-8">
-                         <div className="flex flex-col md:w-1/2 w-full gap-8 md:h-[60rem]">
-                           <div className="flex-1 flex flex-col"> 
-                                <SurveyGraphCard title="In general, do you support the development of new homes in your area?" />
-                           </div>
-                           <div className="flex-1 flex flex-col">
-                                <SurveyGraphCard title="Would you support the creation of new Fairhold homes (or plots) in your area?" />
-                           </div>
-                         </div>
-                         <div className="flex flex-col md:flex-row md:w-1/2 w-full md:h-[60rem]">
-                              <SurveyGraphCard title="Which of these factors would make you more likely to support new homes being created near where you live?" />
-                         </div>
-                       </div>
-
-                      </div>
+                  <div className="flex flex-col py-4">
+                    <h2 className="text-xl font-bold my-8">Who has responded?</h2>
+                    <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
+                      <SurveyGraphCard title="Where do you live?" />
+                      <SurveyGraphCard title="How old are you?" />
                     </div>
                   </div>
+
+                  <div className="flex flex-col gap-8">
+                    <h2 className="text-xl font-bold my-8">Housing preferences</h2>
+                    <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
+                      <SurveyGraphCard title="What type of home do you want to live in?" />
+                      <SurveyGraphCard title="Who do you want to live with?" />
+                    </div>
+                    <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
+                      <SurveyGraphCard title="What do you most want from housing that you don't currently get?" />
+                      <SurveyGraphCard title="Could you afford to buy a Fairhold home in your area?" />
+                    </div>
+                    <div className="flex flex-col md:flex-row md:h-[50rem]">
+                      <SurveyGraphCard title="Which tenure would you choose?" />
+                    </div>
+                    <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
+                      <SurveyGraphCard title="Why would you choose Fairhold?" />
+                      <SurveyGraphCard title="Why wouldn't you choose Fairhold?" />
+                    </div>
+                    <div className="flex flex-col md:flex-row  md:h-[30rem]">
+                      <div className="md:w-1/2 w-full mr-4">
+                        <SurveyGraphCard title="Rank the tenures by preference" />
+                      </div>
+                      <div className="md:w-1/2 md:mr-4 hidden"></div>
+                    </div>
+                  </div>
+
+                <div className="flex flex-col pb-8">
+                  <h2 className="text-xl font-bold my-8">Attitudes towards development</h2>
+                  <div className="flex flex-col md:flex-row w-full md:gap-8">
+                    <div className="flex flex-col md:w-1/2 w-full gap-8 md:h-[60rem]">
+                      <div className="flex-1 flex flex-col"> 
+                          <SurveyGraphCard title="In general, do you support the development of new homes in your area?" />
+                      </div>
+                      <div className="flex-1 flex flex-col">
+                          <SurveyGraphCard title="Would you support the creation of new Fairhold homes (or plots) in your area?" />
+                      </div>
+                    </div>
+                    <div className="flex flex-col md:flex-row md:w-1/2 w-full md:h-[60rem]">
+                        <SurveyGraphCard title="Which of these factors would make you more likely to support new homes being created near where you live?" />
+                    </div>
+                  </div>
+
+                  </div>
                 </div>
-          </section>
-        </main>
-        </SurveyLayout>
+              </div>
+            </div>
+      </section>
+    </main>
     </ErrorBoundary>
   )
 

--- a/app/survey/page.tsx
+++ b/app/survey/page.tsx
@@ -23,6 +23,7 @@ import { SurveyContext } from '@context/surveyContext';
 import { Header } from "@components/custom/ui/Header";
 import { Footer } from "@components/custom/ui/Footer";
 import Highlight from "@components/custom/ui/Highlight";
+import SurveyGraphCard from '@/components/custom/survey/SurveyGraphCard';
 
 export default function SurveyPage() {
   const [surveyResults, setSurveyResults] = useState<SurveyResults | null>(null);
@@ -52,7 +53,7 @@ export default function SurveyPage() {
     fetchSurveyData();
   }, []);
 
-  if (loading) return <div>Loading survey data...</div>;
+  if (loading) return <SurveySkeleton />;
   if (error) return <div>Error: {error}</div>;
   if (!surveyResults) return <div>No survey data available.</div>;
 
@@ -71,7 +72,7 @@ export default function SurveyPage() {
                     {surveyResults.numberResponses === 0 ? (
                   <p>No survey responses found.</p>
                 ) : (
-                  <div>
+                  <>
                     <p className="text-lg md:text-xl">So far, <Highlight>{surveyResults.numberResponses}</Highlight> people have responded.</p>
                     
                     <div className="flex flex-col py-4">
@@ -124,7 +125,7 @@ export default function SurveyPage() {
                         </div>
                       </div>
                     </div>
-                </div>
+                  </>
                 )}
                   </div>
                 </div>
@@ -137,3 +138,75 @@ export default function SurveyPage() {
     </ErrorBoundary>
   );
 }
+
+const SurveySkeleton: React.FC<React.PropsWithChildren> = () => (
+  <ErrorBoundary>
+    <div role ="status" className="min-h-screen w-full bg-gray-50">
+      <Header />
+      <div className="hidden md:block top-spacer"/>
+          <main className="flex justify-center main-content">
+            <section className="w-full max-w-[960px] flex flex-row py-8">
+              <div className="flex flex-row">
+                  <div className="w-full flex flex-col p-4">
+                    <h1 className="h1-style text-2xl md:text-4xl">Fairhold survey results</h1>
+                    <div className="flex flex-col gap-4 mt-6">
+                        <p className="text-lg md:text-xl">So far, <Highlight>...</Highlight> people have responded.</p>
+
+                        <div className="flex flex-col py-4">
+                          <h2 className="text-xl font-bold my-8">Who has responded?</h2>
+                          <div className="flex flex-col gap-8 md:flex-row md:h-[30rem]">
+                            <SurveyGraphCard title="Where do you live?" />
+                            <SurveyGraphCard title="How old are you?" />
+                          </div>
+                        </div>
+
+                        <div className="flex flex-col gap-8">
+                          <h2 className="text-xl font-bold my-8">Housing preferences</h2>
+                          <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
+                            <SurveyGraphCard title="What type of home do you want to live in?" />
+                            <SurveyGraphCard title="Who do you want to live with?" />
+                          </div>
+                          <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
+                            <SurveyGraphCard title="What do you most want from housing that you don't currently get?" />
+                            <SurveyGraphCard title="Could you afford to buy a Fairhold home in your area?" />
+                          </div>
+                          <div className="flex flex-col md:flex-row md:h-[50rem]">
+                            <SurveyGraphCard title="Which tenure would you choose?" />
+                          </div>
+                          <div className="flex flex-col md:flex-row md:h-[30rem] gap-8">
+                            <SurveyGraphCard title="Why would you choose Fairhold?" />
+                            <SurveyGraphCard title="Why wouldn't you choose Fairhold?" />
+                          </div>
+                          <div className="flex flex-col md:flex-row  md:h-[30rem]">
+                            <div className="md:w-1/2 w-full mr-4">
+                              <SurveyGraphCard title="Rank the tenures by preference" />
+                            </div>
+                            <div className="md:w-1/2 md:mr-4 hidden"></div>
+                          </div>
+                        </div>
+
+                     <div className="flex flex-col pb-8">
+                       <h2 className="text-xl font-bold my-8">Attitudes towards development</h2>
+                       <div className="flex flex-col md:flex-row w-full md:gap-8">
+                         <div className="flex flex-col md:w-1/2 w-full gap-8 md:h-[60rem]">
+                           <div className="flex-1 flex flex-col"> 
+                                <SurveyGraphCard title="In general, do you support the development of new homes in your area?" />
+                           </div>
+                           <div className="flex-1 flex flex-col">
+                                <SurveyGraphCard title="Would you support the creation of new Fairhold homes (or plots) in your area?" />
+                           </div>
+                         </div>
+                         <div className="flex flex-col md:flex-row md:w-1/2 w-full md:h-[60rem]">
+                              <SurveyGraphCard title="Which of these factors would make you more likely to support new homes being created near where you live?" />
+                         </div>
+                       </div>
+
+                      </div>
+                    </div>
+                  </div>
+                </div>
+          </section>
+        </main>
+      </div>
+    </ErrorBoundary>
+  )

--- a/components/custom/survey/SurveyGraphCard.tsx
+++ b/components/custom/survey/SurveyGraphCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { ClipLoader } from "react-spinners";
 
 type Props = React.PropsWithChildren<{
   title: string;
@@ -19,9 +20,17 @@ const SurveyGraphCard: React.FC<Props> = ({ title, subtitle, action, children })
             )}
             {action}
           </div>
-        )}      
-        {children && <div className="mt-4 flex-1">{children}</div>}
-    </div>
+        )}
+        <div className="mt-4 flex-1">
+          {children ? (
+            children
+          ) : (
+            <div className="flex items-center justify-center h-full w-full">
+              <ClipLoader />
+            </div>
+          )}
+        </div>
+      </div>
   );
 };
 


### PR DESCRIPTION
Replaces loading screen with a skeleton mimicking eventual content so that loading feels less jarring. 

Adds some conditional logic to `SurveyGraphCard` to show loading spinner while children load. 

Before: 
<img width="500" alt="Screenshot 2025-08-15 141655" src="https://github.com/user-attachments/assets/a0a42d3e-ac57-4bca-9b2a-1ccd51db523d" />

After:
<img width="500" alt="Screenshot 2025-08-15 141552" src="https://github.com/user-attachments/assets/a90c3671-ecc1-4edc-9d3b-fbf361b12312" />
