### PR TITLE
style: mobile sankeys

### DIFF
--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -1,6 +1,5 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { Sankey, Tooltip, Rectangle, ResponsiveContainer } from "recharts"; 
-
 
 type CustomNodeProps = {
     x: number;
@@ -66,6 +65,29 @@ export const CustomSankey: React.FC<SankeyProps> = ({
     leftLabel,
     rightLabel
 }) => {
+    const [margin, setMargin] = useState({
+        left: 150,
+        right: 150,
+        top: 50,
+        bottom: 50,
+    });
+
+    const [fontSize, setFontSize] = useState(14);
+
+    useEffect(() => {
+        const handleResize = () => {
+            if (window.innerWidth < 600) {
+                setMargin({ left: 90, right: 90, top: 40, bottom: 40 });
+                setFontSize(11);
+            } else {
+                setMargin({ left: 150, right: 150, top: 50, bottom: 50 });
+                setFontSize(14);
+            }
+        };
+        handleResize();
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
 
     // Custom Node Component with Label 
     const CustomNode = (props: CustomNodeProps) => { 
@@ -83,7 +105,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                     textAnchor={isLeft ? "end" : "start"}
                     dominantBaseline="middle" 
                     fill={props.payload.color} 
-                    fontSize={14}
+                    fontSize={fontSize}
                     fontWeight={"bold"}
                     fillOpacity={0.8}
                 > 
@@ -177,13 +199,8 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                         }}
                         node={CustomNode}
                         link={CustomLink}
-                        nodePadding={50}
-                        margin={{
-                            left: 150,
-                            right: 150,
-                            top: 50,
-                            bottom: 50,
-                        }}
+                        nodePadding={20}
+                        margin={margin}
                     >
                         <Tooltip />
                     </Sankey>

--- a/components/custom/survey/CustomSankey.tsx
+++ b/components/custom/survey/CustomSankey.tsx
@@ -74,14 +74,18 @@ export const CustomSankey: React.FC<SankeyProps> = ({
 
     const [fontSize, setFontSize] = useState(14);
 
+    const [padding, setPadding] = useState(50);
+
     useEffect(() => {
         const handleResize = () => {
             if (window.innerWidth < 600) {
                 setMargin({ left: 90, right: 90, top: 40, bottom: 40 });
                 setFontSize(11);
+                setPadding(20);
             } else {
                 setMargin({ left: 150, right: 150, top: 50, bottom: 50 });
                 setFontSize(14);
+                setPadding(50);
             }
         };
         handleResize();
@@ -162,7 +166,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                         textAnchor="middle" 
                         dominantBaseline="middle" 
                         fill="#333" 
-                        fontSize={14} 
+                        fontSize={fontSize} 
                         pointerEvents="none" 
                     > 
                         {payload.value} 
@@ -199,7 +203,7 @@ export const CustomSankey: React.FC<SankeyProps> = ({
                         }}
                         node={CustomNode}
                         link={CustomLink}
-                        nodePadding={20}
+                        nodePadding={padding}
                         margin={margin}
                     >
                         <Tooltip />


### PR DESCRIPTION
Uses `useState` to set different margins, padding and font size for sankeys on mobile. 

Before:
<img width="300" alt="Screenshot 2025-08-26 132020" src="https://github.com/user-attachments/assets/5934fead-b4ae-45f3-8c4c-560e4e37d99f" />

After:
<img width="300" alt="Screenshot 2025-08-26 132012" src="https://github.com/user-attachments/assets/573b867c-0366-4347-a0a3-486dfc275567" />

Before:
<img width="300" alt="Screenshot 2025-08-26 131949" src="https://github.com/user-attachments/assets/39d1493a-e4a0-43f2-8c1d-202dac2aecec" />

After:
<img width="300" alt="Screenshot 2025-08-26 132002" src="https://github.com/user-attachments/assets/af302786-377b-49a6-884a-5a39ab2e3223" />
