### PR TITLE
chore: update hookform resolver

### DIFF
--- a/components/custom/ui/CalculatorInput.tsx
+++ b/components/custom/ui/CalculatorInput.tsx
@@ -57,7 +57,7 @@ const CalculatorInput: React.FC<CalculatorInputProps> = ({ onSubmit, isLoading }
     { label: "Pre-1900", value: 130 },
   ] as const;
 
-  const form = useForm<FormFrontend>({
+  const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
       houseType:
@@ -197,7 +197,7 @@ const CalculatorInput: React.FC<CalculatorInputProps> = ({ onSubmit, isLoading }
                     </FormLabel>
                     <FormControl>
                     <InputDropdown
-                      value={field.value}
+                      value={Number(field.value)}
                       onValueChange={field.onChange}
                       options={AGE_OPTIONS}
                       placeholder="Select house age"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@hookform/resolvers": "^4.1.3",
+        "@hookform/resolvers": "^5.2.1",
         "@prisma/client": "^6.13.0",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -927,15 +927,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-4.1.3.tgz",
-      "integrity": "sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/utils": "^0.3.0"
       },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@hookform/resolvers": "^4.1.3",
+    "@hookform/resolvers": "^5.2.1",
     "@prisma/client": "^6.13.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",


### PR DESCRIPTION
So updating `@hookform/resolvers` to 5.2.1 has fixed our missing error bug (so closes #636) but to resolve some type errors following, I had to 1.) remove `<FormFrontend>`from `useForm` and 2.) add a type cast for our dropdown field. 

1.) I think this was because there was a mismatch between what Typescript expected and what Zod expected. The Zod resolver probably expects the input to be unknown because it's not typed before validation? 

2.) Because dropdowns typically expect strings, and we are mapping the string to a number in `AGE_OPTIONS`, we have to tell Typescript that the dropdown ends up returning a number. 

Both of these are confusing and not intuitive to me! Maybe it's worth spending another dev call on validation, my understanding of this part of the codebase is pretty convoluted. 