### PR TITLE
feat: calculator LoadingScreen

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import CalculatorInput from "../components/custom/ui/CalculatorInput";
-import { ClipLoader } from "react-spinners";
+import { LoadingScreen } from "@/components/custom/LoadingScreen";
 import { Suspense } from "react";
 import { Footer } from "../components/custom/ui/Footer";
 import { Header } from "../components/custom/ui/Header";
@@ -49,7 +49,7 @@ export default function Home() {
           {error}
           </div>
       )}
-      <Suspense fallback={<ClipLoader />}>
+      <Suspense fallback={<LoadingScreen />}>
         <CalculatorInput onSubmit={handleSubmit} isLoading={isSubmitting} />
       </Suspense>
       </div>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -3,7 +3,8 @@ import React, { useEffect, useState, Suspense } from "react";
 import Dashboard from "@components/custom/ui/Dashboard";
 import { Header } from "@components/custom/ui/Header";
 import { Footer } from "@components/custom/ui/Footer";
-import ClipLoader from "react-spinners/ClipLoader"; 
+// import ClipLoader from "react-spinners/ClipLoader"; 
+import { LoadingScreen } from "@/components/custom/LoadingScreen";
 import { useSearchParams } from "next/navigation";
 import { FormFrontend } from "@schemas/formSchema";
 import { MaintenanceLevel } from "@models/constants";
@@ -58,7 +59,7 @@ return (
       <section className="w-full max-w-[960px] flex flex-row py-8">
         <div className="w-full flex-1 flex justify-center">
                 {view === "loading" && (
-                    <ClipLoader color="black" size={50} />
+                    <LoadingScreen />
                 )}
                 {view === "dashboard" && data && (
                     <Dashboard processedData={data} />
@@ -73,7 +74,7 @@ const ResultsPage = () => (
     <div className="min-h-screen w-full bg-gray-50">
         <Header />
         <div className="hidden md:block top-spacer"/> 
-        <Suspense fallback={<ClipLoader color="black" size={50} />}>
+        <Suspense fallback={<LoadingScreen />}>
             <ResultsPageContent />
         </Suspense>
         <Footer />

--- a/components/custom/LoadingScreen.tsx
+++ b/components/custom/LoadingScreen.tsx
@@ -1,0 +1,10 @@
+import { ClipLoader } from "react-spinners";
+
+export const LoadingScreen = () => (
+    <div
+        className="flex flex-col justify-center items-center h-[60rem]"
+        style={{ bottom: "4rem" }}
+    >
+        <ClipLoader />
+    </div>
+)

--- a/components/custom/ui/CalculatorInput.tsx
+++ b/components/custom/ui/CalculatorInput.tsx
@@ -80,7 +80,7 @@ const CalculatorInput: React.FC<CalculatorInputProps> = ({ onSubmit, isLoading }
   });
 
     return (
-      <div className="flex flex-col justify-center w-full mx-auto">
+      <div className="flex flex-col justify-center w-full mx-auto md:h-[60rem]">
         <div className="h1-style text-lg md:text-xl lg:text-2xl">
           Calculate how much a Fairhold home might cost you
         </div>

--- a/components/custom/ui/Footer.tsx
+++ b/components/custom/ui/Footer.tsx
@@ -3,7 +3,7 @@ import "@app/webflow.css";
 import Image from "next/image";
 
 export const Footer: React.FC = () => (
-  <footer className="footer">
+  <footer className="footer md:h-100">
     <div className="w-layout-blockcontainer container w-container">
       <div className="columns w-row">
         <div className="column-6 w-col w-col-3"><a href="#" className="footer-link-block w-inline-block">


### PR DESCRIPTION
# What does this PR do?
- Creates new `LoadingScreen` component to use when calculator pages (form and results) load
- Uses fixed height for `CalculatorInput` and `Footer` on screens `md` and up so that the `LoadingScreen` can size accordingly
- Uses `LoadingScreen` instead of previous `ClipLoader`

# Why?
Previous loading screen was the wrong size and the footer would appear partway up the screen. 

Before:
<img width="500" alt="Screenshot 2025-08-15 152902" src="https://github.com/user-attachments/assets/8970f091-0999-46ea-a371-10b40f6c671c" />

After:
<img width="500" alt="Screenshot 2025-08-15 152834" src="https://github.com/user-attachments/assets/cfb6b295-f6f8-4669-b7ce-4643d21e96ad" />
